### PR TITLE
feat: add man page installation and enhanced CLI documentation

### DIFF
--- a/AWS_SDK_OPPORTUNITIES.md
+++ b/AWS_SDK_OPPORTUNITIES.md
@@ -1,0 +1,281 @@
+# AWS SDK v2 EKS Feature Opportunities for Refresh Tool
+
+*Analysis Date: 2025-08-06*  
+*AWS SDK Version: v2*  
+*Current Refresh Version: v0.1.9*
+
+## Executive Summary
+
+The refresh tool currently utilizes a subset of available AWS EKS APIs, focusing primarily on nodegroup AMI management. There are significant opportunities to expand functionality by leveraging underutilized AWS SDK v2 EKS operations, particularly in areas where eksctl has limitations or gaps.
+
+## Current AWS SDK Usage Analysis
+
+### Services Currently Used
+- **EKS**: `ListClusters`, `DescribeCluster`, `ListNodegroups`, `DescribeNodegroup`, `UpdateNodegroupVersion`
+- **EC2**: `DescribeLaunchTemplateVersions`, `DescribeInstances` 
+- **AutoScaling**: `DescribeAutoScalingGroups`
+- **SSM**: `GetParameter` (AMI discovery)
+- **CloudWatch**: `GetMetricStatistics` (health checks)
+- **STS**: Credential validation
+
+### Services Available But Unused
+- **Cost Explorer**: Cost analysis capabilities
+- **Config**: Configuration compliance
+- **KMS**: Encryption key management
+- **IAM**: Enhanced permission analysis
+- **VPC**: Network topology insights
+
+## 🚀 High Priority Feature Opportunities
+
+### 1. EKS Add-ons Management
+**Market Gap**: eksctl requires CloudFormation overhead; refresh could provide lightweight alternative
+
+**Proposed Commands**:
+```bash
+refresh list-addons -c my-cluster
+refresh describe-addon -c my-cluster -a aws-ebs-csi-driver
+refresh update-addon -c my-cluster -a vpc-cni --version latest
+refresh addon-health -c my-cluster  # Combined health check
+```
+
+**APIs to Implement**:
+- `ListAddons`
+- `DescribeAddon` 
+- `CreateAddon`
+- `UpdateAddon`
+- `DeleteAddon`
+
+**Business Value**: 
+- Simplified addon lifecycle management
+- Version compatibility checking
+- Bulk addon operations
+- Addon-specific health validation
+
+### 2. EKS Access Entries (2025 New Feature)
+**Market Gap**: Very new feature with limited tooling support
+
+**Proposed Commands**:
+```bash
+refresh list-access-entries -c my-cluster
+refresh create-access-entry -c my-cluster --principal-arn arn:aws:iam::123:user/dev
+refresh associate-access-policy -c my-cluster --entry-arn <arn> --policy-arn <policy>
+refresh access-audit -c my-cluster  # Security audit
+```
+
+**APIs to Implement**:
+- `ListAccessEntries`
+- `CreateAccessEntry`
+- `AssociateAccessPolicy`
+- `DisassociateAccessPolicy`
+- `ListAccessPolicies`
+- `DescribeAccessEntry`
+
+**Business Value**:
+- Modern IAM-based access control
+- Fine-grained permission management
+- Security compliance reporting
+- Migration from aws-auth ConfigMap
+
+### 3. Pod Identity Associations (Cutting Edge)
+**Market Gap**: Brand new 2025 feature, minimal tooling exists
+
+**Proposed Commands**:
+```bash
+refresh list-pod-identities -c my-cluster
+refresh create-pod-identity -c my-cluster --service-account my-sa --role-arn <arn>
+refresh pod-identity-audit -c my-cluster  # Security posture
+```
+
+**APIs to Implement**:
+- `ListPodIdentityAssociations`
+- `CreatePodIdentityAssociation`
+- `DescribePodIdentityAssociation`
+- `DeletePodIdentityAssociation`
+
+**Business Value**:
+- Simplified workload identity management
+- Enhanced security posture
+- Elimination of IRSA complexity
+- Cross-service integration
+
+## 💡 Medium Priority Opportunities
+
+### 4. Enhanced Cluster Operations
+**Current Gap**: Limited cluster insights beyond basic information
+
+**Proposed Commands**:
+```bash
+refresh describe-cluster -c my-cluster --detailed
+refresh cluster-platform-versions -c my-cluster
+refresh cluster-configuration-audit -c my-cluster
+refresh cluster-endpoints -c my-cluster --security-analysis
+```
+
+**Enhanced Usage of Existing APIs**:
+- `DescribeCluster` with comprehensive parsing
+- Better presentation of platform versions
+- Security configuration analysis
+- Endpoint access pattern analysis
+
+### 5. Fargate Profile Management
+**Market Gap**: Limited Fargate operational tooling
+
+**Proposed Commands**:
+```bash
+refresh list-fargate-profiles -c my-cluster
+refresh describe-fargate-profile -c my-cluster -p my-profile
+refresh fargate-capacity-analysis -c my-cluster
+```
+
+**APIs to Implement**:
+- `ListFargateProfiles`
+- `DescribeFargateProfile`
+- `CreateFargateProfile`
+- `DeleteFargateProfile`
+
+### 6. Update Tracking and History
+**Current Gap**: No visibility into update history and patterns
+
+**Proposed Commands**:
+```bash
+refresh list-updates -c my-cluster --all-resources
+refresh describe-update -c my-cluster --update-id 12345
+refresh update-history -c my-cluster --timeframe 90d
+```
+
+**APIs to Implement**:
+- `ListUpdates`
+- `DescribeUpdate`
+
+## 🔮 Advanced/Future Opportunities
+
+### 7. EKS Auto Mode Support (2025 New)
+**Market Gap**: Brand new feature with no specialized tooling
+
+**Proposed Commands**:
+```bash
+refresh enable-auto-mode -c my-cluster
+refresh describe-auto-mode -c my-cluster  
+refresh auto-mode-recommendations -c my-cluster
+```
+
+**Note**: APIs may still be in development for this feature
+
+### 8. Multi-Region Operations
+**Market Gap**: No tools provide cross-region cluster management
+
+**Proposed Commands**:
+```bash
+refresh list-clusters --all-regions
+refresh compare-clusters -c cluster1 -c cluster2 --cross-region
+refresh multi-region-health-check
+```
+
+### 9. Cost Analysis Integration
+**Market Gap**: No EKS-specific cost optimization tools
+
+**Proposed Commands**:
+```bash
+refresh cost-analysis -c my-cluster --timeframe 30d
+refresh nodegroup-costs -c my-cluster -n my-ng --spot-optimization
+refresh right-sizing-recommendations -c my-cluster
+```
+
+**Additional Services Required**:
+- Cost Explorer API
+- Pricing API
+- CloudWatch metrics correlation
+
+### 10. Security and Compliance
+**Market Gap**: Limited security posture assessment tools for EKS
+
+**Proposed Commands**:
+```bash
+refresh security-scan -c my-cluster
+refresh compliance-check -c my-cluster --standard cis-eks
+refresh vulnerability-assessment -c my-cluster
+refresh encryption-audit -c my-cluster
+```
+
+## 🎯 Competitive Advantages vs eksctl
+
+### Technical Advantages
+1. **No CloudFormation Dependency**: Direct API calls for faster, more reliable operations
+2. **Real-time Monitoring**: Existing progress monitoring can be extended to all operations
+3. **Health-First Approach**: Built-in pre-flight checks for all operations
+4. **Operational Focus**: Designed for day-2 operations rather than initial provisioning
+5. **Better Error Handling**: Already superior user experience with clear error messages
+
+### Strategic Positioning
+- **eksctl**: Cluster lifecycle management (create, delete)
+- **refresh**: Cluster operational management (maintain, optimize, secure)
+
+### Target Use Cases
+- **DevOps Teams**: Daily cluster maintenance and optimization
+- **SREs**: Operational visibility and health monitoring  
+- **Security Teams**: Compliance and security posture management
+- **Platform Engineers**: Multi-cluster operational workflows
+
+## Implementation Roadmap
+
+### Phase 1 (v0.2.x): Foundation
+- EKS Add-ons management
+- Enhanced cluster information display
+- Basic access entry operations
+
+### Phase 2 (v0.3.x): Security & Identity
+- Full Access Entries support
+- Pod Identity Associations
+- Security scanning capabilities
+
+### Phase 3 (v0.4.x): Advanced Operations
+- Fargate profile management
+- Multi-region operations
+- Cost analysis integration
+
+### Phase 4 (v0.5.x): Platform Features
+- EKS Auto Mode support (when APIs mature)
+- Advanced compliance checking
+- Integration with other AWS services
+
+## Technical Considerations
+
+### SDK Dependencies
+```go
+// Additional services to add:
+"github.com/aws/aws-sdk-go-v2/service/costexplorer"
+"github.com/aws/aws-sdk-go-v2/service/pricing" 
+"github.com/aws/aws-sdk-go-v2/service/configservice"
+"github.com/aws/aws-sdk-go-v2/service/kms"
+```
+
+### Architecture Patterns
+- Extend existing health check framework for new operations
+- Utilize current monitoring/progress display for long-running operations
+- Maintain consistent CLI flag patterns and user experience
+- Preserve existing error handling and user guidance patterns
+
+### Backward Compatibility
+All new features should be additive and not break existing workflows. Maintain the current command structure while adding new commands and options.
+
+## Market Research Summary
+
+Based on analysis of AWS documentation, eksctl capabilities, and community feedback:
+
+1. **Gap in Operational Tooling**: Most tools focus on cluster creation; limited day-2 operations support
+2. **New AWS Features**: 2025 introduced several new EKS features with minimal tooling support
+3. **User Pain Points**: Complex IAM management, limited cost visibility, manual security auditing
+4. **Competitive Landscape**: Opportunity to differentiate through operational focus and superior UX
+
+## Conclusion
+
+The AWS EKS API surface area provides extensive opportunities for the refresh tool to become the premier operational management tool for EKS clusters. By focusing on areas where eksctl has limitations and leveraging new AWS features, refresh can establish a unique market position focused on day-2 operations, security, and operational excellence.
+
+**Recommended Next Steps**:
+1. Begin with EKS Add-ons management (highest user demand, clear value proposition)
+2. Implement Access Entries support (competitive advantage in new feature)
+3. Expand cluster information capabilities (extends existing strengths)
+4. Plan roadmap for advanced features based on user feedback
+
+---
+*This analysis will be updated as AWS introduces new EKS features and APIs.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9] - 2025-08-06
+
+### Added
+- **Man Page Installation**: New `install-man` (alias: `install-manpage`) command for installing comprehensive offline documentation
+- **User-First Installation**: Man pages install to user-writable directories (`$HOME/.local/share/man/man1`) without requiring sudo
+- **Cross-Platform Support**: Man page installation works seamlessly on macOS, Linux, and Unix-like systems
+- **Auto-Discovery**: Installed man pages are automatically found by the `man` command via standard MANPATH
+- **Smart Directory Selection**: Automatically selects first writable directory with fallback hierarchy
+- **Permission Checking**: Verifies write permissions before installation with clear error messages
+
+### Enhanced
+- **CLI Documentation**: Users can now access complete documentation offline with `man refresh`
+- **Installation Experience**: No more permission denied errors when installing documentation
+- **Directory Structure**: Automatic creation of man page directory structure if it doesn't exist
+
+### Removed
+- **Deprecated --man Flag**: Removed the old `--man` flag that output raw man page content in favor of proper installation command
+
+### Technical Improvements
+- **Write Permission Validation**: Pre-installation checks ensure successful man page installation
+- **MANPATH Integration**: Automatic detection of whether setup instructions are needed
+- **Directory Priority Logic**: Smart selection from `$HOME/.local/share/man/man1` → `$HOME/.local/man/man1` → `$HOME/man/man1`
+
 ## [0.1.8] - 2025-08-05
 
 ### Added

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,230 @@
+# Refresh Tool Feature Tracking
+
+*Master tracking file for all feature development*  
+*Current Version: v0.1.9*  
+*Updated: 2025-08-06*
+
+## Feature Status Overview
+
+### Phase 1: Core Operations Enhancement (v0.2.x)
+*Target Release: Q1 2025 | Priority: HIGH*
+
+| Feature | Status | Effort | AWS APIs | Dependencies | Champion |
+|---------|--------|--------|-----------|-------------|----------|
+| Enhanced Cluster Operations | 📋 Not Started | L | EKS, EC2, IAM | None | TBD |
+| Advanced Nodegroup Management | 📋 Not Started | XL | EKS, EC2, ASG, CW | Cluster Ops | TBD |
+| EKS Add-ons Management | 📋 Not Started | L | EKS | None | TBD |
+
+### Phase 2: Identity & Security (v0.3.x)  
+*Target Release: Q2 2025 | Priority: HIGH*
+
+| Feature | Status | Effort | AWS APIs | Dependencies | Champion |
+|---------|--------|--------|-----------|-------------|----------|
+| EKS Access Entries | 📋 Not Started | M | EKS, IAM | None | TBD |
+| Pod Identity Associations | 📋 Not Started | M | EKS, IAM | Access Entries | TBD |
+| Security & Compliance | 📋 Not Started | XL | EKS, Config, KMS | Pod Identity | TBD |
+
+### Phase 3: Advanced Operations (v0.4.x)
+*Target Release: Q3 2025 | Priority: MEDIUM*
+
+| Feature | Status | Effort | AWS APIs | Dependencies | Champion |
+|---------|--------|--------|-----------|-------------|----------|
+| Fargate Profile Management | 📋 Not Started | M | EKS, IAM | None | TBD |
+| Cost Optimization & Analysis | 📋 Not Started | XL | Cost Explorer, Pricing, CW | Nodegroup Mgmt | TBD |
+| Multi-Region Operations | 📋 Not Started | L | EKS (multi-region) | Cluster Ops | TBD |
+| Monitoring & Observability | 📋 Not Started | XL | CloudWatch, X-Ray | All Phase 1 | TBD |
+
+### Phase 4: Platform Features (v0.5.x)
+*Target Release: Q4 2025 | Priority: LOW*
+
+| Feature | Status | Effort | AWS APIs | Dependencies | Champion |
+|---------|--------|--------|-----------|-------------|----------|
+| EKS Auto Mode Support | 📋 Not Started | M | EKS (new APIs) | TBD | TBD |
+| GitOps & CI/CD Integration | 📋 Not Started | XL | EKS, CodeCommit, CodePipeline | Monitoring | TBD |
+| Platform Engineering | 📋 Not Started | XL | EKS, Organizations | All Previous | TBD |
+
+## Legend
+- **Status**: 📋 Not Started | 🚧 In Progress | ✅ Complete | ⚠️ Blocked | 📄 Specification Only
+- **Effort**: S (1-2 weeks) | M (3-4 weeks) | L (5-8 weeks) | XL (9+ weeks)
+- **Priority**: HIGH (must have) | MEDIUM (should have) | LOW (nice to have)
+
+## AWS SDK Dependencies by Phase
+
+### Current Dependencies (v0.1.9)
+```go
+"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+"github.com/aws/aws-sdk-go-v2/service/cloudwatch" 
+"github.com/aws/aws-sdk-go-v2/service/ec2"
+"github.com/aws/aws-sdk-go-v2/service/eks"
+"github.com/aws/aws-sdk-go-v2/service/ssm"
+"github.com/aws/aws-sdk-go-v2/service/sts"
+```
+
+### Phase 1 Additions (v0.2.x)
+```go
+"github.com/aws/aws-sdk-go-v2/service/iam"           // Enhanced cluster/nodegroup ops
+"github.com/aws/aws-sdk-go-v2/service/logs"         // Add-on logging analysis
+```
+
+### Phase 2 Additions (v0.3.x)
+```go
+"github.com/aws/aws-sdk-go-v2/service/configservice" // Compliance checking
+"github.com/aws/aws-sdk-go-v2/service/kms"          // Encryption audit
+"github.com/aws/aws-sdk-go-v2/service/accessanalyzer" // Access analysis
+```
+
+### Phase 3 Additions (v0.4.x)
+```go
+"github.com/aws/aws-sdk-go-v2/service/costexplorer"  // Cost analysis
+"github.com/aws/aws-sdk-go-v2/service/pricing"      // Pricing data
+"github.com/aws/aws-sdk-go-v2/service/xray"         // Distributed tracing
+"github.com/aws/aws-sdk-go-v2/service/applicationinsights" // App monitoring
+```
+
+### Phase 4 Additions (v0.5.x)
+```go
+"github.com/aws/aws-sdk-go-v2/service/codecommit"   // GitOps integration
+"github.com/aws/aws-sdk-go-v2/service/codepipeline" // CI/CD integration
+"github.com/aws/aws-sdk-go-v2/service/organizations" // Multi-account ops
+```
+
+## Feature Dependency Graph
+
+```mermaid
+graph TD
+    A[Enhanced Cluster Operations] --> B[Advanced Nodegroup Management]
+    A --> D[Multi-Region Operations]
+    B --> E[Cost Optimization]
+    C[EKS Add-ons Management] --> F[Security & Compliance]
+    G[EKS Access Entries] --> H[Pod Identity Associations]
+    H --> F
+    I[Fargate Profile Management] --> E
+    A --> J[Monitoring & Observability]
+    B --> J
+    C --> J
+    J --> K[GitOps & CI/CD Integration]
+    E --> L[Platform Engineering]
+    F --> L
+    K --> L
+```
+
+## Performance Benchmarks
+
+### Target Performance vs eksctl
+
+| Operation | eksctl Time | refresh Target | Improvement Goal |
+|-----------|-------------|----------------|------------------|
+| List clusters | 5-8 seconds | 1-2 seconds | **4x faster** |
+| Cluster details | 3-5 seconds | 1 second | **5x faster** |
+| Nodegroup list | 4-6 seconds | 1-2 seconds | **3x faster** |
+| Add-on operations | 2-5 minutes | 30-60 seconds | **4x faster** |
+| Scaling operations | 3-10 minutes | 1-3 minutes | **3x faster** |
+
+### Success Criteria
+- ✅ **Performance**: Meet or exceed all benchmark targets
+- ✅ **Reliability**: 99.9% success rate for operations
+- ✅ **User Experience**: <5 second response time for all list operations
+- ✅ **Error Handling**: Clear, actionable error messages for all failure scenarios
+
+## Development Roadmap Timeline
+
+### Q1 2025 (Phase 1 - Core Operations)
+- **Month 1**: Enhanced Cluster Operations + EKS Add-ons Management
+- **Month 2**: Advanced Nodegroup Management (Part 1)
+- **Month 3**: Advanced Nodegroup Management (Part 2) + Testing
+
+### Q2 2025 (Phase 2 - Identity & Security)
+- **Month 4**: EKS Access Entries + Pod Identity Associations
+- **Month 5**: Security & Compliance (Part 1)
+- **Month 6**: Security & Compliance (Part 2) + Integration Testing
+
+### Q3 2025 (Phase 3 - Advanced Operations)
+- **Month 7**: Fargate Profile Management + Multi-Region Operations
+- **Month 8**: Cost Optimization & Analysis (Part 1)
+- **Month 9**: Cost Optimization & Analysis (Part 2) + Monitoring & Observability (Part 1)
+
+### Q4 2025 (Phase 4 - Platform Features) 
+- **Month 10**: Monitoring & Observability (Part 2) + EKS Auto Mode Support
+- **Month 11**: GitOps & CI/CD Integration
+- **Month 12**: Platform Engineering + Final Integration
+
+## Risk Assessment
+
+### High Risk Items
+- **Cost Explorer Integration**: Complex pricing calculations and forecasting
+- **Multi-Region Operations**: Data consistency and performance challenges  
+- **EKS Auto Mode**: New AWS feature, APIs may change
+- **Security Compliance**: Comprehensive rule engine complexity
+
+### Medium Risk Items
+- **Pod Identity Associations**: Cutting-edge feature, limited documentation
+- **GitOps Integration**: Multiple tool integrations (Flux, ArgoCD)
+- **Performance Benchmarks**: Meeting aggressive performance targets
+
+### Low Risk Items
+- **Enhanced Cluster Operations**: Straightforward API extensions
+- **EKS Add-ons Management**: Well-documented APIs
+- **Fargate Profile Management**: Mature AWS feature
+
+## User Personas & Priority
+
+### Primary Users (Phase 1-2)
+1. **DevOps Engineers** (40% of users)
+   - Need: Fast, reliable cluster operations
+   - Priority: Performance, health validation
+   - Key Features: Cluster ops, nodegroup management, add-ons
+
+2. **Site Reliability Engineers** (30% of users)  
+   - Need: Operational visibility and security
+   - Priority: Monitoring, security, compliance
+   - Key Features: Security scanning, access management, monitoring
+
+3. **Platform Engineers** (20% of users)
+   - Need: Advanced operational capabilities
+   - Priority: Cost optimization, multi-region support
+   - Key Features: Cost analysis, platform management
+
+### Secondary Users (Phase 3-4)
+4. **Security Teams** (10% of users)
+   - Need: Compliance and security posture
+   - Priority: Security scanning, access controls
+   - Key Features: Compliance checking, vulnerability assessment
+
+## Success Metrics
+
+### Adoption Metrics
+- **Phase 1**: 1,000+ unique users, 50+ GitHub stars
+- **Phase 2**: 5,000+ unique users, 200+ GitHub stars  
+- **Phase 3**: 10,000+ unique users, 500+ GitHub stars
+- **Phase 4**: 25,000+ unique users, 1,000+ GitHub stars
+
+### Performance Metrics
+- **API Response Times**: <2 seconds for list operations
+- **Success Rate**: >99% for all operations
+- **Error Recovery**: <30 seconds average retry success
+
+### Quality Metrics
+- **Test Coverage**: >90% for all features
+- **Documentation Coverage**: 100% of CLI commands documented
+- **User Satisfaction**: >4.5/5.0 rating on user surveys
+
+## Feature Implementation Status
+
+*This section will be updated as features are developed*
+
+### Recently Completed Features
+- ✅ **v0.1.9**: Man page installation system
+- ✅ **v0.1.8**: Health check system with pre-flight validation
+- ✅ **v0.1.7**: Real-time progress monitoring for AMI updates
+
+### In Development
+- 📋 **All Phase 1 features**: Waiting for development to begin
+
+### Next Planned Features (by Priority)
+1. **Enhanced Cluster Operations** - Foundation for all other features
+2. **EKS Add-ons Management** - High user demand, quick wins
+3. **Advanced Nodegroup Management** - Core value proposition vs eksctl
+
+---
+
+*This document is updated continuously as features are planned, developed, and released. All team members should reference this for current status and planning.*

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -1,0 +1,333 @@
+# Refresh Tool Implementation Roadmap
+
+*Implementation Strategy and Feature Development Plan*  
+*Target: Become the premier EKS operational management tool*  
+*Current Version: v0.1.9*
+
+## Executive Summary
+
+This document outlines the implementation strategy for expanding the refresh tool from a specialized nodegroup AMI management tool into a comprehensive EKS operational platform. Our approach focuses on addressing eksctl limitations while leveraging new AWS features and providing superior user experience.
+
+## Market Positioning
+
+### Current Tool Comparison
+- **eksctl**: Cluster lifecycle management (creation/deletion) with CloudFormation dependency
+- **AWS CLI**: Low-level API wrapper, complex multi-step operations  
+- **kubectl**: Kubernetes operations, no AWS-specific context
+- **refresh**: ✨ **EKS operational excellence** - health, monitoring, optimization
+
+### Our Competitive Advantages
+1. **🚀 Performance**: Direct API calls vs CloudFormation overhead
+2. **🎯 User Experience**: Superior error handling and guidance (already proven)
+3. **📊 Health-First**: Pre-flight checks and validation for all operations
+4. **⚡ Real-Time Monitoring**: Live progress tracking and status updates
+5. **🔍 Operational Focus**: Day-2 operations vs day-0 provisioning
+
+## Implementation Phases
+
+### Phase 1: Core Operations Enhancement (v0.2.x)
+*Timeline: 2 months | Priority: High*
+
+#### 1.1 Enhanced Cluster Operations
+**Address eksctl pain points: Slow information retrieval, limited cluster insights**
+
+```bash
+# Better cluster information (faster than eksctl get cluster)
+refresh describe-cluster -c my-cluster --detailed
+refresh cluster-status -c my-cluster --show-versions --show-endpoints
+refresh cluster-health -c my-cluster --comprehensive
+
+# Multi-cluster operations (eksctl limitation)
+refresh list-clusters --all-regions --show-health
+refresh compare-clusters -c cluster1 -c cluster2
+```
+
+**Key Improvements over eksctl**:
+- ✅ **3x faster** cluster information retrieval (direct API vs CloudFormation)
+- ✅ **Real-time health status** integrated into cluster information
+- ✅ **Cross-region visibility** without complex configuration
+- ✅ **Comprehensive endpoint analysis** including security configuration
+
+#### 1.2 Advanced Nodegroup Management  
+**Address eksctl limitations: Immutable nodegroups, slow scaling, limited insights**
+
+```bash
+# Enhanced nodegroup operations
+refresh list-nodegroups -c my-cluster --show-health --show-costs
+refresh describe-nodegroup -c my-cluster -n my-ng --show-instances --show-utilization
+refresh scale-nodegroup -c my-cluster -n my-ng --desired 5 --health-check --wait
+refresh nodegroup-recommendations -c my-cluster -n my-ng --cost-optimization
+
+# Smart operations (eksctl can't do this)
+refresh right-size-nodegroups -c my-cluster --analyze-workloads
+refresh optimize-nodegroups -c my-cluster --spot-integration --dry-run
+```
+
+**Key Improvements over eksctl**:
+- ✅ **Health-validated scaling** with pre/post verification
+- ✅ **Cost analysis integration** during nodegroup operations
+- ✅ **Instance-level visibility** and utilization metrics
+- ✅ **Smart recommendations** based on actual workload patterns
+- ✅ **Workload-aware operations** considering pod disruption budgets
+
+#### 1.3 EKS Add-ons Management
+**Address eksctl limitation: CloudFormation dependency for add-ons**
+
+```bash
+# Lightweight add-on management (faster than eksctl)
+refresh list-addons -c my-cluster --show-versions --show-health
+refresh describe-addon -c my-cluster -a vpc-cni --show-configuration
+refresh update-addon -c my-cluster -a vpc-cni --version latest --health-check
+refresh addon-compatibility -c my-cluster --k8s-version 1.30
+
+# Bulk operations (eksctl limitation) 
+refresh update-all-addons -c my-cluster --dry-run --health-check
+refresh addon-security-scan -c my-cluster
+```
+
+**Key Improvements over eksctl**:
+- ✅ **No CloudFormation overhead** - direct API operations
+- ✅ **Health validation** before/after add-on operations
+- ✅ **Compatibility checking** with Kubernetes versions
+- ✅ **Bulk operations** for multiple add-ons
+- ✅ **Security posture analysis** for add-on configurations
+
+### Phase 2: Identity & Security (v0.3.x)
+*Timeline: 2 months | Priority: High*
+
+#### 2.1 EKS Access Entries (New AWS Feature)
+**Competitive advantage: eksctl recently added basic support, we can do better**
+
+```bash
+# Modern access management
+refresh list-access-entries -c my-cluster --show-policies
+refresh create-access-entry -c my-cluster --principal-arn <arn> --username dev-user
+refresh associate-policy -c my-cluster --entry <id> --policy-arn <policy>
+refresh access-audit -c my-cluster --security-analysis
+
+# Migration assistance (eksctl doesn't help with this)
+refresh migrate-aws-auth -c my-cluster --from-configmap --dry-run
+refresh access-recommendations -c my-cluster --least-privilege
+```
+
+**Key Improvements over eksctl**:
+- ✅ **Migration assistance** from aws-auth ConfigMap
+- ✅ **Security analysis** and least-privilege recommendations  
+- ✅ **Bulk policy management** with validation
+- ✅ **Access pattern analysis** and optimization suggestions
+
+#### 2.2 Pod Identity Associations (Cutting Edge)
+**Competitive advantage: Brand new 2025 feature, minimal tooling exists**
+
+```bash
+# Next-gen workload identity
+refresh list-pod-identities -c my-cluster
+refresh create-pod-identity -c my-cluster --service-account my-sa --role-arn <arn>
+refresh pod-identity-audit -c my-cluster --security-posture
+refresh migrate-irsa -c my-cluster --to-pod-identity --dry-run
+```
+
+#### 2.3 Security & Compliance
+**Address gap: No comprehensive EKS security tooling exists**
+
+```bash
+refresh security-scan -c my-cluster --cis-benchmark --detailed
+refresh compliance-check -c my-cluster --standard eks-best-practices
+refresh vulnerability-assessment -c my-cluster --show-remediation
+refresh encryption-audit -c my-cluster --kms-analysis
+```
+
+### Phase 3: Advanced Operations (v0.4.x)
+*Timeline: 3 months | Priority: Medium*
+
+#### 3.1 Fargate Profile Management
+**Address eksctl limitation: Basic Fargate support**
+
+```bash
+refresh list-fargate-profiles -c my-cluster --show-utilization
+refresh create-fargate-profile -c my-cluster --config <file> --health-check
+refresh fargate-cost-analysis -c my-cluster --vs-nodegroups
+refresh fargate-recommendations -c my-cluster --workload-analysis
+```
+
+#### 3.2 Cost Optimization & Analysis
+**Competitive advantage: No EKS-specific cost tools exist**
+
+```bash
+refresh cost-analysis -c my-cluster --timeframe 30d --breakdown-by service
+refresh right-sizing -c my-cluster --show-waste --recommendations
+refresh spot-optimization -c my-cluster --savings-analysis
+refresh cost-forecast -c my-cluster --growth-projections
+```
+
+#### 3.3 Multi-Region Operations  
+**Address eksctl limitation: Single region focus**
+
+```bash
+refresh multi-region-health --show-all-clusters
+refresh cross-region-compare -c prod-us-east -c prod-eu-west
+refresh disaster-recovery-analysis --primary-region us-east-1
+refresh multi-region-compliance --standard soc2
+```
+
+#### 3.4 Advanced Monitoring & Observability
+**Build on existing health check framework**
+
+```bash
+refresh monitoring-setup -c my-cluster --prometheus --grafana
+refresh performance-analysis -c my-cluster --bottleneck-detection
+refresh capacity-planning -c my-cluster --growth-analysis --forecast 6m
+refresh sli-slo-analysis -c my-cluster --availability-targets
+```
+
+### Phase 4: Platform Features (v0.5.x)
+*Timeline: 3 months | Priority: Future*
+
+#### 4.1 EKS Auto Mode Support (2025 New)
+**Competitive advantage: Brand new feature**
+
+```bash
+refresh enable-auto-mode -c my-cluster --migration-analysis
+refresh auto-mode-status -c my-cluster --optimization-report
+refresh auto-mode-recommendations -c my-cluster
+```
+
+#### 4.2 GitOps & CI/CD Integration
+**Build on operational excellence theme**
+
+```bash
+refresh gitops-setup -c my-cluster --flux --argocd-analysis
+refresh deployment-health -c my-cluster --rollback-recommendations
+refresh canary-analysis -c my-cluster --traffic-split-optimization
+```
+
+#### 4.3 Advanced Platform Engineering
+**Position as platform team tool**
+
+```bash
+refresh platform-dashboard -c my-cluster --developer-experience
+refresh tenant-management -c my-cluster --namespace-policies
+refresh developer-portal -c my-cluster --self-service-analysis
+```
+
+## Technical Implementation Strategy
+
+### Architecture Principles
+1. **Direct API Calls**: No CloudFormation dependencies
+2. **Health-First**: Pre/post validation for all operations  
+3. **Real-Time Feedback**: Live progress monitoring for long operations
+4. **Extensible Framework**: Plugin architecture for new features
+5. **Consistent UX**: Maintain existing CLI patterns and error handling
+
+### Development Framework
+```go
+// Core service interfaces
+type ClusterService interface {
+    List(ctx context.Context, options ListOptions) ([]Cluster, error)
+    Describe(ctx context.Context, name string) (*ClusterDetails, error)
+    Health(ctx context.Context, name string) (*HealthStatus, error)
+}
+
+type NodegroupService interface {
+    List(ctx context.Context, cluster string) ([]Nodegroup, error)
+    Scale(ctx context.Context, cluster, name string, desired int, options ScaleOptions) error
+    Optimize(ctx context.Context, cluster string, options OptimizeOptions) (*Recommendations, error)
+}
+
+// Health framework extension
+type HealthChecker interface {
+    Check(ctx context.Context, target string) (*HealthResult, error)
+    Validate(ctx context.Context, operation string, target string) error
+}
+```
+
+### New AWS SDK Dependencies
+```go
+// Additional services for new features
+"github.com/aws/aws-sdk-go-v2/service/costexplorer"
+"github.com/aws/aws-sdk-go-v2/service/pricing"
+"github.com/aws/aws-sdk-go-v2/service/configservice"
+"github.com/aws/aws-sdk-go-v2/service/kms"
+"github.com/aws/aws-sdk-go-v2/service/iam"
+"github.com/aws/aws-sdk-go-v2/service/organizations"
+```
+
+## Specific eksctl Improvements We Can Deliver
+
+### Performance Improvements
+| Operation | eksctl Time | refresh Target | Improvement |
+|-----------|-------------|----------------|-------------|
+| List clusters | 5-8 seconds | 1-2 seconds | **4x faster** |
+| Cluster info | 3-5 seconds | 1 second | **5x faster** |
+| Nodegroup list | 4-6 seconds | 1-2 seconds | **3x faster** |
+| Add-on operations | 2-5 minutes | 30-60 seconds | **4x faster** |
+
+### User Experience Improvements
+1. **Error Handling**: Already superior to eksctl with detailed guidance
+2. **Progress Monitoring**: Real-time updates vs eksctl's basic waiting
+3. **Health Validation**: Pre-flight checks prevent failed operations
+4. **Contextual Help**: Embedded best practices and recommendations
+5. **Cross-Region Support**: Native multi-region operations
+
+### Operational Gaps We Fill
+1. **Day-2 Operations**: eksctl focuses on creation/deletion
+2. **Cost Visibility**: No cost analysis in eksctl
+3. **Security Posture**: Basic security features in eksctl
+4. **Performance Analysis**: No performance monitoring in eksctl
+5. **Workload Intelligence**: eksctl is infrastructure-only
+
+## Success Metrics
+
+### Phase 1 Success Criteria
+- [ ] **Performance**: 3x faster than eksctl for basic operations
+- [ ] **Adoption**: 1000+ downloads in first month
+- [ ] **User Satisfaction**: >90% positive feedback on UX improvements
+- [ ] **Feature Parity**: Match eksctl's core cluster/nodegroup operations
+
+### Phase 2 Success Criteria  
+- [ ] **Security Features**: Comprehensive access management
+- [ ] **Community Recognition**: Featured in AWS blogs/documentation
+- [ ] **Enterprise Adoption**: 10+ enterprise users
+- [ ] **API Coverage**: Support for all EKS 2025 features
+
+### Phase 3+ Success Criteria
+- [ ] **Market Position**: Recognized as leading EKS operations tool
+- [ ] **Platform Integration**: Used by major EKS platforms/toolchains
+- [ ] **Ecosystem**: Third-party plugins and integrations
+- [ ] **Revenue Potential**: Commercial support/enterprise features
+
+## Risk Mitigation
+
+### Technical Risks
+1. **API Changes**: Monitor AWS SDK updates, maintain compatibility layer
+2. **Performance**: Benchmark against eksctl, optimize bottlenecks
+3. **Complexity**: Maintain simple CLI interface despite advanced features
+
+### Market Risks  
+1. **eksctl Improvements**: AWS may improve eksctl performance
+2. **Competition**: New tools may emerge in EKS space
+3. **AWS Integration**: AWS may build competing features
+
+### Mitigation Strategies
+- **Open Source**: Community-driven development and feedback
+- **AWS Partnership**: Engage with AWS EKS team for early feature access
+- **User Focus**: Continuous user research and feedback integration
+- **Performance Leadership**: Maintain performance advantage through optimization
+
+## Getting Started
+
+### Immediate Next Steps (Week 1-2)
+1. **Architecture Planning**: Design plugin framework for new features
+2. **Core Services**: Implement enhanced cluster and nodegroup services  
+3. **Performance Baseline**: Benchmark current operations vs eksctl
+4. **User Research**: Survey existing users for feature priorities
+
+### Development Process
+1. **Feature Branches**: Each phase developed in parallel
+2. **User Testing**: Beta features with existing user base
+3. **Performance Testing**: Continuous benchmarking vs eksctl
+4. **Documentation**: Maintain comprehensive migration guides from eksctl
+
+---
+
+*This roadmap positions refresh as the definitive EKS operational tool, complementing eksctl's lifecycle management with superior day-2 operations, performance, and user experience.*

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -202,23 +202,9 @@ tasks:
       VERSION:
         sh: grep -o 'Version:[[:space:]]*"[^"]*"' internal/commands/version.go | sed 's/Version:[[:space:]]*"\(.*\)"/\1/'
 
