### PR TITLE
refactor: propagate signal cancellation through command contexts

### DIFF
--- a/internal/commands/runner/runner.go
+++ b/internal/commands/runner/runner.go
@@ -52,14 +52,21 @@ func setupAWS(c *cli.Context, defaultTimeout time.Duration, check credentialChec
 	if timeout == 0 {
 		timeout = defaultTimeout
 	}
+	// Derive from the CLI's context (cancelled on Ctrl+C / SIGTERM by main) so
+	// signal handling propagates to in-flight AWS calls. c.Context is nil only
+	// for hand-constructed contexts in tests.
+	base := c.Context
+	if base == nil {
+		base = context.Background()
+	}
 	var (
 		ctx    context.Context
 		cancel context.CancelFunc
 	)
 	if timeout > 0 {
-		ctx, cancel = context.WithTimeout(context.Background(), timeout)
+		ctx, cancel = context.WithTimeout(base, timeout)
 	} else {
-		ctx, cancel = context.WithCancel(context.Background())
+		ctx, cancel = context.WithCancel(base)
 	}
 
 	cfg, err := awsconfig.Load(ctx, c)

--- a/internal/commands/runner/runner_test.go
+++ b/internal/commands/runner/runner_test.go
@@ -1,9 +1,12 @@
 package runner
 
 import (
+	"context"
 	"flag"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/urfave/cli/v2"
 )
 
@@ -27,6 +30,56 @@ func newTestContext(t *testing.T, args []string, flags map[string]string) *cli.C
 		t.Fatal(err)
 	}
 	return cli.NewContext(cli.NewApp(), set, nil)
