### PR TITLE
fix: nil ScalingConfig panics and negative health scores

### DIFF
--- a/internal/health/balance.go
+++ b/internal/health/balance.go
@@ -42,18 +42,7 @@ func (hc *HealthChecker) CheckResourceBalance(ctx context.Context, clusterName s
 	maxVariance := analysis.CPUVariance
 	maxUtilization := analysis.MaxCPU
 
-	// Score based on both balance and peak utilization
-	balanceScore := 100.0
-	if maxVariance > 30 {
-		balanceScore -= (maxVariance - 30) * 2 // Penalize high variance
-	}
-
-	utilizationScore := 100.0
-	if maxUtilization > 85 {
-		utilizationScore -= (maxUtilization - 85) * 3 // Penalize high utilization
-	}
-
-	result.Score = int(math.Min(balanceScore, utilizationScore))
+	result.Score = computeBalanceScore(maxVariance, maxUtilization)
 
 	// Determine status based on CPU-only analysis
 	if maxUtilization > 90 {
@@ -75,6 +64,23 @@ func (hc *HealthChecker) CheckResourceBalance(ctx context.Context, clusterName s
 	}
 
 	return result
+}
+
+// computeBalanceScore scores CPU balance and peak utilization on a 0-100 scale.
+// The result is the worse of the two sub-scores, clamped so that extreme
+// variance or utilization cannot push the score below zero.
+func computeBalanceScore(maxVariance, maxUtilization float64) int {
+	balanceScore := 100.0
+	if maxVariance > 30 {
+		balanceScore -= (maxVariance - 30) * 2 // Penalize high variance
+	}
+
+	utilizationScore := 100.0
+	if maxUtilization > 85 {
+		utilizationScore -= (maxUtilization - 85) * 3 // Penalize high utilization
+	}
+
+	return int(math.Max(0, math.Min(balanceScore, utilizationScore)))
 }
 
 // NodeMetrics represents resource metrics for a single node

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -99,6 +99,39 @@ func TestAnalyzeResourceDistribution_HighVarianceDetected(t *testing.T) {
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
+// computeBalanceScore
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestComputeBalanceScore(t *testing.T) {
+	tests := []struct {
+		name           string
+		maxVariance    float64
+		maxUtilization float64
+		want           int
+	}{
+		{"healthy cluster scores 100", 10, 50, 100},
+		{"variance at threshold scores 100", 30, 85, 100},
+		{"moderate variance penalized", 40, 50, 80},   // 100 - (40-30)*2
+		{"high utilization penalized", 10, 95, 70},    // 100 - (95-85)*3
+		{"worse sub-score wins", 40, 95, 70},          // min(80, 70)
+		{"extreme variance clamps to 0", 100, 50, 0},  // would be -40 unclamped
+		{"max utilization clamps to 0", 10, 130, 0},   // would be -35 unclamped
+		{"both extreme clamps to 0", 100, 130, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeBalanceScore(tt.maxVariance, tt.maxUtilization)
+			if got != tt.want {
+				t.Errorf("computeBalanceScore(%v, %v) = %d, want %d", tt.maxVariance, tt.maxUtilization, got, tt.want)
+			}
+			if got < 0 || got > 100 {
+				t.Errorf("score %d outside [0,100]", got)
+			}
+		})
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
 // CheckCriticalWorkloads — nil k8sClient
 // ──────────────────────────────────────────────────────────────────────────────
 

--- a/internal/services/cluster/helpers.go
+++ b/internal/services/cluster/helpers.go
@@ -123,11 +123,17 @@ func (s *ServiceImpl) getClusterNodegroups(ctx context.Context, clusterName stri
 		}
 
 		ng := describeOutput.Nodegroup
-		readyNodes := int32(0)
+
+		// ScalingConfig is optional in the EKS API; never dereference it unchecked.
+		desiredSize := int32(0)
+		if ng.ScalingConfig != nil {
+			desiredSize = aws.ToInt32(ng.ScalingConfig.DesiredSize)
+		}
 
 		// Calculate ready nodes based on scaling config and status
-		if ng.ScalingConfig != nil && ng.Status == ekstypes.NodegroupStatusActive {
-			readyNodes = aws.ToInt32(ng.ScalingConfig.DesiredSize)
+		readyNodes := int32(0)
+		if ng.Status == ekstypes.NodegroupStatusActive {
+			readyNodes = desiredSize
 		}
 
 		instanceTypes := "Unknown"
@@ -139,7 +145,7 @@ func (s *ServiceImpl) getClusterNodegroups(ctx context.Context, clusterName stri
 			Name:         aws.ToString(ng.NodegroupName),
 			Status:       string(ng.Status),
 			InstanceType: instanceTypes,
-			DesiredSize:  aws.ToInt32(ng.ScalingConfig.DesiredSize),
+			DesiredSize:  desiredSize,
 			ReadyNodes:   readyNodes,
 		})
 	}

--- a/internal/services/cluster/service_test.go
+++ b/internal/services/cluster/service_test.go
@@ -48,6 +48,34 @@ func TestBuildListCacheKey_RegionOrderStable(t *testing.T) {
 	}
 }
 
+// Regression: the EKS API marks Nodegroup.scalingConfig as optional ("Required: No"),
+// so getClusterNodegroups must not panic when a nodegroup comes back without one.
+func TestGetClusterNodegroups_NilScalingConfig(t *testing.T) {
+	mock := &mocks.EKSAPI{
+		ListNodegroupsFn: func(_ context.Context, _ *eks.ListNodegroupsInput, _ ...func(*eks.Options)) (*eks.ListNodegroupsOutput, error) {
+			return &eks.ListNodegroupsOutput{Nodegroups: []string{"workers"}}, nil
+		},
+		DescribeNodegroupFn: func(_ context.Context, _ *eks.DescribeNodegroupInput, _ ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error) {
+			return &eks.DescribeNodegroupOutput{Nodegroup: &ekstypes.Nodegroup{
+				NodegroupName: aws.String("workers"),
+				Status:        ekstypes.NodegroupStatusActive,
+				ScalingConfig: nil,
+			}}, nil
+		},
+	}
+	svc := &ServiceImpl{eksClient: mock, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	nodegroups, err := svc.getClusterNodegroups(context.Background(), "my-cluster")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(nodegroups) != 1 {
+		t.Fatalf("expected 1 nodegroup, got %d", len(nodegroups))
+	}
+	if nodegroups[0].DesiredSize != 0 {
+		t.Errorf("DesiredSize = %d, want 0 for nil ScalingConfig", nodegroups[0].DesiredSize)
+	}
+}
+
 // Regression: ListAllRegionsWithMeta must narrow each per-region goroutine's
 // options.Regions to a single region. Without this, every goroutine computes
 // the same cache key (hashed from the parent's full region slice), the second

--- a/internal/services/nodegroup/service.go
+++ b/internal/services/nodegroup/service.go
@@ -121,9 +121,14 @@ func (s *ServiceImpl) List(ctx context.Context, clusterName string, options List
 			continue
 		}
 		ng := desc.Nodegroup
+		// ScalingConfig is optional in the EKS API; never dereference it unchecked.
+		desired := int32(0)
+		if ng.ScalingConfig != nil {
+			desired = aws.ToInt32(ng.ScalingConfig.DesiredSize)
+		}
 		ready := int32(0)
-		if ng.ScalingConfig != nil && ng.Status == ekstypes.NodegroupStatusActive {
-			ready = aws.ToInt32(ng.ScalingConfig.DesiredSize)
+		if ng.Status == ekstypes.NodegroupStatusActive {
+			ready = desired
 		}
 		instanceType := "Unknown"
 		if len(ng.InstanceTypes) > 0 {
@@ -138,7 +143,7 @@ func (s *ServiceImpl) List(ctx context.Context, clusterName string, options List
 			Name:         aws.ToString(ng.NodegroupName),
 			Status:       string(ng.Status),
 			InstanceType: instanceType,
-			DesiredSize:  aws.ToInt32(ng.ScalingConfig.DesiredSize),
+			DesiredSize:  desired,
 			ReadyNodes:   ready,
 			CurrentAMI:   currentAmiId,
 			AMIStatus:    amiStatus,
@@ -153,8 +158,7 @@ func (s *ServiceImpl) List(ctx context.Context, clusterName string, options List
 		}
 		if options.ShowCosts && s.cost != nil {
 			if _, perMonth, ok := s.cost.EstimateOnDemandUSD(ctx, instanceType); ok {
-				nodes := float64(aws.ToInt32(ng.ScalingConfig.DesiredSize))
-				summary.Cost = SummaryCost{Monthly: perMonth * nodes}
+				summary.Cost = SummaryCost{Monthly: perMonth * float64(desired)}
 			}
 		}
 		summaries = append(summaries, summary)
@@ -189,6 +193,14 @@ func (s *ServiceImpl) Describe(ctx context.Context, clusterName, nodegroupName s
 	latestAmiId := awsinternal.LatestAmiIDForType(ctx, s.ssmClient, k8sVersion, ng.AmiType)
 	amiStatus := classifyAMI(ng.Status, currentAmiId, latestAmiId)
 
+	// ScalingConfig is optional in the EKS API; never dereference it unchecked.
+	scaling := ScalingConfig{AutoScaling: ng.ScalingConfig != nil}
+	if ng.ScalingConfig != nil {
+		scaling.DesiredSize = aws.ToInt32(ng.ScalingConfig.DesiredSize)
+		scaling.MinSize = aws.ToInt32(ng.ScalingConfig.MinSize)
+		scaling.MaxSize = aws.ToInt32(ng.ScalingConfig.MaxSize)
+	}
+
 	details := &NodegroupDetails{
 		Name:         aws.ToString(ng.NodegroupName),
 		Status:       string(ng.Status),
@@ -198,12 +210,7 @@ func (s *ServiceImpl) Describe(ctx context.Context, clusterName, nodegroupName s
 		CurrentAMI:   currentAmiId,
 		LatestAMI:    latestAmiId,
 		AMIStatus:    amiStatus,
-		Scaling: ScalingConfig{
-			DesiredSize: aws.ToInt32(ng.ScalingConfig.DesiredSize),
-			MinSize:     aws.ToInt32(ng.ScalingConfig.MinSize),
-			MaxSize:     aws.ToInt32(ng.ScalingConfig.MaxSize),
-			AutoScaling: ng.ScalingConfig != nil,
-		},
+		Scaling: scaling,
 	}
 	if options.ShowUtilization && s.util != nil {
 		window := normalizeWindow(options.Timeframe)
@@ -215,7 +222,7 @@ func (s *ServiceImpl) Describe(ctx context.Context, clusterName, nodegroupName s
 	}
 	if options.ShowCosts && s.cost != nil {
 		if _, perMonth, ok := s.cost.EstimateOnDemandUSD(ctx, details.InstanceType); ok {
-			nodes := float64(aws.ToInt32(ng.ScalingConfig.DesiredSize))
+			nodes := float64(scaling.DesiredSize)
 			details.Cost = CostAnalysis{
 				CurrentMonthlyCost:   perMonth * nodes,
 				ProjectedMonthlyCost: perMonth * nodes,

--- a/internal/services/nodegroup/service_test.go
+++ b/internal/services/nodegroup/service_test.go
@@ -185,6 +185,36 @@ func TestList_AMIStatusUnknownWhenIDsEmpty(t *testing.T) {
 	}
 }
 
+// Regression: the EKS API marks Nodegroup.scalingConfig as optional ("Required: No"),
+// so a nodegroup can come back without one. List must not panic on it.
+func TestList_NilScalingConfig(t *testing.T) {
+	ng := stubNodegroup("workers", ekstypes.NodegroupStatusActive)
+	ng.ScalingConfig = nil
+	mock := &mocks.EKSAPI{
+		DescribeClusterFn: clusterFn("1.29"),
+		ListNodegroupsFn: func(_ context.Context, _ *eks.ListNodegroupsInput, _ ...func(*eks.Options)) (*eks.ListNodegroupsOutput, error) {
+			return &eks.ListNodegroupsOutput{Nodegroups: []string{"workers"}}, nil
+		},
+		DescribeNodegroupFn: func(_ context.Context, _ *eks.DescribeNodegroupInput, _ ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error) {
+			return &eks.DescribeNodegroupOutput{Nodegroup: ng}, nil
+		},
+	}
+	svc := newTestService(mock)
+	summaries, err := svc.List(context.Background(), "my-cluster", ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("expected 1 summary, got %d", len(summaries))
+	}
+	if summaries[0].DesiredSize != 0 {
+		t.Errorf("DesiredSize = %d, want 0 for nil ScalingConfig", summaries[0].DesiredSize)
+	}
+	if summaries[0].ReadyNodes != 0 {
+		t.Errorf("ReadyNodes = %d, want 0 for nil ScalingConfig", summaries[0].ReadyNodes)
+	}
+}
+
 func TestList_EmptyCluster(t *testing.T) {
 	mock := &mocks.EKSAPI{
 		DescribeClusterFn: clusterFn("1.29"),
@@ -230,6 +260,30 @@ func TestDescribe_ReturnsNodegroupDetails(t *testing.T) {
 	}
 	if details.InstanceType != "m5.large" {
 		t.Errorf("InstanceType = %q, want %q", details.InstanceType, "m5.large")
+	}
+}
+
+// Regression: Describe must not panic on a nodegroup without a ScalingConfig,
+// and AutoScaling must report false for it.
+func TestDescribe_NilScalingConfig(t *testing.T) {
+	ng := stubNodegroup("workers", ekstypes.NodegroupStatusActive)
+	ng.ScalingConfig = nil
+	mock := &mocks.EKSAPI{
+		DescribeClusterFn: clusterFn("1.29"),
+		DescribeNodegroupFn: func(_ context.Context, _ *eks.DescribeNodegroupInput, _ ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error) {
+			return &eks.DescribeNodegroupOutput{Nodegroup: ng}, nil
+		},
+	}
+	svc := newTestService(mock)
+	details, err := svc.Describe(context.Background(), "my-cluster", "workers", DescribeOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details.Scaling.DesiredSize != 0 || details.Scaling.MinSize != 0 || details.Scaling.MaxSize != 0 {
+		t.Errorf("Scaling = %+v, want zero values for nil ScalingConfig", details.Scaling)
+	}
+	if details.Scaling.AutoScaling {
+		t.Error("Scaling.AutoScaling = true, want false for nil ScalingConfig")
 	}
 }
 


### PR DESCRIPTION
## What

Two user-facing crash/correctness fixes found during a code-quality review.

### 1. Nil-pointer panics on `Nodegroup.ScalingConfig`

The [EKS API reference](https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html) marks `scalingConfig` as **Required: No** — a nodegroup can legitimately come back without one. Three code paths nil-checked it for one field and then dereferenced it unconditionally a few lines later:

- `internal/services/nodegroup/service.go` — `List()` (summary + cost calc) and `Describe()` (scaling block + cost calc)
- `internal/services/cluster/helpers.go` — `getClusterNodegroups()`

Any affected nodegroup crashed the CLI with a SIGSEGV. Fixed by hoisting nil-checked locals. This also fixes an ordering bug where `AutoScaling: ng.ScalingConfig != nil` was evaluated *after* the dereference — it could only ever be `true`.

### 2. Resource-balance health score went negative

`CheckResourceBalance` applied unbounded linear penalties: CPU variance of 100 scored **−40**, violating the documented 0–100 range. Extracted the math into a pure `computeBalanceScore` function and clamped to `[0, 100]`.

## Tests

- Regression tests reproduce both panics on the unfixed code (SIGSEGV at `service.go:141` / `helpers.go:142`), now pass
- Table-driven tests for `computeBalanceScore` covering thresholds, penalties, and clamping
- `go build`, `go vet`, `golangci-lint` (0 issues), `go test -race ./...` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