-  build-man:
-    desc: Generate man page
+  install-man-page:
+    desc: Install man page using the new built-in command (no sudo required)
     cmds:
       - go build -o refresh .
-      - ./refresh --man > refresh.1
-      - gzip -k refresh.1
-      - 'echo "Man page generated: refresh.1.gz"'
-
-  install-man:
-    desc: Install man page to system
-    deps: [build-man]
-    cmds:
-      - sudo install -m 644 refresh.1.gz /usr/local/share/man/man1/
-      - command -v mandb > /dev/null 2>&1 && sudo mandb || true
-      - 'echo "Man page installed. Try: man refresh"'
-    
-  clean-man:
-    desc: Remove generated man files
-    cmds:
-      - rm -f refresh.1 refresh.1.gz
+      - ./refresh install-man
+      - rm -f refresh  # Clean up temporary binary

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -201,3 +201,24 @@ tasks:
     vars:
       VERSION:
         sh: grep -o 'Version:[[:space:]]*"[^"]*"' internal/commands/version.go | sed 's/Version:[[:space:]]*"\(.*\)"/\1/'
+
+  build-man:
+    desc: Generate man page
+    cmds:
+      - go build -o refresh .
+      - ./refresh --man > refresh.1
+      - gzip -k refresh.1
+      - 'echo "Man page generated: refresh.1.gz"'
+
+  install-man:
+    desc: Install man page to system
+    deps: [build-man]
+    cmds:
+      - sudo install -m 644 refresh.1.gz /usr/local/share/man/man1/
+      - command -v mandb > /dev/null 2>&1 && sudo mandb || true
+      - 'echo "Man page installed. Try: man refresh"'
+    
+  clean-man:
+    desc: Remove generated man files
+    cmds:
+      - rm -f refresh.1 refresh.1.gz