+}
+
+// ── setupAWS context propagation ──────────────────────────────────────────────
+
+// Regression: setupAWS must derive its context from c.Context (cancelled on
+// Ctrl+C / SIGTERM by main) rather than context.Background(), so signal
+// cancellation propagates to in-flight AWS calls.
+func TestSetupAWS_DerivesFromCLIContext(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	set.Duration("timeout", time.Minute, "")
+	c := cli.NewContext(cli.NewApp(), set, nil)
+	c.Context = parent
+
+	var got context.Context
+	_, cancel, _, err := setupAWS(c, 0, func(ctx context.Context, _ aws.Config) error {
+		got = ctx
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("setupAWS() = %v", err)
+	}
+	defer cancel()
+
+	select {
+	case <-got.Done():
+		t.Fatal("context cancelled prematurely")
+	default:
+	}
+	cancelParent()
+	select {
+	case <-got.Done():
+		// parent cancellation propagated — correct
+	case <-time.After(time.Second):
+		t.Fatal("parent cancellation did not propagate to setupAWS context")
+	}
+}
+
+// setupAWS must tolerate a nil c.Context (hand-constructed contexts in tests).
+func TestSetupAWS_NilCLIContextFallsBack(t *testing.T) {
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	set.Duration("timeout", time.Minute, "")
+	c := cli.NewContext(cli.NewApp(), set, nil)
+	c.Context = nil
+
+	_, cancel, _, err := setupAWS(c, 0, func(context.Context, aws.Config) error { return nil })
+	if err != nil {
+		t.Fatalf("setupAWS() = %v", err)
+	}
+	cancel()
 }
 
 // ── PositionalSlot ────────────────────────────────────────────────────────────

--- a/internal/dryrun/dryrun.go
+++ b/internal/dryrun/dryrun.go
@@ -69,12 +69,12 @@ var (
 	newDryRunner = NewDryRunner
 )
 
-// NewDryRunner creates a new dry runner instance.
-func NewDryRunner(eksClient *eks.Client, clusterName string, force, quiet bool) (*DryRunner, error) {
+// NewDryRunner creates a new dry runner instance. It performs AWS lookups
+// (config load + cluster describe) using the caller's context.
+func NewDryRunner(ctx context.Context, eksClient *eks.Client, clusterName string, force, quiet bool) (*DryRunner, error) {
 	if eksClient == nil {
 		return nil, fmt.Errorf("eks client is required")
 	}
-	ctx := context.Background()
 
 	awsCfg, err := dryrunLoadAWSConfig(ctx)
 	if err != nil {
@@ -100,7 +100,7 @@ func NewDryRunner(eksClient *eks.Client, clusterName string, force, quiet bool) 
 
 // PerformDryRun shows what would be updated without making changes.
 func PerformDryRun(ctx context.Context, eksClient *eks.Client, clusterName string, selectedNodegroups []string, force bool, quiet bool) error {
-	runner, err := newDryRunner(eksClient, clusterName, force, quiet)
+	runner, err := newDryRunner(ctx, eksClient, clusterName, force, quiet)
 	if err != nil {
 		return err
 	}

--- a/internal/dryrun/dryrun_test.go
+++ b/internal/dryrun/dryrun_test.go
@@ -259,7 +259,7 @@ func TestAnalyzeNodegroupBranchesWithInjectedLookups(t *testing.T) {
 }
 
 func TestNewDryRunnerAndPerformDryRunErrorPaths(t *testing.T) {
-	if _, err := NewDryRunner(nil, "cluster", false, true); err == nil {
+	if _, err := NewDryRunner(context.Background(), nil, "cluster", false, true); err == nil {
 		t.Fatal("expected error for nil EKS client")
 	}
 	if err := PerformDryRun(context.Background(), nil, "cluster", []string{"ng"}, false, true); err == nil {
@@ -282,7 +282,7 @@ func TestNewDryRunnerSuccessAndErrorSeams(t *testing.T) {
 		return "1.30", nil
 	}
 
-	runner, err := NewDryRunner(eks.New(eks.Options{Region: "us-east-1"}), "cluster", true, true)
+	runner, err := NewDryRunner(context.Background(), eks.New(eks.Options{Region: "us-east-1"}), "cluster", true, true)
 	if err != nil {
 		t.Fatalf("NewDryRunner() = %v", err)
 	}
@@ -293,7 +293,7 @@ func TestNewDryRunnerSuccessAndErrorSeams(t *testing.T) {
 	dryrunLoadAWSConfig = func(context.Context) (aws.Config, error) {
 		return aws.Config{}, errors.New("load")
 	}
-	if _, err := NewDryRunner(eks.New(eks.Options{Region: "us-east-1"}), "cluster", false, false); err == nil {
+	if _, err := NewDryRunner(context.Background(), eks.New(eks.Options{Region: "us-east-1"}), "cluster", false, false); err == nil {
 		t.Fatal("expected load error")
 	}
 
@@ -303,7 +303,7 @@ func TestNewDryRunnerSuccessAndErrorSeams(t *testing.T) {
 	dryrunDescribeCluster = func(context.Context, *eks.Client, string) (string, error) {
 		return "", errors.New("describe")
 	}
-	if _, err := NewDryRunner(eks.New(eks.Options{Region: "us-east-1"}), "cluster", false, false); err == nil {
+	if _, err := NewDryRunner(context.Background(), eks.New(eks.Options{Region: "us-east-1"}), "cluster", false, false); err == nil {
 		t.Fatal("expected describe error")
 	}
 }
@@ -312,7 +312,7 @@ func TestPerformDryRunSuccessWithInjectedRunner(t *testing.T) {
 	oldNew := newDryRunner
 	t.Cleanup(func() { newDryRunner = oldNew })
 
-	newDryRunner = func(*eks.Client, string, bool, bool) (*DryRunner, error) {
+	newDryRunner = func(context.Context, *eks.Client, string, bool, bool) (*DryRunner, error) {
 		return &DryRunner{
 			clusterName: "cluster",
 			quiet:       true,

--- a/internal/monitoring/monitor.go
+++ b/internal/monitoring/monitor.go
@@ -4,6 +4,7 @@ package monitoring
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -67,6 +68,12 @@ func MonitorUpdates(ctx context.Context, eksClient *eks.Client, monitor *refresh
 			return handleUserCancellation(monitor, config)
 
 		case <-monitorCtx.Done():
+			// The parent context is cancelled by main on Ctrl+C / SIGTERM, which
+			// races with sigChan above — treat plain cancellation as the user
+			// stopping, and only a deadline as a timeout.
+			if errors.Is(monitorCtx.Err(), context.Canceled) {
+				return handleUserCancellation(monitor, config)
+			}
 			return handleTimeout(config)
 
 		case <-ticker.C:

--- a/main.go
+++ b/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"regexp"
+	"syscall"
 
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
@@ -90,7 +93,7 @@ func newApp() *cli.App {
 	}
 }
 
-func run(args []string, out, errOut io.Writer) error {
+func run(ctx context.Context, args []string, out, errOut io.Writer) error {
 	// Set custom help printer for colored output
 	cli.HelpPrinter = coloredHelpPrinter
 
@@ -102,11 +105,16 @@ func run(args []string, out, errOut io.Writer) error {
 	app := newApp()
 	app.Writer = out
 	app.ErrWriter = errOut
-	return app.Run(args)
+	return app.RunContext(ctx, args)
 }
 
 func main() {
-	if err := run(os.Args, os.Stdout, os.Stderr); err != nil {
+	// Cancel the root context on Ctrl+C / SIGTERM so in-flight AWS calls are
+	// aborted instead of running to their timeout.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx, os.Args, os.Stdout, os.Stderr); err != nil {
 		color.Red("Error: %v", err)
 		exitProcess(1)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -222,7 +223,7 @@ func TestNewAppAndRun(t *testing.T) {
 	}
 
 	var out, errOut bytes.Buffer
-	if err := run([]string{"refresh", "version"}, &out, &errOut); err != nil {
+	if err := run(context.Background(), []string{"refresh", "version"}, &out, &errOut); err != nil {
 		t.Fatalf("run version: %v", err)
 	}
 	if !strings.Contains(out.String(), "refresh version:") {
@@ -231,7 +232,7 @@ func TestNewAppAndRun(t *testing.T) {
 
 	// The global --version flag must produce the same output as the subcommand.
 	out.Reset()
-	if err := run([]string{"refresh", "--version"}, &out, &errOut); err != nil {
+	if err := run(context.Background(), []string{"refresh", "--version"}, &out, &errOut); err != nil {
 		t.Fatalf("run --version: %v", err)
 	}
 	if !strings.Contains(out.String(), "refresh version:") {
@@ -239,7 +240,7 @@ func TestNewAppAndRun(t *testing.T) {
 	}
 
 	out.Reset()
-	if err := run([]string{"refresh", "--timeout", "not-a-duration", "version"}, &out, &errOut); err == nil {
+	if err := run(context.Background(), []string{"refresh", "--timeout", "not-a-duration", "version"}, &out, &errOut); err == nil {
 		t.Fatal("expected invalid flag error")
 	}
 }


### PR DESCRIPTION
## What

Context & signal plumbing fixes from the code-quality review. Before this PR, Ctrl+C killed the process via the default signal handler without cancelling in-flight AWS calls.

- **main.go**: install `signal.NotifyContext` (SIGINT/SIGTERM) and run the app via `RunContext`, so every command handler receives a cancellable `c.Context`
- **runner.setupAWS**: derive the command context from `c.Context` instead of `context.Background()` — signal cancellation now propagates to all AWS SDK calls (nil-Context fallback kept for hand-constructed test contexts)
- **dryrun.NewDryRunner**: accept the caller's context instead of doing AWS I/O off `context.Background()` inside a constructor; `PerformDryRun` already had the context to pass
- **monitoring**: Ctrl+C now also cancels the monitor's parent context, racing with its own `sigChan` handler. Treat `context.Canceled` as user cancellation so the friendly "monitoring cancelled, updates continue in AWS" message wins over a misleading "timeout reached"

## Tests

- New `TestSetupAWS_DerivesFromCLIContext` asserts parent-cancellation propagation (fails on the old code, which derived from `Background()`)
- New `TestSetupAWS_NilCLIContextFallsBack` covers the test-context fallback
- dryrun seam tests updated for the new signature
- `go build`, `go vet`, `golangci-lint` (0 issues), `go test -race ./...` all green

Note: end-to-end Ctrl-C-aborts-AWS-call behavior is unit-tested at the wiring level; a manual check with real credentials (`refresh cluster list` + Ctrl-C) is a good extra validation before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
