### PR TITLE
ci: run tests in CI, upgrade golangci-lint to v2, bump Go to latest stable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "stable"
           cache: true
 
       - name: Run golangci-lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64
+          version: v2.12.2
           args: --timeout=5m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "stable"
           cache: true
 
       - name: Run GoReleaser

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "stable"
           cache: true
 
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+    branches: ["main", "master"]
+
+jobs:
+  test:
+    name: Run go test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: true
+
+      - name: Build
+        run: go build ./...
+
+      # NOTE: -race is intentionally omitted for now. main has a known data race
+      # in internal/ui (TestMultiProgressAndRegionTracker, via pterm's MultiPrinter).
+      # The fix that skips that test under -race lands with the thermo-nuclear
+      # refactor branch; switch this to `go test -race ./...` once that merges.
+      - name: Test
+        run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/dantech2000/refresh
 
-go 1.24.0
+go 1.26.0
 
-toolchain go1.24.5
+toolchain go1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.38.3


### PR DESCRIPTION
## Summary

Hardens the CI pipeline and removes Go-version drift across the repo. Three related changes, no production code touched.

### 1. Run tests in CI (new gap closed)
- Adds **`.github/workflows/test.yml`** running `go build ./...` + `go test ./...` on push/PR to `main`.
- Previously **lint was the only CI gate** — `go test` never ran on a PR or before a release.

### 2. Upgrade golangci-lint v1 → v2
- `lint.yml`: golangci-lint **`v1.64` (action@v6) → `v2.12.2` (action@v8)**, matching the version run locally.
- No `.golangci` config exists, so defaults apply both locally and in CI — **0 issues** on this branch.

### 3. Bump Go to latest stable everywhere
- `go.mod`: `go 1.24.0` / `toolchain go1.24.5` → **`go 1.26.0` / `toolchain go1.26.4`**.
- `lint`, `test`, `release` workflows: `go-version "1.24"` → **`"stable"`**, so CI tracks future Go releases without further edits.

## Verification
Verified locally under **go1.26.4**:
- `go build ./...` — clean
- `go test ./...` — all packages pass
- `golangci-lint run` (v2.12.2) — 0 issues

## Notes / follow-ups (not in this PR)
- **`-race` is intentionally deferred.** `main` has a real data race in `internal/ui` (`TestMultiProgressAndRegionTracker`, via pterm's `MultiPrinter`); `go test -race ./...` fails on `main` today. The fix that skips that test under `-race` lives on the separate thermo-nuclear refactor branch. A code comment in `test.yml` marks where to flip this to `-race` once that lands.
- **Auto-merge gating:** `auto-merge.yml` waits only on the `"Run golangci-lint"` check, not the new test job. To make tests actually gate Dependabot auto-merges, add the test job as a required status check via branch protection (cleaner than hard-coding another check name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