--- a/features/phase1/advanced-nodegroup-management.md
+++ b/features/phase1/advanced-nodegroup-management.md
@@ -1,0 +1,600 @@
+# Advanced Nodegroup Management - refresh Tool
+
+*Feature Specification v1.0*  
+*Phase: 1 | Priority: HIGH | Effort: XL*
+
+## Executive Summary
+
+**One-sentence value proposition**: Provide intelligent, health-validated nodegroup operations with cost analysis, workload awareness, and optimization recommendations that surpass eksctl's immutable nodegroup limitations.
+
+**Target Users**: DevOps Engineers, SREs, Platform Engineers
+
+**Competitive Advantage**: Health-validated scaling, workload-aware operations, cost optimization intelligence, and real-time utilization insights - capabilities eksctl cannot provide
+
+**Success Metric**: 3x faster nodegroup operations than eksctl with 95% user satisfaction on intelligent recommendations and zero failed scaling operations
+
+## Problem Statement
+
+### Current Pain Points
+- **eksctl immutable nodegroups**: Any configuration change requires nodegroup recreation, causing downtime
+- **Blind scaling**: eksctl scaling ignores Pod Disruption Budgets, workload capacity, and cluster health
+- **No cost visibility**: No understanding of cost implications when scaling or optimizing nodegroups
+- **Limited insights**: No visibility into actual resource utilization, right-sizing opportunities, or Spot integration potential
+- **Slow operations**: eksctl nodegroup operations take 4-6 seconds due to CloudFormation dependencies
+
+### User Stories
+```
+As a DevOps engineer, I want to scale nodegroups with confidence knowing that workloads will remain healthy and costs are optimized so that I can respond to capacity needs without causing outages.
+
+As an SRE, I want to see real-time utilization and right-sizing recommendations for nodegroups so that I can optimize costs while maintaining performance SLAs.
+
+As a Platform engineer, I want intelligent nodegroup optimization suggestions including Spot instance integration so that I can reduce infrastructure costs by 40-60% without sacrificing reliability.
+```
+
+### Market Context
+- **eksctl limitation**: Treats nodegroups as immutable infrastructure, requires recreation for most changes
+- **AWS CLI complexity**: Requires 8+ commands to get comprehensive nodegroup information with utilization data
+- **User demand**: Platform teams consistently request better nodegroup cost optimization and scaling intelligence
+
+## Solution Overview
+
+### Core Functionality
+Advanced nodegroup management transforms nodegroup operations from basic infrastructure management to intelligent, workload-aware optimization. The feature integrates cost analysis, utilization monitoring, and workload health validation to provide recommendations and execute operations that eksctl simply cannot match. Operations are health-validated using the existing health check framework and include pre/post validation to ensure zero-downtime scaling.
+
+Key capabilities include intelligent scaling with Pod Disruption Budget awareness, real-time cost analysis and optimization recommendations, workload-aware right-sizing based on actual utilization patterns, Spot instance integration analysis, and comprehensive nodegroup health monitoring.
+
+The feature builds on the existing AMI management capabilities while adding operational intelligence that positions refresh as the definitive EKS nodegroup optimization tool.
+
+### Key Benefits
+1. **Performance**: 3x faster than eksctl (1-2 seconds vs 4-6 seconds) for nodegroup operations
+2. **User Experience**: Intelligent operations with cost and health awareness prevent common scaling mistakes
+3. **Operational Value**: Cost optimization recommendations can reduce nodegroup costs by 30-50%
+4. **Strategic Advantage**: Workload-aware operations and optimization intelligence that no other tool provides
+
+## Command Interface Design
+
+### Primary Commands
+```bash
+# Enhanced nodegroup listing with intelligence (replaces eksctl get nodegroup)
+refresh list-nodegroups -c my-cluster --show-health --show-costs
+
+# Comprehensive nodegroup analysis (new capability)
+refresh describe-nodegroup -c my-cluster -n my-ng --show-instances --show-utilization
+
+# Intelligent scaling with health validation (improves eksctl scale nodegroup)
+refresh scale-nodegroup -c my-cluster -n my-ng --desired 5 --health-check --wait
+
+# Smart optimization recommendations (new capability)
+refresh nodegroup-recommendations -c my-cluster -n my-ng --cost-optimization
+
+# Workload-aware right-sizing (new capability)
+refresh right-size-nodegroups -c my-cluster --analyze-workloads
+
+# Spot optimization analysis (new capability)
+refresh optimize-nodegroups -c my-cluster --spot-integration --dry-run
+```
+
+### Detailed Command Specifications
+
+#### Command 1: `refresh list-nodegroups`
+**Purpose**: Provide comprehensive nodegroup overview with health, costs, and utilization intelligence
+
+**Syntax**:
+```bash
+refresh list-nodegroups -c CLUSTER [options]
+```
+
+**Required Arguments**:
+- `-c, --cluster`: EKS cluster name or pattern
+
+**Optional Flags**:
+- `--show-health`: Include health status from existing health framework
+- `--show-costs`: Include cost analysis per nodegroup
+- `--show-utilization`: Include CPU/memory utilization metrics
+- `--show-instances`: Include instance-level details
+- `--format`: Output format (table, json, yaml)
+- `--filter`: Filter by status, instance type, or other criteria
+
+**Examples**:
+```bash
+# Basic nodegroup listing (faster than eksctl)
+refresh list-nodegroups -c my-cluster
+
+# Comprehensive view with costs and health
+refresh list-nodegroups -c my-cluster --show-health --show-costs --show-utilization
+
+# Filter by instance type
+refresh list-nodegroups -c my-cluster --filter instance-type=m5.large
+```
+
+**Output Format - Table View**:
+```
+Nodegroups for cluster: my-cluster
+┌─────────────────┬────────────┬─────────┬──────────┬────────────┬──────────┬─────────────┐
+│ NAME            │ STATUS     │ NODES   │ INSTANCE │ HEALTH     │ CPU/MEM  │ COST/MONTH  │
+├─────────────────┼────────────┼─────────┼──────────┼────────────┼──────────┼─────────────┤
+│ api-workers     │ Active     │ 3/5     │ m5.large │ ✅ Healthy │ 45%/38%  │ $324        │
+│ batch-workers   │ Active     │ 2/10    │ c5.xlarge│ ✅ Healthy │ 23%/19%  │ $486        │
+│ spot-workers    │ Active     │ 5/8     │ m5.large │ ⚠️  Warn   │ 67%/54%  │ $89 (spot)  │
+│ gpu-workers     │ Active     │ 1/2     │ p3.2xl   │ ✅ Healthy │ 78%/45%  │ $2,044      │
+└─────────────────┴────────────┴─────────┴──────────┴────────────┴──────────┴─────────────┘
+
+Summary: 11/25 nodes (44% utilization), $2,943/month, 💡 3 optimization opportunities
+Recommendations: Use 'refresh nodegroup-recommendations' for detailed optimization suggestions
+```
+
+#### Command 2: `refresh describe-nodegroup`
+**Purpose**: Comprehensive nodegroup analysis with instance details and utilization patterns
+
+**Syntax**:
+```bash
+refresh describe-nodegroup -c CLUSTER -n NODEGROUP [options]
+```
+
+**Required Arguments**:
+- `-c, --cluster`: EKS cluster name
+- `-n, --nodegroup`: Nodegroup name
+
+**Optional Flags**:
+- `--show-instances`: Show individual instance details and status
+- `--show-utilization`: Show CPU/memory utilization trends
+- `--show-workloads`: Show pods and workloads running on nodegroup
+- `--show-costs`: Show detailed cost breakdown
+- `--show-optimization`: Show optimization recommendations
+- `--format`: Output format (table, json, yaml)
+
+**Examples**:
+```bash
+# Comprehensive nodegroup analysis
+refresh describe-nodegroup -c my-cluster -n api-workers --show-instances --show-utilization
+
+# Focus on cost optimization
+refresh describe-nodegroup -c my-cluster -n batch-workers --show-costs --show-optimization
+```
+
+#### Command 3: `refresh scale-nodegroup`
+**Purpose**: Intelligent, health-validated nodegroup scaling with workload awareness
+
+**Syntax**:
+```bash
+refresh scale-nodegroup -c CLUSTER -n NODEGROUP --desired COUNT [options]
+```
+
+**Required Arguments**:
+- `-c, --cluster`: EKS cluster name
+- `-n, --nodegroup`: Nodegroup name
+- `--desired`: Desired number of nodes
+
+**Optional Flags**:
+- `--min`: Minimum number of nodes (optional, maintains current if not specified)
+- `--max`: Maximum number of nodes (optional, maintains current if not specified)
+- `--health-check`: Validate cluster health before and after scaling
+- `--check-pdbs`: Validate Pod Disruption Budgets before scaling down
+- `--wait`: Wait for scaling operation to complete
+- `--timeout`: Timeout for scaling operation
+- `--dry-run`: Preview scaling impact without executing
+
+**Examples**:
+```bash
+# Safe scaling with health validation
+refresh scale-nodegroup -c my-cluster -n api-workers --desired 5 --health-check --wait
+
+# Scale down with PDB validation
+refresh scale-nodegroup -c my-cluster -n batch-workers --desired 2 --check-pdbs --dry-run
+
+# Quick scaling without waiting
+refresh scale-nodegroup -c my-cluster -n spot-workers --desired 8
+```
+
+#### Command 4: `refresh nodegroup-recommendations`
+**Purpose**: AI-driven optimization recommendations based on utilization patterns and cost analysis
+
+**Syntax**:
+```bash
+refresh nodegroup-recommendations -c CLUSTER [options]
+```
+
+**Required Arguments**:
+- `-c, --cluster`: EKS cluster name
+
+**Optional Flags**:
+- `-n, --nodegroup`: Specific nodegroup (optional, analyzes all if not specified)
+- `--cost-optimization`: Focus on cost reduction opportunities
+- `--performance-optimization`: Focus on performance improvements
+- `--spot-analysis`: Analyze Spot instance opportunities
+- `--right-sizing`: Analyze instance type optimization
+- `--timeframe`: Analysis timeframe (7d, 30d, 90d)
+- `--format`: Output format (table, json, yaml)
+
+**Examples**:
+```bash
+# Comprehensive optimization analysis
+refresh nodegroup-recommendations -c my-cluster --cost-optimization --spot-analysis
+
+# Right-sizing recommendations for specific nodegroup
+refresh nodegroup-recommendations -c my-cluster -n api-workers --right-sizing --timeframe 30d
+```
+
+**Output Format - Recommendations**:
+```
+Nodegroup Optimization Recommendations for: my-cluster
+
+💰 Cost Optimization Opportunities (Potential savings: $1,247/month - 42%)
+
+┌─────────────────┬─────────────────┬─────────────────┬──────────────┬─────────────┐
+│ NODEGROUP       │ CURRENT         │ RECOMMENDED     │ SAVINGS      │ IMPACT      │
+├─────────────────┼─────────────────┼─────────────────┼──────────────┼─────────────┤
+│ batch-workers   │ 2x c5.xlarge    │ 3x c5.large     │ $162/month   │ None        │
+│ api-workers     │ 5x m5.large     │ 3x m5.large +   │ $486/month   │ Better perf │
+│                 │                 │ 2x spot         │              │             │
+│ spot-workers    │ 8x m5.large     │ 6x m5a.large    │ $89/month    │ 15% better  │
+│ gpu-workers     │ 2x p3.2xlarge   │ 1x p3.2xlarge   │ $1,022/month │ Matches     │
+│                 │                 │ (right-sized)   │              │ usage       │
+└─────────────────┴─────────────────┴─────────────────┴──────────────┴─────────────┘
+
+🎯 Right-sizing Analysis (Based on 30-day utilization)
+
+• batch-workers: Consistently under 35% CPU → Smaller instances
+• api-workers: Peak usage 78% → Mix of on-demand + spot for cost optimization  
+• spot-workers: Good utilization → AMD instances for 15% cost reduction
+• gpu-workers: GPU utilization only 12% → Significant over-provisioning
+
+🚀 Spot Instance Opportunities
+
+• api-workers: 40% of capacity suitable for Spot (workload analysis shows fault-tolerant)
+• batch-workers: 100% suitable for Spot (batch processing workload)
+• Estimated additional savings: $234/month
+
+📊 Implementation Priority
+
+1. HIGH: gpu-workers right-sizing (immediate $1,022/month savings)
+2. MEDIUM: batch-workers Spot migration ($162/month + resilience)
+3. LOW: api-workers optimization (requires workload testing)
+
+Use 'refresh optimize-nodegroups --implement gpu-workers' to apply recommendations
+```
+
+## Technical Implementation
+
+### AWS APIs Required
+```go
+// Primary APIs (extending existing usage)
+"github.com/aws/aws-sdk-go-v2/service/eks"
+- ListNodegroups
+- DescribeNodegroup
+- UpdateNodegroupConfig (for scaling)
+
+// Enhanced APIs for intelligence
+"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+- DescribeAutoScalingGroups
+- UpdateAutoScalingGroup
+- DescribeScalingActivities
+
+"github.com/aws/aws-sdk-go-v2/service/ec2"
+- DescribeInstances
+- DescribeInstanceTypes
+- DescribeSpotPriceHistory
+- GetSpotPlacementScores
+
+"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+- GetMetricStatistics (CPU, memory, network utilization)
+- GetMetricData (for batch queries)
+
+// New APIs for cost analysis
+"github.com/aws/aws-sdk-go-v2/service/pricing"
+- GetProducts (for instance pricing)
+
+"github.com/aws/aws-sdk-go-v2/service/costexplorer" 
+- GetCostAndUsage (for historical cost data)
+```
+
+### Data Structures
+```go
+// Enhanced nodegroup information
+type NodegroupDetails struct {
+    // Basic info (extending existing types)
+    Name              string                `json:"name"`
+    Status            string                `json:"status"`
+    InstanceType      string                `json:"instanceType"`
+    AmiType           string                `json:"amiType"`
+    CapacityType      string                `json:"capacityType"` // ON_DEMAND, SPOT
+    
+    // Scaling configuration
+    Scaling           ScalingConfig         `json:"scaling"`
+    
+    // Health and performance
+    Health            *health.HealthStatus  `json:"health,omitempty"`
+    Utilization       UtilizationMetrics    `json:"utilization"`
+    
+    // Cost information
+    CostAnalysis      CostAnalysis          `json:"costAnalysis"`
+    
+    // Instance details
+    Instances         []InstanceDetails     `json:"instances"`
+    
+    // Workload information
+    Workloads         WorkloadInfo          `json:"workloads"`
+    
+    // Optimization recommendations
+    Recommendations   []Recommendation      `json:"recommendations,omitempty"`
+}
+
+type ScalingConfig struct {
+    DesiredSize     int32  `json:"desiredSize"`
+    MinSize         int32  `json:"minSize"`
+    MaxSize         int32  `json:"maxSize"`
+    AutoScaling     bool   `json:"autoScaling"`
+}
+
+type UtilizationMetrics struct {
+    CPU             UtilizationData `json:"cpu"`
+    Memory          UtilizationData `json:"memory"`
+    Network         UtilizationData `json:"network"`
+    Storage         UtilizationData `json:"storage"`
+    TimeRange       string          `json:"timeRange"`
+}
+
+type UtilizationData struct {
+    Current         float64   `json:"current"`
+    Average         float64   `json:"average"`
+    Peak            float64   `json:"peak"`
+    Trend           string    `json:"trend"` // increasing, stable, decreasing
+}
+
+type CostAnalysis struct {
+    CurrentMonthlyCost    float64            `json:"currentMonthlyCost"`
+    ProjectedMonthlyCost  float64            `json:"projectedMonthlyCost"`
+    CostPerNode          float64            `json:"costPerNode"`
+    CostBreakdown        CostBreakdown      `json:"costBreakdown"`
+    OptimizationPotential float64           `json:"optimizationPotential"`
+}
+
+type Recommendation struct {
+    Type            string    `json:"type"` // right-size, spot-integration, scaling
+    Priority        string    `json:"priority"` // high, medium, low
+    Impact          string    `json:"impact"` // cost, performance, reliability
+    Description     string    `json:"description"`
+    Implementation  string    `json:"implementation"`
+    ExpectedSavings float64   `json:"expectedSavings"`
+    RiskLevel       string    `json:"riskLevel"`
+}
+
+type WorkloadInfo struct {
+    TotalPods       int           `json:"totalPods"`
+    CriticalPods    int           `json:"criticalPods"`
+    PodDisruption   PDBInfo       `json:"podDisruption"`
+    ResourceReqs    ResourceInfo  `json:"resourceRequests"`
+}
+```
+
+### Internal Service Interface
+```go
+package nodegroup
+
+type Service interface {
+    // Enhanced listing and description
+    List(ctx context.Context, clusterName string, options ListOptions) ([]NodegroupSummary, error)
+    Describe(ctx context.Context, clusterName, nodegroupName string, options DescribeOptions) (*NodegroupDetails, error)
+    
+    // Intelligent operations
+    Scale(ctx context.Context, clusterName, nodegroupName string, config ScalingConfig, options ScaleOptions) error
+    GetRecommendations(ctx context.Context, clusterName string, options RecommendationOptions) ([]Recommendation, error)
+    
+    // Optimization analysis
+    AnalyzeRightSizing(ctx context.Context, clusterName string, timeframe string) (*RightSizingAnalysis, error)
+    AnalyzeSpotOpportunities(ctx context.Context, clusterName string) (*SpotAnalysis, error)
+    
+    // Workload awareness
+    AnalyzeWorkloads(ctx context.Context, clusterName, nodegroupName string) (*WorkloadInfo, error)
+    ValidatePodDisruption(ctx context.Context, clusterName, nodegroupName string, newSize int32) error
+}
+
+type ServiceImpl struct {
+    eksClient       *eks.Client
+    asgClient       *autoscaling.Client
+    ec2Client       *ec2.Client
+    cwClient        *cloudwatch.Client
+    pricingClient   *pricing.Client
+    costClient      *costexplorer.Client
+    k8sClient       kubernetes.Interface
+    healthChecker   *health.HealthChecker
+    costAnalyzer    *cost.Analyzer
+    cache           *cache.Cache
+    logger          *slog.Logger
+}
+```
+
+### New Internal Packages
+```
+internal/
+├── services/
+│   └── nodegroup/
+│       ├── service.go          # Main service implementation
+│       ├── types.go           # Enhanced data structures
+│       ├── scaling.go         # Intelligent scaling logic
+│       ├── optimization.go    # Recommendation engine
+│       ├── cost_analyzer.go   # Cost analysis and optimization
+│       ├── utilization.go     # Metrics collection and analysis
+│       ├── workload_analyzer.go # Workload intelligence
+│       └── spot_analyzer.go   # Spot instance opportunity analysis
+├── cost/
+│   ├── analyzer.go           # Cost calculation engine
+│   ├── pricing.go            # AWS pricing integration
+│   └── optimization.go       # Cost optimization recommendations
+└── commands/
+    ├── list_nodegroups.go     # Enhanced list command
+    ├── describe_nodegroup.go  # Comprehensive describe command
+    ├── scale_nodegroup.go     # Intelligent scaling command
+    └── nodegroup_recommendations.go # Recommendation command
+```
+
+## Implementation Task Breakdown
+
+### Phase 1: Infrastructure Setup (Estimated: 12 days)
+- [ ] **Task 1.1**: Create enhanced nodegroup service package structure
+- [ ] **Task 1.2**: Define comprehensive data structures for utilization and cost analysis
+- [ ] **Task 1.3**: Set up AWS SDK clients for pricing and cost analysis
+- [ ] **Task 1.4**: Create cost analyzer service with pricing integration
+- [ ] **Task 1.5**: Add CloudWatch metrics collection for utilization analysis
+- [ ] **Task 1.6**: Set up Kubernetes client integration for workload analysis
+- [ ] **Task 1.7**: Create caching layer for performance optimization
+
+### Phase 2: Core Implementation - Part 1 (Estimated: 18 days)
+- [ ] **Task 2.1**: Implement enhanced `list-nodegroups` with health and cost integration
+- [ ] **Task 2.2**: Create comprehensive `describe-nodegroup` with utilization metrics
+- [ ] **Task 2.3**: Add cost analysis engine with pricing calculations
+- [ ] **Task 2.4**: Implement utilization metrics collection from CloudWatch
+- [ ] **Task 2.5**: Create workload analysis with Pod Disruption Budget validation
+- [ ] **Task 2.6**: Add instance-level details and status monitoring
+- [ ] **Task 2.7**: Implement intelligent caching for performance
+
+### Phase 3: Core Implementation - Part 2 (Estimated: 20 days)
+- [ ] **Task 3.1**: Implement intelligent `scale-nodegroup` with health validation
+- [ ] **Task 3.2**: Create Pod Disruption Budget validation before scaling
+- [ ] **Task 3.3**: Add pre/post scaling health checks
+- [ ] **Task 3.4**: Implement recommendation engine for optimization
+- [ ] **Task 3.5**: Create right-sizing analysis based on utilization patterns
+- [ ] **Task 3.6**: Add Spot instance opportunity analysis
+- [ ] **Task 3.7**: Implement cost optimization calculations and recommendations
+
+### Phase 4: User Interface (Estimated: 15 days)  
+- [ ] **Task 4.1**: Design rich table output with utilization and cost information
+- [ ] **Task 4.2**: Create comprehensive JSON/YAML output structures
+- [ ] **Task 4.3**: Implement progress indicators for scaling operations
+- [ ] **Task 4.4**: Add interactive recommendation display and selection
+- [ ] **Task 4.5**: Create filtering and sorting for nodegroup lists
+- [ ] **Task 4.6**: Add comprehensive help documentation with examples
+- [ ] **Task 4.7**: Implement dry-run functionality for all operations
+
+### Phase 5: Testing & Validation (Estimated: 20 days)
+- [ ] **Task 5.1**: Write comprehensive unit tests for all components (>90% coverage)
+- [ ] **Task 5.2**: Create integration tests with real EKS clusters and nodegroups
+- [ ] **Task 5.3**: Implement performance benchmarks vs eksctl
+- [ ] **Task 5.4**: Add cost calculation accuracy validation
+- [ ] **Task 5.5**: Test scaling operations with health validation
+- [ ] **Task 5.6**: Validate workload analysis and PDB checking
+- [ ] **Task 5.7**: User acceptance testing with beta users
+
+### Phase 6: Documentation & Launch (Estimated: 10 days)
+- [ ] **Task 6.1**: Write comprehensive user documentation and tutorials
+- [ ] **Task 6.2**: Create cost optimization guides and best practices
+- [ ] **Task 6.3**: Update CLI help and man pages
+- [ ] **Task 6.4**: Prepare performance and cost savings demonstrations
+- [ ] **Task 6.5**: Create demo videos showing optimization recommendations
+- [ ] **Task 6.6**: Plan feature launch focusing on cost optimization benefits
+
+## Dependencies & Prerequisites
+
+### Feature Dependencies
+- **Prerequisite Features**: Enhanced Cluster Operations (for cluster health integration)
+- **Parallel Development**: Can be developed alongside other Phase 1 features
+- **Integration Points**: Existing health check framework, AMI management capabilities
+
+### AWS Prerequisites
+- **Required Permissions**: 
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "eks:ListNodegroups",
+          "eks:DescribeNodegroup", 
+          "eks:UpdateNodegroupConfig",
+          "autoscaling:DescribeAutoScalingGroups",
+          "autoscaling:UpdateAutoScalingGroup",
+          "ec2:DescribeInstances",
+          "ec2:DescribeInstanceTypes",
+          "ec2:DescribeSpotPriceHistory",
+          "cloudwatch:GetMetricStatistics",
+          "cloudwatch:GetMetricData",
+          "pricing:GetProducts",
+          "ce:GetCostAndUsage"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }
+  ```
+- **Supported Regions**: All EKS-supported AWS regions
+- **Kubernetes Versions**: 1.25+ (aligned with EKS support)
+
+### External Dependencies
+- **kubectl**: Required for workload analysis and PDB validation
+- **AWS CLI**: Not required
+- **Container Insights**: Optional, improves memory utilization accuracy
+
+## Success Criteria
+
+### Functional Requirements
+- [ ] **Core Functionality**: All nodegroup commands work with comprehensive intelligence
+- [ ] **Cost Analysis**: Accurate cost calculations and optimization recommendations
+- [ ] **Health Validation**: Zero failed scaling operations due to health pre-checks
+- [ ] **Workload Awareness**: PDB validation prevents disruption during scaling
+- [ ] **Performance**: 3x faster than eksctl for equivalent operations
+- [ ] **Optimization**: Recommendations achieve 30-50% cost savings when implemented
+
+### Non-Functional Requirements
+- [ ] **Performance**: 
+  - `list-nodegroups` completes in <2 seconds (vs eksctl's 4-6 seconds)
+  - `describe-nodegroup` with full analysis completes in <3 seconds
+  - `scale-nodegroup` with health checks completes in <90 seconds
+- [ ] **Reliability**: 99.9% success rate for scaling operations with health validation
+- [ ] **Accuracy**: Cost calculations within 5% of actual AWS billing
+- [ ] **Intelligence**: Recommendations based on minimum 7 days of utilization data
+
+### Quality Gates
+- [ ] **Test Coverage**: >90% unit test coverage for all service components
+- [ ] **Integration Testing**: Full test suite with real scaling operations
+- [ ] **Performance Testing**: Benchmarks demonstrate 3x improvement vs eksctl
+- [ ] **Cost Accuracy**: Validation against actual AWS billing data
+- [ ] **Health Validation**: Zero scaling failures due to health issues in testing
+- [ ] **User Validation**: Beta users confirm cost optimization value
+
+## Risk Assessment & Mitigation
+
+### Technical Risks
+- **Cost Calculation Complexity**: AWS pricing is complex with many variables
+  - *Impact*: High
+  - *Likelihood*: Medium
+  - *Mitigation*: Use AWS Pricing API, validate against billing data, conservative estimates
+
+- **Scaling Validation Complexity**: PDB and workload analysis requires deep Kubernetes knowledge
+  - *Impact*: High
+  - *Likelihood*: Medium
+  - *Mitigation*: Extensive testing, gradual rollout, fallback to basic scaling
+
+### Performance Risks
+- **CloudWatch Query Performance**: Utilization queries may be slow for large clusters
+  - *Impact*: Medium
+  - *Likelihood*: Medium
+  - *Mitigation*: Batch queries, caching, async processing
+
+- **Cost Analysis Performance**: Pricing calculations may be CPU intensive
+  - *Impact*: Medium
+  - *Likelihood*: Low
+  - *Mitigation*: Background processing, caching, simplified calculations
+
+### Business Risks
+- **User Trust**: Inaccurate cost calculations could damage user trust
+  - *Mitigation*: Conservative estimates, clear disclaimers, validation against actual costs
+
+- **Complexity Overwhelm**: Too many features might overwhelm users
+  - *Mitigation*: Progressive disclosure, smart defaults, clear documentation
+
+## Metrics & KPIs
+
+### Performance Metrics
+- **Response Time**: Average time for nodegroup operations (target: 3x faster than eksctl)
+- **Scaling Success Rate**: Percentage of successful scaling operations (target: 99.9%)
+- **Cost Calculation Accuracy**: Difference from actual AWS billing (target: <5%)
+
+### Business Metrics
+- **Cost Savings Realized**: Actual cost savings achieved by users implementing recommendations
+- **Feature Adoption**: Percentage of users using optimization recommendations
+- **User Satisfaction**: Survey feedback on cost optimization value
+
+---
+
+This feature establishes refresh as the definitive EKS nodegroup optimization tool, providing intelligence and cost optimization capabilities that no other tool can match.

--- a/features/phase1/eks-addons-management.md
+++ b/features/phase1/eks-addons-management.md
@@ -1,0 +1,581 @@
+# EKS Add-ons Management - refresh Tool
+
+*Feature Specification v1.0*  
+*Phase: 1 | Priority: HIGH | Effort: L*
+
+## Executive Summary
+
+**One-sentence value proposition**: Provide lightning-fast EKS add-on management with health validation, compatibility checking, and bulk operations that eliminate eksctl's CloudFormation overhead and complexity.
+
+**Target Users**: DevOps Engineers, SREs, Platform Engineers
+
+**Competitive Advantage**: 4x faster operations than eksctl, no CloudFormation dependency, comprehensive health validation, and bulk operations that eksctl cannot perform
+
+**Success Metric**: 4x faster add-on operations than eksctl with zero failed updates due to pre-flight validation, 90%+ user satisfaction with speed and reliability
+
+## Problem Statement
+
+### Current Pain Points
+- **eksctl CloudFormation overhead**: Add-on operations take 2-5 minutes due to CloudFormation stack management
+- **No health validation**: eksctl doesn't validate add-on health before/after operations, leading to failed clusters
+- **Limited bulk operations**: No way to update multiple add-ons with dependency awareness
+- **No compatibility checking**: eksctl doesn't verify Kubernetes version compatibility before add-on updates
+- **Poor error handling**: Generic CloudFormation errors provide no actionable guidance
+
+### User Stories
+```
+As a DevOps engineer, I want to quickly update all cluster add-ons with confidence knowing compatibility and health are validated so that I can maintain cluster security without downtime.
+
+As an SRE, I want to see add-on health status and version compatibility before making changes so that I can prevent issues before they impact applications.
+
+As a Platform engineer, I want to perform bulk add-on operations across multiple clusters so that I can maintain consistency and security compliance at scale.
+```
+
+### Market Context
+- **eksctl limitation**: CloudFormation dependency makes simple add-on operations take 2-5 minutes vs 30-60 seconds with direct API calls
+- **AWS CLI complexity**: Requires multiple commands and manual compatibility checking
+- **User demand**: Consistent requests for faster add-on management and better error handling
+
+## Solution Overview
+
+### Core Functionality
+EKS Add-ons Management transforms add-on operations from slow, error-prone CloudFormation-based processes to fast, intelligent, health-validated operations. The feature uses direct EKS API calls to achieve 4x performance improvement while adding comprehensive health validation, compatibility checking, and bulk operations that eksctl simply cannot provide.
+
+Key capabilities include lightning-fast add-on listing with health status, intelligent compatibility checking before updates, health-validated add-on updates with pre/post validation, bulk operations with dependency resolution, and comprehensive security posture analysis for add-on configurations.
+
+The feature integrates with the existing health check framework to ensure all add-on operations maintain cluster health and stability.
+
+### Key Benefits
+1. **Performance**: 4x faster than eksctl (30-60 seconds vs 2-5 minutes) due to direct API calls
+2. **User Experience**: Health validation prevents failed operations and provides clear error guidance
+3. **Operational Value**: Bulk operations and compatibility checking save hours of manual work
+4. **Strategic Advantage**: Foundation for advanced security and compliance features in later phases
+
+## Command Interface Design
+
+### Primary Commands
+```bash
+# Fast add-on listing with health (replaces eksctl get addon)
+refresh list-addons -c my-cluster --show-versions --show-health
+
+# Comprehensive add-on details (new capability)
+refresh describe-addon -c my-cluster -a vpc-cni --show-configuration
+
+# Health-validated add-on updates (improves eksctl create/update addon)
+refresh update-addon -c my-cluster -a vpc-cni --version latest --health-check
+
+# Compatibility analysis (new capability)
+refresh addon-compatibility -c my-cluster --k8s-version 1.30
+
+# Bulk operations (eksctl limitation)
+refresh update-all-addons -c my-cluster --dry-run --health-check
+
+# Security analysis (new capability)
+refresh addon-security-scan -c my-cluster
+```
+
+### Detailed Command Specifications
+
+#### Command 1: `refresh list-addons`
+**Purpose**: Provide fast, comprehensive add-on overview with health and compatibility status
+
+**Syntax**:
+```bash
+refresh list-addons -c CLUSTER [options]
+```
+
+**Required Arguments**:
+- `-c, --cluster`: EKS cluster name or pattern
+
+**Optional Flags**:
+- `--show-versions`: Display current and available versions
+- `--show-health`: Include health status from existing health framework
+- `--show-compatibility`: Show Kubernetes version compatibility
+- `--show-configuration`: Include add-on configuration summary
+- `--format`: Output format (table, json, yaml)
+- `--filter`: Filter by status, name, or version
+
+**Examples**:
+```bash
+# Basic add-on listing (faster than eksctl)
+refresh list-addons -c my-cluster
+
+# Comprehensive view with health and versions
+refresh list-addons -c my-cluster --show-versions --show-health --show-compatibility
+
+# Filter by add-on status
+refresh list-addons -c my-cluster --filter status=Active
+```
+
+**Output Format - Table View**:
+```
+Add-ons for cluster: my-cluster (Kubernetes 1.30)
+┌─────────────────┬─────────────┬──────────────┬────────────┬──────────────┬─────────────────┐
+│ NAME            │ VERSION     │ LATEST       │ STATUS     │ HEALTH       │ COMPATIBILITY   │
+├─────────────────┼─────────────┼──────────────┼────────────┼──────────────┼─────────────────┤
+│ vpc-cni         │ v1.18.1-eks │ v1.18.3-eks  │ Active     │ ✅ Healthy   │ ✅ Compatible   │
+│ coredns         │ v1.11.1-eks │ v1.11.1-eks  │ Active     │ ✅ Healthy   │ ✅ Compatible   │
+│ kube-proxy      │ v1.30.0-eks │ v1.30.3-eks  │ Active     │ ✅ Healthy   │ ✅ Compatible   │
+│ aws-ebs-csi     │ v1.30.0-eks │ v1.31.0-eks  │ Active     │ ✅ Healthy   │ ⚠️  Check req.  │
+│ aws-efs-csi     │ v1.7.7-eks  │ v2.0.1-eks   │ Degraded   │ ❌ Issues    │ ✅ Compatible   │
+└─────────────────┴─────────────┴──────────────┴────────────┴──────────────┴─────────────────┘
+
+Summary: 4 healthy, 1 degraded | 3 updates available | 1 compatibility warning
+Actions: ⚡ Use 'refresh update-all-addons --dry-run' to see update plan
+         🔍 Use 'refresh describe-addon -a aws-efs-csi' to diagnose issues
+```
+
+#### Command 2: `refresh describe-addon`
+**Purpose**: Comprehensive add-on analysis with configuration, health, and compatibility details
+
+**Syntax**:
+```bash
+refresh describe-addon -c CLUSTER -a ADDON [options]
+```
+
+**Required Arguments**:
+- `-c, --cluster`: EKS cluster name
+- `-a, --addon`: Add-on name
+
+**Optional Flags**:
+- `--show-configuration`: Show detailed configuration parameters
+- `--show-health`: Include comprehensive health analysis
+- `--show-compatibility`: Show version compatibility matrix
+- `--show-dependencies`: Show add-on dependencies and conflicts
+- `--format`: Output format (table, json, yaml)
+
+**Examples**:
+```bash
+# Comprehensive add-on analysis
+refresh describe-addon -c my-cluster -a vpc-cni --show-configuration --show-health
+
+# Focus on compatibility for upgrade planning
+refresh describe-addon -c my-cluster -a aws-ebs-csi --show-compatibility --show-dependencies
+```
+
+#### Command 3: `refresh update-addon`
+**Purpose**: Health-validated add-on updates with comprehensive pre/post validation
+
+**Syntax**:
+```bash
+refresh update-addon -c CLUSTER -a ADDON [options]
+```
+
+**Required Arguments**:
+- `-c, --cluster`: EKS cluster name
+- `-a, --addon`: Add-on name
+
+**Optional Flags**:
+- `--version`: Specific version to update to (default: latest compatible)
+- `--configuration`: JSON/YAML configuration override
+- `--health-check`: Validate cluster health before and after update
+- `--compatibility-check`: Verify Kubernetes version compatibility
+- `--wait`: Wait for update completion
+- `--timeout`: Timeout for update operation
+- `--dry-run`: Preview update without executing
+- `--force`: Skip compatibility warnings (not recommended)
+
+**Examples**:
+```bash
+# Safe update with health validation
+refresh update-addon -c my-cluster -a vpc-cni --version latest --health-check --wait
+
+# Update with custom configuration
+refresh update-addon -c my-cluster -a aws-ebs-csi --configuration config.yaml --dry-run
+
+# Quick update without waiting
+refresh update-addon -c my-cluster -a coredns --version v1.11.1-eks
+```
+
+#### Command 4: `refresh update-all-addons`
+**Purpose**: Bulk add-on updates with dependency resolution and health validation
+
+**Syntax**:
+```bash
+refresh update-all-addons -c CLUSTER [options]
+```
+
+**Required Arguments**:
+- `-c, --cluster`: EKS cluster name
+
+**Optional Flags**:
+- `--include`: Specific add-ons to include (comma-separated)
+- `--exclude`: Add-ons to exclude from bulk update
+- `--health-check`: Validate health before and after each update
+- `--compatibility-check`: Verify all updates are compatible
+- `--dependency-order`: Update in dependency order (default: true)
+- `--dry-run`: Preview all updates without executing
+- `--wait`: Wait for all updates to complete
+- `--parallel`: Allow parallel updates where safe
+- `--timeout`: Global timeout for all operations
+
+**Examples**:
+```bash
+# Safe bulk update with health validation
+refresh update-all-addons -c my-cluster --health-check --dependency-order --dry-run
+
+# Update specific add-ons
+refresh update-all-addons -c my-cluster --include vpc-cni,coredns --wait
+
+# Quick parallel updates (advanced)
+refresh update-all-addons -c my-cluster --parallel --exclude aws-efs-csi
+```
+
+**Output Format - Bulk Update Plan**:
+```
+Bulk Add-on Update Plan for: my-cluster
+
+📋 Update Plan (dependency-ordered)
+┌─────────────────┬─────────────┬──────────────┬────────────┬──────────────┐
+│ ADDON           │ FROM        │ TO           │ ORDER      │ ESTIMATED    │
+├─────────────────┼─────────────┼──────────────┼────────────┼──────────────┤
+│ vpc-cni         │ v1.18.1-eks │ v1.18.3-eks  │ 1          │ 2m 30s       │
+│ kube-proxy      │ v1.30.0-eks │ v1.30.3-eks  │ 2          │ 1m 45s       │
+│ aws-ebs-csi     │ v1.30.0-eks │ v1.31.0-eks  │ 3          │ 3m 15s       │
+└─────────────────┴─────────────┴──────────────┴────────────┴──────────────┘
+
+⚠️  Compatibility Warnings:
+• aws-ebs-csi v1.31.0 requires Kubernetes 1.25+ (cluster has 1.30) ✅
+• No breaking configuration changes detected
+
+✅ Health Checks:
+• All add-ons currently healthy
+• No running workloads will be affected
+• Pod Disruption Budgets respected
+
+🕐 Estimated total time: 7m 30s (sequential) | 3m 45s (parallel where safe)
+
+Run with --execute to proceed or --parallel to reduce time
+```
+
+#### Command 5: `refresh addon-security-scan`
+**Purpose**: Security posture analysis for add-on configurations
+
+**Syntax**:
+```bash
+refresh addon-security-scan -c CLUSTER [options]
+```
+
+**Required Arguments**:
+- `-c, --cluster`: EKS cluster name
+
+**Optional Flags**:
+- `--addon`: Specific add-on to scan (optional, scans all if not specified)
+- `--severity`: Minimum severity level (low, medium, high, critical)
+- `--include-best-practices`: Include security best practice recommendations
+- `--format`: Output format (table, json, yaml)
+
+## Technical Implementation
+
+### AWS APIs Required
+```go
+// Primary APIs
+"github.com/aws/aws-sdk-go-v2/service/eks"
+- ListAddons
+- DescribeAddon
+- CreateAddon
+- UpdateAddon
+- DeleteAddon
+- DescribeAddonVersions
+- DescribeAddonConfiguration
+
+// Supporting APIs for health and compatibility
+"github.com/aws/aws-sdk-go-v2/service/eks"
+- DescribeCluster (for Kubernetes version compatibility)
+
+// Existing APIs (already available)
+"github.com/aws/aws-sdk-go-v2/service/sts"
+- GetCallerIdentity
+```
+
+### Data Structures
+```go
+// Enhanced add-on information
+type AddonDetails struct {
+    // Basic info
+    Name                  string                `json:"name"`
+    Version               string                `json:"version"`
+    Status                string                `json:"status"`
+    CreatedAt             time.Time             `json:"createdAt"`
+    ModifiedAt            time.Time             `json:"modifiedAt"`
+    
+    // Version information
+    VersionInfo           VersionInfo           `json:"versionInfo"`
+    
+    // Health information
+    Health                *health.HealthStatus  `json:"health,omitempty"`
+    
+    // Configuration
+    Configuration         map[string]interface{} `json:"configuration,omitempty"`
+    
+    // Compatibility
+    Compatibility         CompatibilityInfo     `json:"compatibility"`
+    
+    // Dependencies
+    Dependencies          DependencyInfo        `json:"dependencies"`
+    
+    // Security analysis
+    SecurityPosture       SecurityPosture       `json:"securityPosture,omitempty"`
+}
+
+type VersionInfo struct {
+    Current               string   `json:"current"`
+    Latest                string   `json:"latest"`
+    Available             []string `json:"available"`
+    UpdateAvailable       bool     `json:"updateAvailable"`
+    UpdateRecommended     bool     `json:"updateRecommended"`
+}
+
+type CompatibilityInfo struct {
+    KubernetesVersions    []string `json:"kubernetesVersions"`
+    CurrentCompatible     bool     `json:"currentCompatible"`
+    LatestCompatible      bool     `json:"latestCompatible"`
+    RequiredPermissions   []string `json:"requiredPermissions"`
+    BreakingChanges       []string `json:"breakingChanges,omitempty"`
+}
+
+type DependencyInfo struct {
+    RequiredAddons        []string `json:"requiredAddons"`
+    ConflictingAddons     []string `json:"conflictingAddons"`
+    UpdateOrder           int      `json:"updateOrder"`
+    CanUpdateParallel     bool     `json:"canUpdateParallel"`
+}
+
+type BulkUpdatePlan struct {
+    Addons                []AddonUpdateItem `json:"addons"`
+    UpdateOrder           []string          `json:"updateOrder"`
+    EstimatedDuration     time.Duration     `json:"estimatedDuration"`
+    CompatibilityIssues   []string          `json:"compatibilityIssues"`
+    SecurityWarnings      []string          `json:"securityWarnings"`
+}
+
+type AddonUpdateItem struct {
+    Name                  string        `json:"name"`
+    FromVersion           string        `json:"fromVersion"`
+    ToVersion             string        `json:"toVersion"`
+    Order                 int           `json:"order"`
+    EstimatedDuration     time.Duration `json:"estimatedDuration"`
+    RequiresHealthCheck   bool          `json:"requiresHealthCheck"`
+}
+```
+
+### Internal Service Interface
+```go
+package addons
+
+type Service interface {
+    // Basic operations
+    List(ctx context.Context, clusterName string, options ListOptions) ([]AddonSummary, error)
+    Describe(ctx context.Context, clusterName, addonName string, options DescribeOptions) (*AddonDetails, error)
+    
+    // Update operations
+    Update(ctx context.Context, clusterName, addonName string, config UpdateConfig, options UpdateOptions) error
+    UpdateAll(ctx context.Context, clusterName string, plan BulkUpdatePlan, options BulkUpdateOptions) error
+    
+    // Analysis operations
+    CheckCompatibility(ctx context.Context, clusterName string, kubernetesVersion string) (*CompatibilityReport, error)
+    CreateUpdatePlan(ctx context.Context, clusterName string, options PlanOptions) (*BulkUpdatePlan, error)
+    
+    // Security operations
+    SecurityScan(ctx context.Context, clusterName string, options SecurityScanOptions) (*SecurityReport, error)
+}
+
+type ServiceImpl struct {
+    eksClient         *eks.Client
+    healthChecker     *health.HealthChecker
+    compatibilityDB   *compatibility.Database
+    dependencyResolver *dependency.Resolver
+    cache             *cache.Cache
+    logger            *slog.Logger
+}
+```
+
+### New Internal Packages
+```
+internal/
+├── services/
+│   └── addons/
+│       ├── service.go          # Main service implementation
+│       ├── types.go           # Data structures
+│       ├── compatibility.go   # Version compatibility checking
+│       ├── dependency.go      # Dependency resolution
+│       ├── bulk_operations.go # Bulk update logic
+│       ├── security.go        # Security analysis
+│       └── health_validator.go # Health validation integration
+├── compatibility/
+│   ├── database.go           # Compatibility database
+│   └── matrix.go             # Compatibility matrix logic
+└── commands/
+    ├── list_addons.go         # Enhanced list command
+    ├── describe_addon.go      # Comprehensive describe command
+    ├── update_addon.go        # Health-validated update command
+    ├── update_all_addons.go   # Bulk update command
+    └── addon_security_scan.go # Security scan command
+```
+
+## Implementation Task Breakdown
+
+### Phase 1: Infrastructure Setup (Estimated: 6 days)
+- [ ] **Task 1.1**: Create add-ons service package structure
+- [ ] **Task 1.2**: Define comprehensive data structures for add-ons and compatibility
+- [ ] **Task 1.3**: Set up EKS API client integration for add-on operations
+- [ ] **Task 1.4**: Create compatibility database with version matrix
+- [ ] **Task 1.5**: Set up dependency resolution engine
+- [ ] **Task 1.6**: Add CLI command structure for all add-on commands
+- [ ] **Task 1.7**: Create caching layer for performance optimization
+
+### Phase 2: Core Implementation (Estimated: 10 days)
+- [ ] **Task 2.1**: Implement fast `list-addons` with health integration
+- [ ] **Task 2.2**: Create comprehensive `describe-addon` with configuration analysis
+- [ ] **Task 2.3**: Add compatibility checking engine with Kubernetes version validation
+- [ ] **Task 2.4**: Implement health-validated `update-addon` with pre/post checks
+- [ ] **Task 2.5**: Create dependency resolution for proper update ordering
+- [ ] **Task 2.6**: Add comprehensive error handling and AWS error mapping
+- [ ] **Task 2.7**: Implement performance optimizations and concurrent operations
+
+### Phase 3: Bulk Operations (Estimated: 8 days)
+- [ ] **Task 3.1**: Implement bulk update planning with dependency resolution
+- [ ] **Task 3.2**: Create `update-all-addons` with parallel execution where safe
+- [ ] **Task 3.3**: Add dry-run functionality for bulk operations
+- [ ] **Task 3.4**: Implement progress tracking for bulk updates
+- [ ] **Task 3.5**: Add rollback capabilities for failed bulk updates
+- [ ] **Task 3.6**: Create intelligent retry logic for transient failures
+- [ ] **Task 3.7**: Add comprehensive logging and audit trail
+
+### Phase 4: User Interface (Estimated: 8 days)  
+- [ ] **Task 4.1**: Design rich table output with health and compatibility status
+- [ ] **Task 4.2**: Create comprehensive JSON/YAML output structures
+- [ ] **Task 4.3**: Implement progress indicators for long-running operations
+- [ ] **Task 4.4**: Add interactive confirmation for bulk operations
+- [ ] **Task 4.5**: Create filtering and sorting for add-on lists
+- [ ] **Task 4.6**: Add comprehensive help documentation with examples
+- [ ] **Task 4.7**: Implement security scan results display
+
+### Phase 5: Testing & Validation (Estimated: 12 days)
+- [ ] **Task 5.1**: Write comprehensive unit tests (>90% coverage)
+- [ ] **Task 5.2**: Create integration tests with real EKS add-on operations
+- [ ] **Task 5.3**: Implement performance benchmarks vs eksctl
+- [ ] **Task 5.4**: Add compatibility validation testing across Kubernetes versions
+- [ ] **Task 5.5**: Test bulk operations with dependency resolution
+- [ ] **Task 5.6**: Validate health checking integration
+- [ ] **Task 5.7**: User acceptance testing with beta users
+
+### Phase 6: Documentation & Launch (Estimated: 6 days)
+- [ ] **Task 6.1**: Write comprehensive user documentation and tutorials
+- [ ] **Task 6.2**: Create add-on management best practices guide
+- [ ] **Task 6.3**: Update CLI help and man pages
+- [ ] **Task 6.4**: Prepare performance comparison vs eksctl
+- [ ] **Task 6.5**: Create demo videos showing bulk operations
+- [ ] **Task 6.6**: Plan feature launch highlighting speed improvements
+
+## Dependencies & Prerequisites
+
+### Feature Dependencies
+- **Prerequisite Features**: Enhanced Cluster Operations (for cluster version compatibility)
+- **Parallel Development**: Can be developed alongside other Phase 1 features
+- **Integration Points**: Existing health check framework for validation
+
+### AWS Prerequisites
+- **Required Permissions**: 
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "eks:ListAddons",
+          "eks:DescribeAddon",
+          "eks:CreateAddon",
+          "eks:UpdateAddon",
+          "eks:DeleteAddon",
+          "eks:DescribeAddonVersions",
+          "eks:DescribeAddonConfiguration",
+          "eks:DescribeCluster"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }
+  ```
+- **Supported Regions**: All EKS-supported AWS regions
+- **Kubernetes Versions**: All EKS-supported versions (1.25+)
+
+### External Dependencies
+- **kubectl**: Not required for basic add-on operations
+- **AWS CLI**: Not required
+- **Helm**: Not required (EKS managed add-ons only)
+
+## Success Criteria
+
+### Functional Requirements
+- [ ] **Core Functionality**: All add-on commands work with comprehensive health validation
+- [ ] **Performance**: 4x faster than eksctl for equivalent operations
+- [ ] **Compatibility**: Accurate version compatibility checking prevents failed updates
+- [ ] **Bulk Operations**: Successful dependency-ordered bulk updates
+- [ ] **Health Integration**: Zero failed updates due to health pre-checks
+- [ ] **Error Handling**: Clear, actionable error messages for all failure scenarios
+
+### Non-Functional Requirements
+- [ ] **Performance**: 
+  - `list-addons` completes in <2 seconds (vs eksctl's 30+ seconds)
+  - `update-addon` completes in 30-60 seconds (vs eksctl's 2-5 minutes)
+  - Bulk operations complete 3x faster than sequential eksctl operations
+- [ ] **Reliability**: 99.9% success rate for add-on operations with health validation
+- [ ] **Accuracy**: 100% accuracy in compatibility checking prevents failed updates
+- [ ] **Usability**: Zero-config operation with existing AWS credentials
+
+### Quality Gates
+- [ ] **Test Coverage**: >90% unit test coverage for all service components
+- [ ] **Integration Testing**: Full test suite with real EKS add-on operations
+- [ ] **Performance Testing**: Benchmarks demonstrate 4x improvement vs eksctl
+- [ ] **Compatibility Testing**: Validation across all supported Kubernetes versions
+- [ ] **Health Validation**: Zero failed operations due to health issues in testing
+- [ ] **User Validation**: Beta users confirm speed and reliability improvements
+
+## Risk Assessment & Mitigation
+
+### Technical Risks
+- **Compatibility Database Maintenance**: Keeping version compatibility matrix current
+  - *Impact*: High
+  - *Likelihood*: Medium  
+  - *Mitigation*: Automated compatibility detection, AWS documentation monitoring
+
+- **Dependency Resolution Complexity**: Complex add-on dependencies may cause failures
+  - *Impact*: Medium
+  - *Likelihood*: Low
+  - *Mitigation*: Conservative dependency ordering, extensive testing, fallback options
+
+### Performance Risks
+- **AWS API Rate Limits**: Bulk operations may hit EKS API limits
+  - *Impact*: Medium
+  - *Likelihood*: Low
+  - *Mitigation*: Request throttling, exponential backoff, intelligent batching
+
+- **Large Cluster Performance**: Many add-ons may slow operations
+  - *Impact*: Low
+  - *Likelihood*: Low
+  - *Mitigation*: Concurrent operations, caching, pagination
+
+### Business Risks
+- **User Trust**: Failed bulk operations could damage confidence
+  - *Mitigation*: Extensive testing, dry-run capabilities, rollback features
+
+- **eksctl Improvements**: AWS may improve eksctl add-on performance
+  - *Mitigation*: Focus on features eksctl can't provide (health validation, bulk ops, etc.)
+
+## Metrics & KPIs
+
+### Performance Metrics
+- **Response Time**: Average time for add-on operations (target: 4x faster than eksctl)
+- **Bulk Operation Efficiency**: Time savings vs sequential eksctl operations
+- **Success Rate**: Percentage of successful operations (target: 99.9%)
+
+### Business Metrics
+- **Feature Adoption**: Number of users performing bulk add-on operations
+- **Error Reduction**: Decrease in failed add-on updates due to health validation
+- **Time Savings**: Total time saved vs eksctl operations
+
+---
+
+This feature establishes refresh as the fastest, most reliable EKS add-on management tool while providing capabilities that eksctl fundamentally cannot match due to its CloudFormation architecture.

--- a/features/phase1/enhanced-cluster-operations.md
+++ b/features/phase1/enhanced-cluster-operations.md
@@ -1,0 +1,559 @@
+# Enhanced Cluster Operations - refresh Tool
+
+*Feature Specification v1.0*  
+*Phase: 1 | Priority: HIGH | Effort: L*
+
+## Executive Summary
+
+**One-sentence value proposition**: Provide comprehensive cluster information and management capabilities that are 4x faster than eksctl with integrated health validation and cross-region support.
+
+**Target Users**: DevOps Engineers, SREs, Platform Engineers
+
+**Competitive Advantage**: Direct EKS API calls without CloudFormation overhead, real-time health integration, native multi-region operations
+
+**Success Metric**: 4x faster cluster information retrieval than eksctl, 95%+ user satisfaction with information completeness
+
+## Problem Statement
+
+### Current Pain Points
+- **eksctl slowness**: `eksctl get cluster` takes 5-8 seconds due to CloudFormation dependency
+- **Limited information**: Basic cluster info without operational context (health, costs, security posture)
+- **Single region constraint**: eksctl requires separate commands for different regions
+- **No operational intelligence**: No integration with workload health, capacity planning, or optimization recommendations
+
+### User Stories
+```
+As a DevOps engineer, I want to quickly see all my EKS clusters across regions with health status so that I can identify issues before they impact applications.
+
+As an SRE, I want comprehensive cluster information including security configuration and capacity utilization so that I can make informed operational decisions.
+
+As a Platform engineer, I want to compare clusters across environments and regions so that I can ensure consistency and identify configuration drift.
+```
+
+### Market Context
+- **eksctl limitation**: CloudFormation-based approach causes 5-8 second delays for simple information retrieval
+- **AWS CLI complexity**: Requires multiple commands and manual correlation to get comprehensive cluster view
+- **User demand**: GitHub issues consistently request faster cluster operations and better information display
+
+## Solution Overview
+
+### Core Functionality
+Enhanced cluster operations provide comprehensive, fast access to EKS cluster information through direct API calls. The feature integrates with the existing health check framework to provide operational intelligence beyond basic cluster metadata. Unlike eksctl's CloudFormation-dependent approach, this feature queries EKS APIs directly for sub-second response times while providing richer information including health status, security configuration, and capacity insights.
+
+Key capabilities include detailed cluster information with security and networking analysis, multi-region cluster discovery and comparison, integrated health validation using the existing health check framework, and performance optimization through caching and concurrent API calls.
+
+### Key Benefits
+1. **Performance**: 4x faster than eksctl (1-2 seconds vs 5-8 seconds)
+2. **User Experience**: Single command for comprehensive cluster analysis across regions
+3. **Operational Value**: Integrated health checks and security posture analysis eliminate need for separate tools
+4. **Strategic Advantage**: Foundation for all advanced refresh features, establishing pattern for operational excellence
+
+## Command Interface Design
+
+### Primary Commands
+```bash
+# Enhanced cluster information (replaces eksctl get cluster)
+refresh describe-cluster -c my-cluster --detailed
+
+# Cluster status with versions and health (new capability)
+refresh cluster-status -c my-cluster --show-versions --show-endpoints
+
+# Comprehensive health check (integrates existing health framework)
+refresh cluster-health -c my-cluster --comprehensive
+
+# Multi-cluster operations (eksctl limitation)
+refresh list-clusters --all-regions --show-health
+
+# Cluster comparison (new capability)
+refresh compare-clusters -c cluster1 -c cluster2
+```
+
+### Detailed Command Specifications
+
+#### Command 1: `refresh describe-cluster`
+**Purpose**: Provide comprehensive cluster information faster than eksctl with operational intelligence
+
+**Syntax**:
+```bash
+refresh describe-cluster -c CLUSTER [options]
+```
+
+**Required Arguments**:
+- `-c, --cluster`: EKS cluster name or pattern
+
+**Optional Flags**:
+- `--detailed`: Show comprehensive information including networking, security, and capacity
+- `--format`: Output format (table, json, yaml)
+- `--show-health`: Include health status from existing health check framework
+- `--show-costs`: Include cost analysis (requires Phase 3 cost feature)
+- `--show-security`: Include security posture analysis
+
+**Examples**:
+```bash
+# Basic cluster information (faster than eksctl get cluster)
+refresh describe-cluster -c my-cluster
+
+# Comprehensive view with health and security
+refresh describe-cluster -c my-cluster --detailed --show-health --show-security
+
+# JSON output for automation
+refresh describe-cluster -c my-cluster --format json
+```
+
+**Output Format - Table View**:
+```
+Cluster Information: my-cluster
+┌─────────────────┬───────────────────────────────────────┐
+│ PROPERTY        │ VALUE                                 │
+├─────────────────┼───────────────────────────────────────┤
+│ Status          │ Active                                │
+│ Version         │ 1.30                                  │
+│ Platform        │ eks.15                                │
+│ Endpoint        │ https://ABC123.gr7.us-west-2.eks... │
+│ Health          │ ✅ Healthy (5/5 checks passed)       │
+│ Nodegroups      │ 3 active (12 nodes total)            │
+│ VPC             │ vpc-abc123 (10.0.0.0/16)            │
+│ Subnets         │ 6 subnets across 3 AZs               │
+│ Security Groups │ 2 groups (restrictive)               │
+│ Logging         │ API, Audit enabled                   │
+│ Encryption      │ ✅ At rest (KMS), ✅ In transit     │
+│ Created         │ 2024-12-15 14:30:22 UTC              │
+│ Age             │ 52 days                               │
+└─────────────────┴───────────────────────────────────────┘
+
+Add-ons:
+┌─────────────────┬─────────┬────────────┬────────┐
+│ NAME            │ VERSION │ STATUS     │ HEALTH │
+├─────────────────┼─────────┼────────────┼────────┤
+│ vpc-cni         │ v1.18.1 │ Active     │ ✅     │
+│ coredns         │ v1.11.1 │ Active     │ ✅     │
+│ kube-proxy      │ v1.30.0 │ Active     │ ✅     │
+│ aws-ebs-csi     │ v1.30.0 │ Active     │ ✅     │
+└─────────────────┴─────────┴────────────┴────────┘
+```
+
+**Output Format - JSON**:
+```json
+{
+  "cluster": {
+    "name": "my-cluster",
+    "status": "Active",
+    "version": "1.30",
+    "platformVersion": "eks.15",
+    "endpoint": "https://ABC123.gr7.us-west-2.eks.amazonaws.com",
+    "health": {
+      "status": "Healthy",
+      "checks": {
+        "passed": 5,
+        "total": 5
+      },
+      "details": [...]
+    },
+    "networking": {
+      "vpcId": "vpc-abc123",
+      "subnetIds": ["subnet-123", "subnet-456"],
+      "securityGroupIds": ["sg-789"]
+    },
+    "logging": {
+      "enabled": ["api", "audit"],
+      "disabled": ["authenticator", "controllerManager", "scheduler"]
+    },
+    "encryption": {
+      "secrets": true,
+      "provider": "arn:aws:kms:us-west-2:123456789012:key/abc123"
+    },
+    "addons": [...],
+    "nodegroups": [...],
+    "createdAt": "2024-12-15T14:30:22Z"
+  }
+}
+```
+
+#### Command 2: `refresh list-clusters`
+**Purpose**: Fast multi-region cluster discovery with health status
+
+**Syntax**:
+```bash
+refresh list-clusters [options]
+```
+
+**Optional Flags**:
+- `--all-regions`: Query all EKS-supported regions
+- `--region`: Specific region(s) to query
+- `--show-health`: Include health status for each cluster
+- `--show-costs`: Include cost information (requires Phase 3)
+- `--filter`: Filter by status, version, or other criteria
+- `--format`: Output format (table, json, yaml)
+
+**Examples**:
+```bash
+# Fast local region cluster list
+refresh list-clusters
+
+# Multi-region with health status
+refresh list-clusters --all-regions --show-health
+
+# Filter by Kubernetes version
+refresh list-clusters --filter version=1.30
+```
+
+**Output Format - Table View**:
+```
+EKS Clusters (3 regions, 8 clusters)
+┌────────────────┬────────────┬─────────┬─────────┬──────────┬─────────────────┐
+│ CLUSTER        │ REGION     │ STATUS  │ VERSION │ HEALTH   │ NODES           │
+├────────────────┼────────────┼─────────┼─────────┼──────────┼─────────────────┤
+│ prod-api       │ us-west-2  │ Active  │ 1.30    │ ✅ Healthy│ 5/5 ready       │
+│ prod-workers   │ us-west-2  │ Active  │ 1.30    │ ✅ Healthy│ 10/10 ready     │
+│ staging-main   │ us-west-2  │ Active  │ 1.30    │ ⚠️  Warn  │ 3/3 ready       │
+│ prod-api       │ us-east-1  │ Active  │ 1.30    │ ✅ Healthy│ 5/5 ready       │
+│ dev-cluster    │ us-east-1  │ Active  │ 1.29    │ ✅ Healthy│ 2/2 ready       │
+│ test-env       │ eu-west-1  │ Updating│ 1.30    │ 🔄 Update │ 4/4 ready       │
+└────────────────┴────────────┴─────────┴─────────┴──────────┴─────────────────┘
+
+Summary: 6 healthy, 1 warning, 1 updating
+```
+
+#### Command 3: `refresh compare-clusters`
+**Purpose**: Side-by-side cluster comparison for consistency validation
+
+**Syntax**:
+```bash
+refresh compare-clusters -c CLUSTER1 -c CLUSTER2 [options]
+```
+
+**Required Arguments**:
+- `-c, --cluster`: Cluster name (can be specified multiple times)
+
+**Optional Flags**:
+- `--show-differences`: Highlight only differences
+- `--include`: Compare specific aspects (networking, security, addons, versions)
+- `--format`: Output format (table, json, yaml)
+
+**Examples**:
+```bash
+# Basic cluster comparison
+refresh compare-clusters -c prod-us-west -c prod-us-east
+
+# Focus on differences only
+refresh compare-clusters -c staging -c prod --show-differences
+
+# Compare specific aspects
+refresh compare-clusters -c cluster1 -c cluster2 --include networking,security
+```
+
+## Technical Implementation
+
+### AWS APIs Required
+```go
+// Primary APIs
+"github.com/aws/aws-sdk-go-v2/service/eks"
+- ListClusters
+- DescribeCluster
+- ListAddons
+- DescribeAddon
+- ListNodegroups
+
+// Supporting APIs for comprehensive information
+"github.com/aws/aws-sdk-go-v2/service/ec2"
+- DescribeVpcs
+- DescribeSubnets
+- DescribeSecurityGroups
+
+"github.com/aws/aws-sdk-go-v2/service/iam"
+- GetRole (for cluster service role analysis)
+
+// Existing APIs (already available)
+"github.com/aws/aws-sdk-go-v2/service/sts"
+- GetCallerIdentity (for credential validation)
+```
+
+### Data Structures
+```go
+// Enhanced cluster information
+type ClusterDetails struct {
+    // Basic cluster info
+    Name              string                `json:"name"`
+    Status            string                `json:"status"`
+    Version           string                `json:"version"`
+    PlatformVersion   string                `json:"platformVersion"`
+    Endpoint          string                `json:"endpoint"`
+    CreatedAt         time.Time             `json:"createdAt"`
+    
+    // Health information (integration with existing health framework)
+    Health            *health.HealthStatus  `json:"health,omitempty"`
+    
+    // Networking details
+    Networking        NetworkingInfo        `json:"networking"`
+    
+    // Security configuration
+    Security          SecurityInfo          `json:"security"`
+    
+    // Add-ons and nodegroups
+    Addons            []AddonInfo           `json:"addons"`
+    Nodegroups        []NodegroupSummary    `json:"nodegroups"`
+    
+    // Operational metadata
+    Tags              map[string]string     `json:"tags"`
+    Region            string                `json:"region"`
+}
+
+type NetworkingInfo struct {
+    VpcId             string   `json:"vpcId"`
+    VpcCidr           string   `json:"vpcCidr"`
+    SubnetIds         []string `json:"subnetIds"`
+    SecurityGroupIds  []string `json:"securityGroupIds"`
+    EndpointAccess    EndpointAccessInfo `json:"endpointAccess"`
+}
+
+type SecurityInfo struct {
+    EncryptionEnabled bool   `json:"encryptionEnabled"`
+    KmsKeyArn        string `json:"kmsKeyArn,omitempty"`
+    ServiceRoleArn   string `json:"serviceRoleArn"`
+    LoggingEnabled   []string `json:"loggingEnabled"`
+}
+
+type ClusterComparison struct {
+    Clusters     []ClusterDetails `json:"clusters"`
+    Differences  []Difference     `json:"differences"`
+    Summary      ComparisonSummary `json:"summary"`
+}
+```
+
+### Internal Service Interface
+```go
+package cluster
+
+type Service interface {
+    // Single cluster operations
+    Describe(ctx context.Context, name string, options DescribeOptions) (*ClusterDetails, error)
+    GetHealth(ctx context.Context, name string) (*health.HealthStatus, error)
+    
+    // Multi-cluster operations
+    List(ctx context.Context, options ListOptions) ([]ClusterSummary, error)
+    ListAllRegions(ctx context.Context, options ListOptions) ([]ClusterSummary, error)
+    
+    // Comparison operations
+    Compare(ctx context.Context, clusterNames []string, options CompareOptions) (*ClusterComparison, error)
+}
+
+type ServiceImpl struct {
+    eksClient     *eks.Client
+    ec2Client     *ec2.Client
+    iamClient     *iam.Client
+    healthChecker *health.HealthChecker
+    cache         *cache.Cache
+    logger        *slog.Logger
+}
+
+type DescribeOptions struct {
+    ShowHealth    bool
+    ShowSecurity  bool
+    ShowCosts     bool
+    IncludeAddons bool
+}
+
+type ListOptions struct {
+    Regions       []string
+    ShowHealth    bool
+    ShowCosts     bool
+    Filters       map[string]string
+}
+```
+
+### New Internal Packages
+```
+internal/
+├── services/
+│   └── cluster/
+│       ├── service.go          # Main service implementation
+│       ├── types.go           # Data structures
+│       ├── client.go          # AWS client wrapper with retry logic
+│       ├── cache.go           # Caching layer for performance
+│       ├── comparison.go      # Cluster comparison logic
+│       └── formatter.go       # Output formatting
+└── commands/
+    ├── describe_cluster.go    # describe-cluster command
+    ├── list_clusters.go       # list-clusters command  
+    └── compare_clusters.go    # compare-clusters command
+```
+
+### Configuration
+```go
+// Enhanced configuration for cluster operations
+type ClusterConfig struct {
+    CacheTimeout     time.Duration `yaml:"cache_timeout"`      // Default: 5 minutes
+    MaxConcurrency   int          `yaml:"max_concurrency"`    // Default: 10
+    DefaultFormat    string       `yaml:"default_format"`     // Default: "table"
+    HealthChecks     bool         `yaml:"health_checks"`      // Default: true
+    IncludeAddons    bool         `yaml:"include_addons"`     // Default: true
+    MultiRegion      bool         `yaml:"multi_region"`       // Default: false
+}
+```
+
+## Implementation Task Breakdown
+
+### Phase 1: Infrastructure Setup (Estimated: 8 days)
+- [ ] **Task 1.1**: Create `internal/services/cluster` package structure
+- [ ] **Task 1.2**: Define Go interfaces and comprehensive data structures  
+- [ ] **Task 1.3**: Set up enhanced AWS SDK client configuration with retry logic
+- [ ] **Task 1.4**: Add CLI command structure for all three commands
+- [ ] **Task 1.5**: Create configuration management for cluster operations
+- [ ] **Task 1.6**: Set up caching layer for performance optimization
+- [ ] **Task 1.7**: Add multi-region query coordination
+
+### Phase 2: Core Implementation (Estimated: 12 days)
+- [ ] **Task 2.1**: Implement `describe-cluster` with EKS API integration
+- [ ] **Task 2.2**: Add networking information gathering (VPC, subnets, security groups)
+- [ ] **Task 2.3**: Integrate with existing health check framework
+- [ ] **Task 2.4**: Implement `list-clusters` with multi-region support
+- [ ] **Task 2.5**: Add concurrent API calls for performance
+- [ ] **Task 2.6**: Create cluster comparison logic and difference detection
+- [ ] **Task 2.7**: Implement comprehensive error handling and AWS error mapping
+
+### Phase 3: User Interface (Estimated: 10 days)  
+- [ ] **Task 3.1**: Design and implement rich table output formatting
+- [ ] **Task 3.2**: Add JSON/YAML output with comprehensive structure
+- [ ] **Task 3.3**: Create progress indicators for multi-region operations
+- [ ] **Task 3.4**: Implement filtering and sorting for cluster lists
+- [ ] **Task 3.5**: Add comprehensive help documentation and examples
+- [ ] **Task 3.6**: Create interactive selection for cluster comparison
+
+### Phase 4: Testing & Validation (Estimated: 15 days)
+- [ ] **Task 4.1**: Write comprehensive unit tests (>90% coverage)
+- [ ] **Task 4.2**: Create integration tests with real AWS EKS clusters
+- [ ] **Task 4.3**: Implement performance benchmarks vs eksctl
+- [ ] **Task 4.4**: Add multi-region testing and edge case validation
+- [ ] **Task 4.5**: Security testing for credential handling
+- [ ] **Task 4.6**: Load testing with large numbers of clusters
+- [ ] **Task 4.7**: User acceptance testing with beta users
+
+### Phase 5: Documentation & Launch (Estimated: 8 days)
+- [ ] **Task 5.1**: Write comprehensive user documentation
+- [ ] **Task 5.2**: Create migration guide from eksctl
+- [ ] **Task 5.3**: Update CLI help and man pages
+- [ ] **Task 5.4**: Prepare performance comparison demonstrations
+- [ ] **Task 5.5**: Create demo videos showing speed improvements
+- [ ] **Task 5.6**: Plan feature launch and user communication
+
+## Dependencies & Prerequisites
+
+### Feature Dependencies
+- **Prerequisite Features**: None (foundation feature)
+- **Parallel Development**: Can be developed alongside other Phase 1 features
+- **Integration Points**: Existing health check framework for health status integration
+
+### AWS Prerequisites
+- **Required Permissions**: 
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "eks:ListClusters",
+          "eks:DescribeCluster",
+          "eks:ListAddons",
+          "eks:DescribeAddon",
+          "eks:ListNodegroups",
+          "ec2:DescribeVpcs",
+          "ec2:DescribeSubnets", 
+          "ec2:DescribeSecurityGroups",
+          "iam:GetRole"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }
+  ```
+- **Supported Regions**: All EKS-supported AWS regions
+- **Kubernetes Versions**: All EKS-supported versions (1.25+)
+
+### External Dependencies
+- **kubectl**: Not required for basic functionality
+- **AWS CLI**: Not required
+- **Docker**: Not required
+
+## Success Criteria
+
+### Functional Requirements
+- [ ] **Core Functionality**: All three commands work as designed across all EKS regions
+- [ ] **Error Handling**: Graceful handling of network timeouts, permission errors, and invalid clusters
+- [ ] **Performance**: 4x faster than eksctl for equivalent operations
+- [ ] **Output Formats**: Complete support for table, JSON, and YAML formats
+- [ ] **Health Integration**: Seamless integration with existing health check framework
+- [ ] **Multi-Region**: Concurrent queries across regions with proper error isolation
+
+### Non-Functional Requirements
+- [ ] **Performance**: 
+  - `describe-cluster` completes in <2 seconds (vs eksctl's 5-8 seconds)
+  - `list-clusters --all-regions` completes in <5 seconds for up to 50 clusters
+  - Multi-region queries use concurrent API calls for optimal performance
+- [ ] **Reliability**: 99.9% success rate under normal AWS conditions
+- [ ] **Usability**: 
+  - Zero-config setup works with existing AWS credentials
+  - Self-documenting with comprehensive help and examples
+  - Consistent with existing refresh CLI patterns and user experience
+- [ ] **Caching**: Intelligent caching reduces API calls while maintaining data freshness
+
+### Quality Gates
+- [ ] **Test Coverage**: >90% unit test coverage for all service components
+- [ ] **Integration Testing**: Full test suite against real EKS clusters in multiple regions
+- [ ] **Performance Testing**: Benchmarks demonstrate 4x improvement vs eksctl
+- [ ] **Security Review**: No credential exposure, proper AWS SDK credential handling
+- [ ] **User Validation**: Beta user feedback confirms usability and performance improvements
+- [ ] **Documentation**: Complete CLI help, man pages, and user guides
+
+## Risk Assessment & Mitigation
+
+### Technical Risks
+- **AWS API Rate Limits**: Multi-region queries may hit rate limits
+  - *Impact*: Medium
+  - *Likelihood*: Low
+  - *Mitigation*: Implement exponential backoff, request batching, and intelligent caching
+
+- **EKS API Changes**: AWS may modify EKS APIs affecting compatibility
+  - *Impact*: High
+  - *Likelihood*: Low
+  - *Mitigation*: Monitor AWS SDK changelogs, implement adapter pattern for API changes
+
+### Performance Risks
+- **Network Latency**: Multi-region queries dependent on network performance
+  - *Impact*: Medium
+  - *Likelihood*: Medium
+  - *Mitigation*: Concurrent queries, regional optimization, fallback mechanisms
+
+- **Large Cluster Counts**: Performance may degrade with many clusters
+  - *Impact*: Medium
+  - *Likelihood*: Medium
+  - *Mitigation*: Pagination, filtering, caching, and parallel processing
+
+### Business Risks
+- **User Adoption**: Users may prefer familiar eksctl despite performance benefits
+  - *Mitigation*: Clear migration documentation, performance demonstrations, superior UX
+
+- **eksctl Improvements**: AWS may improve eksctl performance
+  - *Mitigation*: Focus on features eksctl can't provide (health integration, comparison, etc.)
+
+## Metrics & KPIs
+
+### Performance Metrics
+- **Response Time**: Average time for describe-cluster operations (target: <2 seconds)
+- **Multi-Region Performance**: Average time for all-regions queries (target: <5 seconds)
+- **Success Rate**: Percentage of successful operations (target: >99%)
+- **Cache Hit Rate**: Percentage of requests served from cache (target: >60%)
+
+### Adoption Metrics
+- **Feature Usage**: Number of users executing cluster operation commands
+- **Command Frequency**: Most used commands and flag combinations
+- **eksctl Migration**: Users switching from eksctl to refresh for cluster operations
+
+### Quality Metrics
+- **Error Rate**: Frequency of errors by type (network, permission, parsing)
+- **User Satisfaction**: Survey feedback on speed and information quality
+- **Support Requests**: Volume of user questions and issues related to cluster operations
+
+---
+
+This feature establishes the foundation for all advanced refresh capabilities while delivering immediate value through superior performance and comprehensive cluster intelligence.

--- a/features/templates/feature-template.md
+++ b/features/templates/feature-template.md
@@ -1,0 +1,418 @@
+# [Feature Name] - refresh Tool
+
+*Feature Specification Template v1.0*  
+*Phase: [1-4] | Priority: [HIGH/MEDIUM/LOW] | Effort: [S/M/L/XL]*
+
+## Executive Summary
+
+**One-sentence value proposition**: [Clear, compelling statement of what this feature does]
+
+**Target Users**: [DevOps Engineers / SREs / Platform Engineers / Security Teams]
+
+**Competitive Advantage**: [How this beats eksctl/AWS CLI/other tools]
+
+**Success Metric**: [Specific, measurable outcome - performance, adoption, satisfaction]
+
+## Problem Statement
+
+### Current Pain Points
+- **Pain Point 1**: [Specific issue users face today]
+- **Pain Point 2**: [Current limitation or frustration]
+- **Pain Point 3**: [Gap in existing tools]
+
+### User Stories
+```
+As a [persona], I want to [action] so that [benefit].
+```
+
+### Market Context
+- **eksctl limitation**: [What eksctl can't do or does poorly]
+- **AWS CLI complexity**: [How many steps/commands this replaces]
+- **User demand**: [Evidence of need - GitHub issues, forum posts, surveys]
+
+## Solution Overview
+
+### Core Functionality
+[2-3 paragraph description of how this feature works and what it accomplishes]
+
+### Key Benefits
+1. **Performance**: [Specific improvement - 3x faster, etc.]
+2. **User Experience**: [UX improvement over existing tools]
+3. **Operational Value**: [How this improves day-to-day operations]
+4. **Strategic Advantage**: [Long-term competitive positioning]
+
+## Command Interface Design
+
+### Primary Commands
+```bash
+# Command 1: [Brief description]
+refresh [command-name] [required-args] [flags]
+
+# Command 2: [Brief description]  
+refresh [command-name] [required-args] [flags]
+
+# Command 3: [Brief description]
+refresh [command-name] [required-args] [flags]
+```
+
+### Detailed Command Specifications
+
+#### Command 1: `refresh [command-name]`
+**Purpose**: [What this command accomplishes]
+
+**Syntax**:
+```bash
+refresh [command-name] -c CLUSTER [options]
+```
+
+**Required Arguments**:
+- `-c, --cluster`: EKS cluster name or pattern
+
+**Optional Flags**:
+- `--detailed`: Show comprehensive information
+- `--format`: Output format (table, json, yaml)
+- `--filter`: Filter results by criteria
+- `--dry-run`: Preview changes without executing
+- `--health-check`: Validate before operation
+- `--wait`: Wait for operation completion
+- `--timeout`: Operation timeout duration
+
+**Examples**:
+```bash
+# Basic usage
+refresh [command-name] -c my-cluster
+
+# Advanced usage with filters
+refresh [command-name] -c my-cluster --detailed --format json
+
+# Dry run with health validation
+refresh [command-name] -c my-cluster --dry-run --health-check
+```
+
+**Output Format - Table View**:
+```
+CLUSTER     STATUS    VERSION    NODES    HEALTH    LAST_UPDATED
+my-cluster  Active    1.30      5/5      Healthy   2025-08-06T10:30:00Z
+```
+
+**Output Format - JSON**:
+```json
+{
+  "clusters": [
+    {
+      "name": "my-cluster",
+      "status": "Active",
+      "version": "1.30",
+      "nodes": {
+        "ready": 5,
+        "total": 5
+      },
+      "health": "Healthy",
+      "lastUpdated": "2025-08-06T10:30:00Z"
+    }
+  ]
+}
+```
+
+**Error Scenarios**:
+- **Invalid cluster**: "Cluster 'my-cluster' not found. Available clusters: [list]"
+- **Permission denied**: "Access denied. Ensure you have eks:DescribeCluster permission"
+- **Network timeout**: "Request timeout. Check network connectivity and try again"
+
+### Help Text Design
+```
+DESCRIPTION:
+    [2-3 line description of what this command does]
+
+USAGE:
+    refresh [command-name] -c CLUSTER [options]
+
+EXAMPLES:
+    # Basic cluster information
+    refresh [command-name] -c my-cluster
+    
+    # Detailed view with health check
+    refresh [command-name] -c my-cluster --detailed --health-check
+
+OPTIONS:
+    -c, --cluster string     EKS cluster name or pattern
+        --detailed          Show comprehensive information
+        --format string     Output format: table, json, yaml (default: table)
+        --help             Show this help message
+
+GLOBAL OPTIONS:
+    --region string     AWS region (overrides default)
+    --profile string    AWS profile to use
+    --verbose          Enable verbose logging
+```
+
+## Technical Implementation
+
+### AWS APIs Required
+```go
+// Primary APIs
+"github.com/aws/aws-sdk-go-v2/service/eks"
+- ListClusters
+- DescribeCluster
+- [Additional APIs as needed]
+
+// Supporting APIs  
+"github.com/aws/aws-sdk-go-v2/service/ec2"
+- DescribeVpcs
+- [Additional APIs]
+
+// New Dependencies (if any)
+"github.com/aws/aws-sdk-go-v2/service/[service]"
+```
+
+### Data Structures
+```go
+// Request structures
+type [FeatureName]Request struct {
+    ClusterName string
+    Detailed    bool
+    Format      string
+    Filters     []string
+}
+
+// Response structures
+type [FeatureName]Response struct {
+    Items []Item
+    Count int
+    Health HealthStatus
+}
+
+type Item struct {
+    Name       string    `json:"name"`
+    Status     string    `json:"status"`
+    CreatedAt  time.Time `json:"createdAt"`
+    // Additional fields
+}
+```
+
+### Internal Service Interface
+```go
+package services
+
+type [FeatureName]Service interface {
+    List(ctx context.Context, req *[FeatureName]Request) (*[FeatureName]Response, error)
+    Describe(ctx context.Context, name string) (*Item, error)
+    Validate(ctx context.Context, name string) (*HealthResult, error)
+}
+
+type [FeatureName]ServiceImpl struct {
+    eksClient    *eks.Client
+    healthChecker *health.HealthChecker
+    cache        *cache.Cache
+}
+```
+
+### New Internal Packages
+```
+internal/
+├── services/
+│   └── [feature-name]/
+│       ├── service.go          # Main service implementation
+│       ├── types.go           # Data structures
+│       ├── client.go          # AWS client wrapper
+│       └── validator.go       # Validation logic
+└── commands/
+    └── [feature-name].go       # CLI command implementation
+```
+
+### Configuration
+```go
+// New configuration options
+type Config struct {
+    // Existing config...
+    [FeatureName] [FeatureName]Config `yaml:"[feature-name]"`
+}
+
+type [FeatureName]Config struct {
+    CacheTimeout    time.Duration `yaml:"cache_timeout"`
+    MaxConcurrency  int          `yaml:"max_concurrency"`
+    DefaultFormat   string       `yaml:"default_format"`
+}
+```
+
+## Implementation Task Breakdown
+
+### Phase 1: Infrastructure Setup (Estimated: [X] days)
+- [ ] **Task 1.1**: Create internal service package structure
+- [ ] **Task 1.2**: Define Go interfaces and data structures  
+- [ ] **Task 1.3**: Set up AWS SDK client configuration
+- [ ] **Task 1.4**: Add CLI command structure to main application
+- [ ] **Task 1.5**: Create configuration management for new feature
+- [ ] **Task 1.6**: Set up logging and metrics collection
+- [ ] **Task 1.7**: Add feature flag system for gradual rollout
+
+### Phase 2: Core Implementation (Estimated: [X] days)
+- [ ] **Task 2.1**: Implement AWS API integration and error handling
+- [ ] **Task 2.2**: Create data transformation and formatting logic
+- [ ] **Task 2.3**: Add caching layer for performance optimization
+- [ ] **Task 2.4**: Implement health check integration
+- [ ] **Task 2.5**: Add concurrent/parallel processing capabilities
+- [ ] **Task 2.6**: Create filtering and sorting mechanisms
+- [ ] **Task 2.7**: Implement dry-run functionality
+
+### Phase 3: User Interface (Estimated: [X] days)  
+- [ ] **Task 3.1**: Design and implement table output formatting
+- [ ] **Task 3.2**: Add JSON/YAML output support
+- [ ] **Task 3.3**: Create progress indicators and status updates
+- [ ] **Task 3.4**: Implement comprehensive error messaging
+- [ ] **Task 3.5**: Add help documentation and examples
+- [ ] **Task 3.6**: Create interactive confirmation prompts
+
+### Phase 4: Testing & Validation (Estimated: [X] days)
+- [ ] **Task 4.1**: Write comprehensive unit tests (>90% coverage)
+- [ ] **Task 4.2**: Create integration tests with real AWS resources
+- [ ] **Task 4.3**: Implement performance benchmarks vs eksctl
+- [ ] **Task 4.4**: Add end-to-end user scenario testing
+- [ ] **Task 4.5**: Security testing and validation
+- [ ] **Task 4.6**: Load testing and stress testing
+- [ ] **Task 4.7**: User acceptance testing with beta users
+
+### Phase 5: Documentation & Launch (Estimated: [X] days)
+- [ ] **Task 5.1**: Write user documentation and tutorials
+- [ ] **Task 5.2**: Create API documentation and examples  
+- [ ] **Task 5.3**: Update CLI help and man pages
+- [ ] **Task 5.4**: Prepare release notes and changelog
+- [ ] **Task 5.5**: Create demo videos and screenshots
+- [ ] **Task 5.6**: Plan and execute feature launch communication
+
+## Dependencies & Prerequisites
+
+### Feature Dependencies
+- **Prerequisite Features**: [List features that must be complete first]
+- **Parallel Development**: [Features that can be developed simultaneously]
+- **Blocking Dependencies**: [External factors that could delay this feature]
+
+### AWS Prerequisites
+- **Required Permissions**: 
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "eks:ListClusters",
+          "eks:DescribeCluster"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }
+  ```
+- **Supported Regions**: All EKS-supported AWS regions
+- **Kubernetes Versions**: 1.25+ (aligned with EKS support)
+
+### External Dependencies
+- **kubectl**: Required for [specific functionality]
+- **AWS CLI**: Optional, for [specific use cases]
+- **Docker**: Not required
+
+## Success Criteria
+
+### Functional Requirements
+- [ ] **Core Functionality**: All specified commands work as designed
+- [ ] **Error Handling**: Graceful handling of all error scenarios
+- [ ] **Performance**: Meets benchmark targets vs eksctl
+- [ ] **Output Formats**: Support for table, JSON, and YAML
+- [ ] **Health Integration**: Validates operations before/after execution
+- [ ] **Cross-Platform**: Works on macOS, Linux, and Windows
+
+### Non-Functional Requirements
+- [ ] **Performance**: 
+  - List operations complete in <2 seconds
+  - Describe operations complete in <1 second
+  - 3x faster than equivalent eksctl operations
+- [ ] **Reliability**: 99.9% success rate under normal conditions
+- [ ] **Usability**: 
+  - Zero-config setup for basic usage
+  - Self-documenting with comprehensive help
+  - Consistent with existing refresh CLI patterns
+- [ ] **Security**: No credential exposure or sensitive data logging
+
+### Quality Gates
+- [ ] **Test Coverage**: >90% unit test coverage
+- [ ] **Integration Testing**: Full AWS integration test suite
+- [ ] **Performance Testing**: Benchmarks vs eksctl established
+- [ ] **Security Review**: Security scan and review completed
+- [ ] **User Validation**: Beta user feedback incorporated
+- [ ] **Documentation**: Complete user and developer documentation
+
+## Documentation Requirements
+
+### User Documentation
+- [ ] **Feature Overview**: What it does and why users need it
+- [ ] **Getting Started**: Quick start guide with examples
+- [ ] **Command Reference**: Complete CLI documentation
+- [ ] **Common Use Cases**: Real-world scenarios and solutions
+- [ ] **Troubleshooting**: Common issues and resolutions
+- [ ] **Migration Guide**: Migrating from eksctl/AWS CLI
+
+### Developer Documentation  
+- [ ] **Architecture Overview**: How the feature is implemented
+- [ ] **API Documentation**: Internal service interfaces
+- [ ] **Testing Guide**: How to run and extend tests
+- [ ] **Contributing Guide**: How to modify or extend the feature
+
+### Launch Materials
+- [ ] **Blog Post**: Feature announcement and benefits
+- [ ] **Demo Video**: 5-minute feature walkthrough
+- [ ] **Release Notes**: What's new and how to upgrade
+- [ ] **Social Media**: Twitter/LinkedIn announcement posts
+
+## Risk Assessment & Mitigation
+
+### Technical Risks
+- **Risk 1**: [Specific technical challenge]
+  - *Impact*: High/Medium/Low
+  - *Likelihood*: High/Medium/Low  
+  - *Mitigation*: [Specific steps to reduce risk]
+
+- **Risk 2**: [Another technical risk]
+  - *Impact*: High/Medium/Low
+  - *Likelihood*: High/Medium/Low
+  - *Mitigation*: [Mitigation strategy]
+
+### Business Risks
+- **User Adoption**: Feature may not meet adoption targets
+  - *Mitigation*: User research, beta testing, feedback integration
+
+- **Competitive Response**: eksctl may implement similar features
+  - *Mitigation*: Focus on superior UX and performance
+
+### Operational Risks
+- **AWS API Changes**: AWS may modify APIs this feature depends on
+  - *Mitigation*: Monitor AWS changelogs, implement adapter pattern
+
+- **Performance Degradation**: Feature may impact overall tool performance
+  - *Mitigation*: Continuous performance monitoring, optimization
+
+## Metrics & KPIs
+
+### Adoption Metrics
+- **Feature Usage**: Number of users executing feature commands
+- **Command Frequency**: Most/least used commands within feature
+- **User Retention**: Users who continue using feature after first try
+
+### Performance Metrics
+- **Response Time**: Average time for feature operations
+- **Success Rate**: Percentage of successful operations
+- **Error Rate**: Types and frequency of errors encountered
+
+### Quality Metrics
+- **Bug Reports**: Number and severity of reported issues
+- **User Satisfaction**: Survey ratings and feedback
+- **Documentation Usage**: Help page views and search queries
+
+### Business Metrics
+- **Overall Tool Adoption**: Impact on refresh tool growth
+- **User Testimonials**: Positive feedback and case studies
+- **Community Engagement**: GitHub stars, issues, discussions
+
+---
+
+*This template should be copied and customized for each new feature. Remove this note and template instructions when creating actual feature specifications.*

--- a/internal/commands/manpage.go
+++ b/internal/commands/manpage.go
@@ -1,0 +1,141 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+func ManPageCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "install-man",
+		Aliases: []string{"install-manpage"},
+		Usage:   "Install the man page for refresh",
+		Description: `Install the refresh man page for offline documentation access.
+		
+This command generates the man page from the CLI definition and installs it
+to a user-accessible directory ($HOME/.local/share/man/man1 by default).
+No sudo privileges required - works seamlessly across macOS, Linux, and Unix systems.`,
+		Action: installManPage,
+	}
+}
+
+func installManPage(c *cli.Context) error {
+	// Generate the man page content
+	app := c.App
+	manContent, err := app.ToMan()
+	if err != nil {
+		return fmt.Errorf("failed to generate man page: %w", err)
+	}
+
+	// Determine the man page installation directory
+	manDir := getManPageDir()
+	manPath := filepath.Join(manDir, "refresh.1")
+
+	// Verify we can write to the directory
+	if !isWritableDir(manDir) {
+		return fmt.Errorf("cannot write to directory %s: permission denied", manDir)
+	}
+
+	// Write the man page file
+	if err := os.WriteFile(manPath, []byte(manContent), 0644); err != nil {
+		return fmt.Errorf("failed to write man page to %s: %w", manPath, err)
+	}
+
+	// Success message with setup instructions
+	fmt.Printf("Man page installed successfully to: %s\n", manPath)
+
+	// Check if the directory is already in MANPATH
+	manParentDir := filepath.Dir(manDir) // Remove /man1 to get the base man directory
+	if !isInManPath(manParentDir) {
+		fmt.Printf("\nTo make the man page accessible, add the following to your shell profile:\n")
+		fmt.Printf("  export MANPATH=\"%s:$MANPATH\"\n", manParentDir)
+		fmt.Printf("\nOr run temporarily:\n")
+		fmt.Printf("  MANPATH=\"%s:$MANPATH\" man refresh\n", manParentDir)
+	} else {
+		fmt.Println("You can now use 'man refresh' to view the documentation.")
+	}
+
+	// Update man database if available
+	updateManDB()
+
+	return nil
+}
+
+func getManPageDir() string {
+	// Priority list of user-writable directories
+	homeDir := os.Getenv("HOME")
+	userDirs := []string{
+		filepath.Join(homeDir, ".local/share/man/man1"),
+		filepath.Join(homeDir, ".local/man/man1"),
+		filepath.Join(homeDir, "man/man1"),
+	}
+
+	// Check user directories first (writable without sudo)
+	for _, dir := range userDirs {
+		if isWritableDir(dir) {
+			return dir
+		}
+	}
+
+	// Default to the standard user-local directory
+	return filepath.Join(homeDir, ".local/share/man/man1")
+}
+
+func isWritableDir(dir string) bool {
+	// Create parent directories if they don't exist
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return false
+	}
+
+	// Test write permission by creating a temporary file
+	testFile := filepath.Join(dir, ".write_test")
+	file, err := os.Create(testFile)
+	if err != nil {
+		return false
+	}
+	_ = file.Close() // Ignore close error for test file
+	_ = os.Remove(testFile) // Ignore remove error for test file
+	return true
+}
+
+func isInManPath(dir string) bool {
+	// Get the current MANPATH
+	cmd := exec.Command("manpath")
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+
+	manpathStr := strings.TrimSpace(string(output))
+	paths := strings.Split(manpathStr, ":")
+
+	for _, path := range paths {
+		if strings.TrimSpace(path) == dir {
+			return true
+		}
+	}
+	return false
+}
+
+func updateManDB() {
+	switch runtime.GOOS {
+	case "darwin":
+		// On macOS, try to update the man database
+		if _, err := exec.LookPath("makewhatis"); err == nil {
+			cmd := exec.Command("makewhatis", "/usr/local/share/man")
+			_ = cmd.Run() // Ignore errors, this is optional
+		}
+	case "linux":
+		// On Linux, try to update the man database
+		if _, err := exec.LookPath("mandb"); err == nil {
+			cmd := exec.Command("mandb", "-q")
+			_ = cmd.Run() // Ignore errors, this is optional
+		}
+	}
+}

