### PR TITLE
refactor: enforce ProgressMonitor locking and remove unstoppable cache goroutine

### DIFF
--- a/internal/commands/nodegroup/actions.go
+++ b/internal/commands/nodegroup/actions.go
@@ -233,12 +233,9 @@ func runUpdateAMI(c *cli.Context) error {
 		return nil
 	}
 
-	monitor := &refreshTypes.ProgressMonitor{
-		Updates:   updates,
-		StartTime: time.Now(),
-		Quiet:     flags.quiet,
-		NoWait:    flags.noWait,
-		Timeout:   flags.timeout,
+	monitor := refreshTypes.NewProgressMonitor(flags.quiet, flags.noWait, flags.timeout)
+	for _, update := range updates {
+		monitor.AddUpdate(update)
 	}
 	config := refreshTypes.MonitorConfig{
 		PollInterval:    flags.pollInterval,

--- a/internal/monitoring/display.go
+++ b/internal/monitoring/display.go
@@ -27,11 +27,11 @@ func DisplayProgressUpdate(monitor *refreshTypes.ProgressMonitor) {
 	lineCount++
 
 	// Print cluster name as root (get from first update)
-	if len(monitor.Updates) > 0 {
-		fmt.Printf("%s\n", color.CyanString(monitor.Updates[0].ClusterName))
+	if updates := monitor.GetUpdates(); len(updates) > 0 {
+		fmt.Printf("%s\n", color.CyanString(updates[0].ClusterName))
 		lineCount++
 
-		additionalLines := printUpdateProgressTree(monitor.Updates)
+		additionalLines := printUpdateProgressTree(updates)
 		lineCount += additionalLines
 	}
 
@@ -90,6 +90,7 @@ func printUpdateProgressTree(updates []refreshTypes.UpdateProgress) int {
 
 // DisplayCompletionSummary shows the final summary when all updates are complete in tree format
 func DisplayCompletionSummary(monitor *refreshTypes.ProgressMonitor, config refreshTypes.MonitorConfig) error {
+	updates := monitor.GetUpdates()
 	if !config.Quiet {
 		// Clear previous progress output if any was printed
 		if monitor.LastPrinted > 0 {
@@ -103,15 +104,15 @@ func DisplayCompletionSummary(monitor *refreshTypes.ProgressMonitor, config refr
 		fmt.Printf("\nAll updates completed in %v\n\n", totalDuration.Round(time.Second))
 
 		// Print cluster name as root
-		if len(monitor.Updates) > 0 {
-			fmt.Printf("%s\n", color.CyanString(monitor.Updates[0].ClusterName))
-			printCompletionSummaryTree(monitor.Updates)
+		if len(updates) > 0 {
+			fmt.Printf("%s\n", color.CyanString(updates[0].ClusterName))
+			printCompletionSummaryTree(updates)
 		}
 
 		// Print results summary
 		successful := 0
 		failed := 0
-		for _, update := range monitor.Updates {
+		for _, update := range updates {
 			switch update.Status {
 			case types.UpdateStatusSuccessful:
 				successful++
@@ -126,7 +127,7 @@ func DisplayCompletionSummary(monitor *refreshTypes.ProgressMonitor, config refr
 	}
 
 	// Return error if any updates failed
-	for _, update := range monitor.Updates {
+	for _, update := range updates {
 		if update.Status == types.UpdateStatusFailed {
 			return fmt.Errorf("one or more nodegroup updates failed")
 		}

--- a/internal/monitoring/monitor.go
+++ b/internal/monitoring/monitor.go
@@ -87,16 +87,16 @@ func MonitorUpdates(ctx context.Context, eksClient *eks.Client, monitor *refresh
 
 // printMonitoringHeader displays initial monitoring information.
 func printMonitoringHeader(monitor *refreshTypes.ProgressMonitor, config refreshTypes.MonitorConfig) {
-	fmt.Printf("\nMonitoring %d nodegroup update(s)...\n", len(monitor.Updates))
+	fmt.Printf("\nMonitoring %d nodegroup update(s)...\n", monitor.Len())
 	fmt.Printf("Timeout: %v | Poll interval: %v\n", config.Timeout, config.PollInterval)
 	fmt.Printf("Press Ctrl+C to stop monitoring (updates will continue)\n\n")
 }
 
 // handleUserCancellation handles graceful cancellation by user signal.
 func handleUserCancellation(monitor *refreshTypes.ProgressMonitor, config refreshTypes.MonitorConfig) error {
-	if !config.Quiet && len(monitor.Updates) > 0 {
+	if updates := monitor.GetUpdates(); !config.Quiet && len(updates) > 0 {
 		color.Yellow("\nMonitoring cancelled by user. Updates are still running in AWS.")
-		fmt.Printf("Use 'refresh list --cluster %s' to check status manually.\n", monitor.Updates[0].ClusterName)
+		fmt.Printf("Use 'refresh list --cluster %s' to check status manually.\n", updates[0].ClusterName)
 	}
 	return nil
 }
@@ -112,23 +112,25 @@ func handleTimeout(config refreshTypes.MonitorConfig) error {
 
 // checkAllUpdatesWithChannels checks all update statuses concurrently using channels.
 func checkAllUpdatesWithChannels(ctx context.Context, eksClient *eks.Client, monitor *refreshTypes.ProgressMonitor, config refreshTypes.MonitorConfig) (bool, error) {
+	// Work from a locked snapshot; results are written back through the
+	// monitor's locked setters keyed by index.
+	updates := monitor.GetUpdates()
+
 	// Create buffered channel for results
-	resultsChan := make(chan statusResult, len(monitor.Updates))
+	resultsChan := make(chan statusResult, len(updates))
 
 	// Use wait group to track goroutines
 	var wg sync.WaitGroup
 
 	// Launch concurrent status checks
-	for i := range monitor.Updates {
-		update := &monitor.Updates[i]
-
+	for i, update := range updates {
 		// Skip completed updates
 		if isUpdateComplete(update.Status) {
 			continue
 		}
 
 		wg.Add(1)
-		go func(idx int, u *refreshTypes.UpdateProgress) {
+		go func(idx int, u refreshTypes.UpdateProgress) {
 			defer wg.Done()
 			result := checkSingleUpdate(ctx, eksClient, u, config)
 			result.index = idx
@@ -144,32 +146,14 @@ func checkAllUpdatesWithChannels(ctx context.Context, eksClient *eks.Client, mon
 
 	// Collect results
 	now := time.Now()
-	allComplete := true
-
 	for result := range resultsChan {
-		update := &monitor.Updates[result.index]
-
 		if result.err != nil {
-			update.ErrorMessage = result.err.Error()
-			allComplete = false
+			// Keep the last known status; an incomplete update stays incomplete,
+			// so AllComplete below remains false.
+			monitor.SetErrorByIndex(result.index, result.err.Error())
 			continue
 		}
-
-		update.Status = result.status
-		update.LastChecked = now
-		update.ErrorMessage = result.errMsg
-
-		if !isUpdateComplete(update.Status) {
-			allComplete = false
-		}
-	}
-
-	// Also check updates that were skipped (already complete)
-	for _, update := range monitor.Updates {
-		if !isUpdateComplete(update.Status) {
-			allComplete = false
-			break
-		}
+		monitor.SetResultByIndex(result.index, result.status, result.errMsg, now)
 	}
 
 	// Display current status
@@ -177,11 +161,11 @@ func checkAllUpdatesWithChannels(ctx context.Context, eksClient *eks.Client, mon
 		DisplayProgressUpdate(monitor)
 	}
 
-	return allComplete && len(monitor.Updates) > 0, nil
+	return monitor.AllComplete(), nil
 }
 
 // checkSingleUpdate checks the status of a single update with retry logic.
-func checkSingleUpdate(ctx context.Context, eksClient *eks.Client, update *refreshTypes.UpdateProgress, config refreshTypes.MonitorConfig) statusResult {
+func checkSingleUpdate(ctx context.Context, eksClient *eks.Client, update refreshTypes.UpdateProgress, config refreshTypes.MonitorConfig) statusResult {
 	result := statusResult{}
 
 	updateStatus, err := checkUpdateWithRetry(ctx, eksClient, update, config)
@@ -214,7 +198,7 @@ func isUpdateComplete(status types.UpdateStatus) bool {
 }
 
 // checkUpdateWithRetry checks update status with exponential backoff retry.
-func checkUpdateWithRetry(ctx context.Context, eksClient *eks.Client, update *refreshTypes.UpdateProgress, config refreshTypes.MonitorConfig) (*eks.DescribeUpdateOutput, error) {
+func checkUpdateWithRetry(ctx context.Context, eksClient *eks.Client, update refreshTypes.UpdateProgress, config refreshTypes.MonitorConfig) (*eks.DescribeUpdateOutput, error) {
 	var lastErr error
 	backoff := time.Second
 

--- a/internal/monitoring/monitor_test.go
+++ b/internal/monitoring/monitor_test.go
@@ -217,7 +217,7 @@ func TestDisplayCompletionSummary_EmptyMonitorReturnsNil(t *testing.T) {
 
 func TestCheckUpdateWithRetrySuccessAndErrors(t *testing.T) {
 	cfg := refreshTypes.MonitorConfig{MaxRetries: 2, BackoffMultiple: 1}
-	update := &refreshTypes.UpdateProgress{ClusterName: "cluster", NodegroupName: "ng", UpdateID: "upd-a"}
+	update := refreshTypes.UpdateProgress{ClusterName: "cluster", NodegroupName: "ng", UpdateID: "upd-a"}
 
 	out, err := checkUpdateWithRetry(context.Background(), fakeEKSDescribeUpdate(ekstypes.UpdateStatusSuccessful, ""), update, cfg)
 	if err != nil {
@@ -242,7 +242,7 @@ func TestCheckUpdateWithRetrySuccessAndErrors(t *testing.T) {
 
 func TestCheckSingleUpdateAndAllUpdates(t *testing.T) {
 	cfg := refreshTypes.MonitorConfig{Quiet: true, MaxRetries: 1, BackoffMultiple: 1}
-	update := &refreshTypes.UpdateProgress{ClusterName: "cluster", NodegroupName: "ng", UpdateID: "upd-a"}
+	update := refreshTypes.UpdateProgress{ClusterName: "cluster", NodegroupName: "ng", UpdateID: "upd-a"}
 
 	result := checkSingleUpdate(context.Background(), fakeEKSDescribeUpdate(ekstypes.UpdateStatusFailed, "boom"), update, cfg)
 	if result.status != ekstypes.UpdateStatusFailed {
@@ -262,8 +262,8 @@ func TestCheckSingleUpdateAndAllUpdates(t *testing.T) {
 	if err != nil || !allComplete {
 		t.Fatalf("checkAllUpdatesWithChannels = %v, %v", allComplete, err)
 	}
-	if monitor.Updates[0].Status != ekstypes.UpdateStatusSuccessful {
-		t.Fatalf("monitor update not updated: %+v", monitor.Updates[0])
+	if got := monitor.GetUpdates()[0]; got.Status != ekstypes.UpdateStatusSuccessful {
+		t.Fatalf("monitor update not updated: %+v", got)
 	}
 
 	empty := refreshTypes.NewProgressMonitor(true, false, 0)

--- a/internal/services/cluster/cache.go
+++ b/internal/services/cluster/cache.go
@@ -18,17 +18,13 @@ type Cache struct {
 	defaultTTL time.Duration
 }
 
-// NewCache creates a new cache instance
+// NewCache creates a new cache instance. Expired entries are evicted
+// opportunistically on Set; there is no background goroutine to manage.
 func NewCache(defaultTTL time.Duration) *Cache {
-	cache := &Cache{
+	return &Cache{
 		items:      make(map[string]CacheItem),
 		defaultTTL: defaultTTL,
 	}
-
-	// Start cleanup goroutine
-	go cache.cleanup()
-
-	return cache
 }
 
 // Get retrieves a value from the cache
@@ -50,14 +46,24 @@ func (c *Cache) Get(key string) (any, bool) {
 	return item.Value, true
 }
 
-// Set stores a value in the cache with specified TTL
+// Set stores a value in the cache with specified TTL. It also evicts any
+// expired entries while holding the write lock — the cache holds at most a
+// handful of keys in this short-lived CLI, so the sweep is cheap and replaces
+// the previous background cleanup goroutine (which could never be stopped).
 func (c *Cache) Set(key string, value any, ttl time.Duration) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
+	now := time.Now()
+	for k, item := range c.items {
+		if now.After(item.ExpiresAt) {
+			delete(c.items, k)
+		}
+	}
+
 	c.items[key] = CacheItem{
 		Value:     value,
-		ExpiresAt: time.Now().Add(ttl),
+		ExpiresAt: now.Add(ttl),
 	}
 }
 
@@ -80,23 +86,6 @@ func (c *Cache) Clear() {
 	defer c.mutex.Unlock()
 
 	c.items = make(map[string]CacheItem)
-}
-
-// cleanup periodically removes expired items
-func (c *Cache) cleanup() {
-	ticker := time.NewTicker(time.Minute)
-	defer ticker.Stop()
-
-	for range ticker.C {
-		c.mutex.Lock()
-		now := time.Now()
-		for key, item := range c.items {
-			if now.After(item.ExpiresAt) {
-				delete(c.items, key)
-			}
-		}
-		c.mutex.Unlock()
-	}
 }
 
 // Stats returns cache statistics

--- a/internal/services/cluster/cache_test.go
+++ b/internal/services/cluster/cache_test.go
@@ -68,6 +68,23 @@ func TestCache_Clear(t *testing.T) {
 	}
 }
 
+// Set must evict expired entries (this replaced the background cleanup
+// goroutine, which could never be stopped and leaked per cache instance).
+func TestCache_Set_EvictsExpiredEntries(t *testing.T) {
+	c := NewCache(time.Minute)
+	c.Set("stale", 1, time.Nanosecond)
+	time.Sleep(time.Millisecond)
+	c.Set("fresh", 2, time.Minute)
+
+	stats := c.Stats()
+	if stats["total"] != 1 {
+		t.Errorf("total = %v, want 1 (stale entry should be evicted by Set)", stats["total"])
+	}
+	if _, ok := c.Get("fresh"); !ok {
+		t.Error("fresh entry should still be retrievable")
+	}
+}
+
 func TestCache_Stats_Active(t *testing.T) {
 	c := NewCache(time.Minute)
 	c.Set("a", 1, time.Minute)

--- a/internal/types/monitoring.go
+++ b/internal/types/monitoring.go
@@ -39,10 +39,11 @@ func (u UpdateProgress) Duration() time.Duration {
 }
 
 // ProgressMonitor manages the monitoring of multiple concurrent nodegroup updates.
-// It is thread-safe through the use of sync.RWMutex.
+// It is thread-safe: the update list is unexported and all access goes through
+// the locked accessors below.
 type ProgressMonitor struct {
 	mu          sync.RWMutex
-	Updates     []UpdateProgress
+	updates     []UpdateProgress
 	StartTime   time.Time
 	Quiet       bool
 	NoWait      bool
@@ -53,7 +54,7 @@ type ProgressMonitor struct {
 // NewProgressMonitor creates a new progress monitor with the specified configuration.
 func NewProgressMonitor(quiet, noWait bool, timeout time.Duration) *ProgressMonitor {
 	return &ProgressMonitor{
-		Updates:   make([]UpdateProgress, 0),
+		updates:   make([]UpdateProgress, 0),
 		StartTime: time.Now(),
 		Quiet:     quiet,
 		NoWait:    noWait,
@@ -65,42 +66,73 @@ func NewProgressMonitor(quiet, noWait bool, timeout time.Duration) *ProgressMoni
 func (pm *ProgressMonitor) AddUpdate(update UpdateProgress) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
-	pm.Updates = append(pm.Updates, update)
+	pm.updates = append(pm.updates, update)
 }
 
 // GetUpdates returns a copy of all updates being monitored.
 func (pm *ProgressMonitor) GetUpdates() []UpdateProgress {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
-	updates := make([]UpdateProgress, len(pm.Updates))
-	copy(updates, pm.Updates)
+	updates := make([]UpdateProgress, len(pm.updates))
+	copy(updates, pm.updates)
 	return updates
+}
+
+// Len returns the number of updates being monitored.
+func (pm *ProgressMonitor) Len() int {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	return len(pm.updates)
 }
 
 // UpdateStatus updates the status of a specific nodegroup update.
 func (pm *ProgressMonitor) UpdateStatus(nodegroupName string, status types.UpdateStatus, errorMsg string) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
-	for i := range pm.Updates {
-		if pm.Updates[i].NodegroupName == nodegroupName {
-			pm.Updates[i].Status = status
-			pm.Updates[i].LastChecked = time.Now()
-			pm.Updates[i].ErrorMessage = errorMsg
+	for i := range pm.updates {
+		if pm.updates[i].NodegroupName == nodegroupName {
+			pm.updates[i].Status = status
+			pm.updates[i].LastChecked = time.Now()
+			pm.updates[i].ErrorMessage = errorMsg
 			return
 		}
 	}
+}
+
+// SetResultByIndex records the result of a status check for the update at idx.
+// Out-of-range indices are ignored.
+func (pm *ProgressMonitor) SetResultByIndex(idx int, status types.UpdateStatus, errorMsg string, checkedAt time.Time) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	if idx < 0 || idx >= len(pm.updates) {
+		return
+	}
+	pm.updates[idx].Status = status
+	pm.updates[idx].LastChecked = checkedAt
+	pm.updates[idx].ErrorMessage = errorMsg
+}
+
+// SetErrorByIndex records a failed status check for the update at idx without
+// touching its last known status. Out-of-range indices are ignored.
+func (pm *ProgressMonitor) SetErrorByIndex(idx int, errorMsg string) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	if idx < 0 || idx >= len(pm.updates) {
+		return
+	}
+	pm.updates[idx].ErrorMessage = errorMsg
 }
 
 // AllComplete returns true if all updates have finished.
 func (pm *ProgressMonitor) AllComplete() bool {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
-	for _, update := range pm.Updates {
+	for _, update := range pm.updates {
 		if !update.IsComplete() {
 			return false
 		}
 	}
-	return len(pm.Updates) > 0
+	return len(pm.updates) > 0
 }
 
 // SuccessCount returns the number of successful updates.
@@ -108,7 +140,7 @@ func (pm *ProgressMonitor) SuccessCount() int {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
 	count := 0
-	for _, update := range pm.Updates {
+	for _, update := range pm.updates {
 		if update.IsSuccessful() {
 			count++
 		}
@@ -121,7 +153,7 @@ func (pm *ProgressMonitor) FailureCount() int {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
 	count := 0
-	for _, update := range pm.Updates {
+	for _, update := range pm.updates {
 		if update.Status == types.UpdateStatusFailed || update.Status == types.UpdateStatusCancelled {
 			count++
 		}

--- a/internal/types/monitoring_test.go
+++ b/internal/types/monitoring_test.go
@@ -95,7 +95,7 @@ func TestNewProgressMonitor_Fields(t *testing.T) {
 	if pm.Timeout != 10*time.Minute {
 		t.Errorf("Timeout = %v, want 10m", pm.Timeout)
 	}
-	if len(pm.Updates) != 0 {
+	if pm.Len() != 0 {
 		t.Error("Updates should be empty initially")
 	}
 }


### PR DESCRIPTION
## What

Concurrency hygiene fixes from the code-quality review.

### 1. `ProgressMonitor`: make the documented thread-safety real

`internal/types/monitoring.go` documents the type as "thread-safe through the use of sync.RWMutex" — but every production access bypassed the mutex. `monitor.go` and `display.go` indexed the exported `Updates` slice directly across goroutine boundaries; the locked accessors were used only by tests. Today's call pattern happened to be safe, but it was one refactor away from a data race.

- Unexport `Updates` → all access now goes through locked methods
- New accessors: `Len()`, `SetResultByIndex(...)`, `SetErrorByIndex(...)` (plus existing `GetUpdates()` snapshot)
- The status-check fan-out works from a snapshot and writes back through setters; `checkSingleUpdate`/`checkUpdateWithRetry` take the update by value
- Manual `allComplete` bookkeeping replaced by the already-locked `monitor.AllComplete()` (behavior-equivalent: a check error keeps the previous incomplete status, so `AllComplete()` stays false)

### 2. `cluster.Cache`: remove the unstoppable cleanup goroutine

`NewCache()` spawned a `for range ticker.C` goroutine with no stop channel — one permanently leaked goroutine per cache instance. Replaced with opportunistic eviction of expired entries inside `Set` while the write lock is already held. The cache holds at most a handful of keys in this short-lived CLI, so the sweep is cheap, and there is no lifecycle to manage at all.

## Tests

- New `TestCache_Set_EvictsExpiredEntries` regression test
- Existing monitoring/types tests migrated to the accessors
- `go build`, `go vet`, `golangci-lint` (0 issues), `go test -race ./...` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