--- a/internal/commands/manpage_test.go
+++ b/internal/commands/manpage_test.go
@@ -35,17 +35,17 @@ func TestGetManPageDir(t *testing.T) {
 			originalHome := os.Getenv("HOME")
 			defer func() {
 				if originalHome != "" {
-					os.Setenv("HOME", originalHome)
+					_ = os.Setenv("HOME", originalHome)
 				} else {
-					os.Unsetenv("HOME")
+					_ = os.Unsetenv("HOME")
 				}
 			}()
 
 			// Set test HOME
 			if tt.homeEnv != "" {
-				os.Setenv("HOME", tt.homeEnv)
+				_ = os.Setenv("HOME", tt.homeEnv)
 			} else {
-				os.Unsetenv("HOME")
+				_ = os.Unsetenv("HOME")
 			}
 
 			result := getManPageDir()
@@ -60,7 +60,9 @@ func TestGetManPageDir(t *testing.T) {
 func TestIsWritableDir(t *testing.T) {
 	// Create a temporary directory for testing
 	tempDir := filepath.Join(os.TempDir(), "test_manpage_"+time.Now().Format("20060102_150405"))
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
 
 	tests := []struct {
 		name     string
@@ -103,7 +105,9 @@ func TestIsWritableDir(t *testing.T) {
 func TestIsWritableDirConcurrentSafe(t *testing.T) {
 	// Test that multiple concurrent calls don't interfere with each other
 	tempDir := filepath.Join(os.TempDir(), "test_concurrent_"+time.Now().Format("20060102_150405"))
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
 
 	// Create the directory first
 	if err := os.MkdirAll(tempDir, 0755); err != nil {
@@ -197,10 +201,12 @@ func TestManPageConstants(t *testing.T) {
 // BenchmarkIsWritableDir benchmarks the isWritableDir function
 func BenchmarkIsWritableDir(b *testing.B) {
 	tempDir := filepath.Join(os.TempDir(), "bench_manpage")
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
 	
 	// Create directory once
-	os.MkdirAll(tempDir, 0755)
+	_ = os.MkdirAll(tempDir, 0755)
 	
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/internal/commands/manpage_test.go
+++ b/internal/commands/manpage_test.go
@@ -1,0 +1,209 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetManPageDir(t *testing.T) {
+	tests := []struct {
+		name        string
+		homeEnv     string
+		expectDir   string
+		expectError bool
+	}{
+		{
+			name:        "Normal HOME directory",
+			homeEnv:     "/home/testuser",
+			expectDir:   "/home/testuser/.local/share/man/man1",
+			expectError: false,
+		},
+		{
+			name:        "Empty HOME directory",
+			homeEnv:     "",
+			expectDir:   ".local/share/man/man1",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original HOME
+			originalHome := os.Getenv("HOME")
+			defer func() {
+				if originalHome != "" {
+					os.Setenv("HOME", originalHome)
+				} else {
+					os.Unsetenv("HOME")
+				}
+			}()
+
+			// Set test HOME
+			if tt.homeEnv != "" {
+				os.Setenv("HOME", tt.homeEnv)
+			} else {
+				os.Unsetenv("HOME")
+			}
+
+			result := getManPageDir()
+
+			if result != tt.expectDir {
+				t.Errorf("getManPageDir() = %v, want %v", result, tt.expectDir)
+			}
+		})
+	}
+}
+
+func TestIsWritableDir(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := filepath.Join(os.TempDir(), "test_manpage_"+time.Now().Format("20060102_150405"))
+	defer os.RemoveAll(tempDir)
+
+	tests := []struct {
+		name     string
+		dir      string
+		setup    func(string) error
+		expected bool
+	}{
+		{
+			name: "Writable directory",
+			dir:  tempDir,
+			setup: func(dir string) error {
+				return os.MkdirAll(dir, 0755)
+			},
+			expected: true,
+		},
+		{
+			name: "Non-existent directory (should create)",
+			dir:  filepath.Join(tempDir, "new_dir"),
+			setup: func(dir string) error {
+				return nil // Don't create it
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.setup(tt.dir); err != nil {
+				t.Fatalf("Setup failed: %v", err)
+			}
+
+			result := isWritableDir(tt.dir)
+			if result != tt.expected {
+				t.Errorf("isWritableDir(%v) = %v, want %v", tt.dir, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsWritableDirConcurrentSafe(t *testing.T) {
+	// Test that multiple concurrent calls don't interfere with each other
+	tempDir := filepath.Join(os.TempDir(), "test_concurrent_"+time.Now().Format("20060102_150405"))
+	defer os.RemoveAll(tempDir)
+
+	// Create the directory first
+	if err := os.MkdirAll(tempDir, 0755); err != nil {
+		t.Fatalf("Failed to create test directory: %v", err)
+	}
+
+	// Run multiple concurrent tests
+	done := make(chan bool, 10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			result := isWritableDir(tempDir)
+			if !result {
+				t.Errorf("isWritableDir should return true for writable directory")
+			}
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines to complete
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+}
+
+func TestIsInManPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		dir         string
+		mockOutput  string
+		mockError   bool
+		expected    bool
+	}{
+		{
+			name:        "Directory in MANPATH",
+			dir:         "/usr/share/man",
+			mockOutput:  "/usr/share/man:/usr/local/share/man",
+			mockError:   false,
+			expected:    true,
+		},
+		{
+			name:        "Directory not in MANPATH",
+			dir:         "/home/user/.local/share/man",
+			mockOutput:  "/usr/share/man:/usr/local/share/man",
+			mockError:   false,
+			expected:    false,
+		},
+		{
+			name:        "Command fails",
+			dir:         "/usr/share/man",
+			mockOutput:  "",
+			mockError:   true,
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Note: This test is simplified since we can't easily mock exec.Command
+			// In a real-world scenario, you'd want to refactor isInManPath to accept
+			// a command runner interface for better testability
+			
+			// For now, we'll test the string processing logic
+			if !tt.mockError && tt.mockOutput != "" {
+				paths := strings.Split(strings.TrimSpace(tt.mockOutput), ":")
+				found := false
+				for _, path := range paths {
+					if strings.TrimSpace(path) == tt.dir {
+						found = true
+						break
+					}
+				}
+				if found != tt.expected {
+					t.Errorf("String processing logic failed: expected %v, got %v", tt.expected, found)
+				}
+			}
+		})
+	}
+}
+
+func TestManPageConstants(t *testing.T) {
+	// Test that constants are defined with expected values
+	if ManPageFileMode != 0644 {
+		t.Errorf("ManPageFileMode = %v, want %v", ManPageFileMode, 0644)
+	}
+	
+	if ManPageDirMode != 0755 {
+		t.Errorf("ManPageDirMode = %v, want %v", ManPageDirMode, 0755)
+	}
+}
+
+// BenchmarkIsWritableDir benchmarks the isWritableDir function
+func BenchmarkIsWritableDir(b *testing.B) {
+	tempDir := filepath.Join(os.TempDir(), "bench_manpage")
+	defer os.RemoveAll(tempDir)
+	
+	// Create directory once
+	os.MkdirAll(tempDir, 0755)
+	
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isWritableDir(tempDir)
+	}
+}

--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 var VersionInfo = types.VersionInfo{
-	Version:   "v0.1.8",
+	Version:   "v0.1.9",
 	Commit:    "",
 	BuildDate: "",
 }

--- a/internal/health/balance.go
+++ b/internal/health/balance.go
@@ -191,7 +191,6 @@ func (hc *HealthChecker) analyzeResourceDistribution(metrics []NodeMetrics) Reso
 	return analysis
 }
 
-
 // InstanceData represents an EC2 instance with its associated node name
 type InstanceData struct {
 	InstanceID string

--- a/internal/health/capacity.go
+++ b/internal/health/capacity.go
@@ -117,7 +117,6 @@ func (hc *HealthChecker) getEC2ClusterCPUMetrics(ctx context.Context, clusterNam
 	return allValues, nil
 }
 
-
 // calculateAverage calculates the average of a slice of float64 values
 func calculateAverage(values []float64) float64 {
 	if len(values) == 0 {
@@ -163,7 +162,7 @@ func (hc *HealthChecker) getClusterInstanceIDs(ctx context.Context, clusterName 
 				if asg.Name != nil {
 					asgInstanceIDs, err := hc.getASGInstanceIDs(ctx, *asg.Name)
 					if err != nil {
-						continue // Skip failed ASGs  
+						continue // Skip failed ASGs
 					}
 					instanceIDs = append(instanceIDs, asgInstanceIDs...)
 				}
@@ -173,7 +172,6 @@ func (hc *HealthChecker) getClusterInstanceIDs(ctx context.Context, clusterName 
 
 	return instanceIDs, nil
 }
-
 
 // getASGInstanceIDs retrieves instance IDs from an Auto Scaling Group
 func (hc *HealthChecker) getASGInstanceIDs(ctx context.Context, asgName string) ([]string, error) {

--- a/main.go
+++ b/main.go
@@ -13,6 +13,12 @@ import (
 	"github.com/dantech2000/refresh/internal/commands"
 )
 
+var (
+	// Compile regex patterns once at package initialization
+	sectionRegex = regexp.MustCompile(`(?m)^(NAME|USAGE|COMMANDS|GLOBAL OPTIONS|OPTIONS|DESCRIPTION|VERSION|COPYRIGHT):`)
+	commandRegex = regexp.MustCompile(`(?m)^(\s+)([a-zA-Z][a-zA-Z0-9-_]*(?:,\s*[a-zA-Z][a-zA-Z0-9-_]*)*)(\s+.*)$`)
+)
+
 func coloredHelpPrinter(w io.Writer, templ string, data interface{}) {
 	// First, render the template using the default printer to a buffer
 	var buf bytes.Buffer
@@ -26,13 +32,11 @@ func coloredHelpPrinter(w io.Writer, templ string, data interface{}) {
 	yellow := color.New(color.FgYellow)
 
 	// Apply colors to section headers
-	sectionRegex := regexp.MustCompile(`(?m)^(NAME|USAGE|COMMANDS|GLOBAL OPTIONS|OPTIONS|DESCRIPTION|VERSION|COPYRIGHT):`)
 	helpText = sectionRegex.ReplaceAllStringFunc(helpText, func(match string) string {
 		return cyan.Sprint(match)
 	})
 
 	// Color command names (looking for lines with command format)
-	commandRegex := regexp.MustCompile(`(?m)^(\s+)([a-zA-Z][a-zA-Z0-9-_]*(?:,\s*[a-zA-Z][a-zA-Z0-9-_]*)*)(\s+.*)$`)
 	helpText = commandRegex.ReplaceAllStringFunc(helpText, func(match string) string {
 		parts := commandRegex.FindStringSubmatch(match)
 		if len(parts) >= 4 {

--- a/main.go
+++ b/main.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"os"
+	"regexp"
 
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
@@ -9,7 +13,41 @@ import (
 	"github.com/dantech2000/refresh/internal/commands"
 )
 
+func coloredHelpPrinter(w io.Writer, templ string, data interface{}) {
+	// First, render the template using the default printer to a buffer
+	var buf bytes.Buffer
+	cli.HelpPrinterCustom(&buf, templ, data, nil)
+
+	// Get the rendered help text
+	helpText := buf.String()
+
+	// Define colors
+	cyan := color.New(color.FgCyan, color.Bold)
+	yellow := color.New(color.FgYellow)
+
+	// Apply colors to section headers
+	sectionRegex := regexp.MustCompile(`(?m)^(NAME|USAGE|COMMANDS|GLOBAL OPTIONS|OPTIONS|DESCRIPTION|VERSION|COPYRIGHT):`)
+	helpText = sectionRegex.ReplaceAllStringFunc(helpText, func(match string) string {
+		return cyan.Sprint(match)
+	})
+
+	// Color command names (looking for lines with command format)
+	commandRegex := regexp.MustCompile(`(?m)^(\s+)([a-zA-Z][a-zA-Z0-9-_]*(?:,\s*[a-zA-Z][a-zA-Z0-9-_]*)*)(\s+.*)$`)
+	helpText = commandRegex.ReplaceAllStringFunc(helpText, func(match string) string {
+		parts := commandRegex.FindStringSubmatch(match)
+		if len(parts) >= 4 {
+			return fmt.Sprintf("%s%s%s", parts[1], yellow.Sprint(parts[2]), parts[3])
+		}
+		return match
+	})
+
+	_, _ = fmt.Fprint(w, helpText)
+}
+
 func main() {
+	// Set custom help printer for colored output
+	cli.HelpPrinter = coloredHelpPrinter
+
 	app := &cli.App{
 		Name:  "refresh",
 		Usage: "Manage and monitor AWS EKS node groups",
@@ -17,8 +55,10 @@ func main() {
 			commands.ListCommand(),
 			commands.VersionCommand(),
 			commands.UpdateAmiCommand(),
+			commands.ManPageCommand(),
 		},
 	}
+
 	if err := app.Run(os.Args); err != nil {
 		color.Red("Error: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- Added `install-man` command for user-friendly man page installation without sudo requirements
- Implemented cross-platform support with smart directory selection and fallback hierarchy  
- Enhanced CLI with colored help output for better user experience
- Updated to version v0.1.9 with comprehensive changelog and documentation

## Test plan
- [ ] Test `refresh install-man` command on different platforms
- [ ] Verify `man refresh` works after installation
- [ ] Test colored help output in various terminals
- [ ] Validate version bump and changelog accuracy