### PR TITLE
chore: error wrapping, named constants, and redundant init() cleanup

### DIFF
--- a/internal/aws/errors.go
+++ b/internal/aws/errors.go
@@ -156,7 +156,7 @@ func FormatAWSError(err error, operation string) error {
 	}
 
 	// Default case - return the error with context
-	return fmt.Errorf("error while %s: %v", operation, err)
+	return fmt.Errorf("error while %s: %w", operation, err)
 }
 
 func formatRegionError(err error, operation string) error {
@@ -169,7 +169,7 @@ Please verify:
 
 Current error indicates an invalid or unsupported region.
 
-Current error: %v`, operation, err)
+Current error: %w`, operation, err)
 }
 
 func formatCredentialError(err error) error {
@@ -190,7 +190,7 @@ Please set up your AWS credentials using one of these methods:
 4. AWS SSO:
    aws sso login
 
-Current error: %s`, err)
+Current error: %w`, err)
 }
 
 func formatNetworkError(err error, operation string) error {
@@ -202,7 +202,7 @@ Please check:
 - VPC/Security group settings (if running in private network)
 - Regional service availability
 
-Current error: %v`, operation, err)
+Current error: %w`, operation, err)
 }
 
 func formatPermissionError(err error, operation string) error {
@@ -216,13 +216,17 @@ Required permissions for refresh tool:
 - eks:UpdateNodegroupVersion
 - cloudwatch:GetMetricStatistics (for health checks)
 
-Current error: %v`, operation, err)
+Current error: %w`, operation, err)
 }
+
+// credentialValidationTimeout bounds the STS GetCallerIdentity call used to
+// validate credentials, so a misconfigured environment fails fast.
+const credentialValidationTimeout = 10 * time.Second
 
 // ValidateAWSCredentials performs a basic validation of AWS credentials.
 func ValidateAWSCredentials(ctx context.Context, awsCfg aws.Config) error {
 	// Create a short timeout context for validation
-	validationCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	validationCtx, cancel := context.WithTimeout(ctx, credentialValidationTimeout)
 	defer cancel()
 
 	stsClient := sts.NewFromConfig(awsCfg)

--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -18,18 +18,14 @@ var (
 	buildDate = ""    // overridden by GoReleaser: -X ...commands.buildDate={{.Date}}
 )
 
-// VersionInfo provides access to version information
+// VersionInfo provides access to version information. ldflags -X values are
+// applied at link time, so this package-level initializer (which runs after
+// version/commit/buildDate in dependency order) already sees them — no init()
+// re-assignment is needed.
 var VersionInfo = types.VersionInfo{
 	Version:   version,
 	Commit:    commit,
 	BuildDate: buildDate,
-}
-
-func init() {
-	// Update VersionInfo with ldflags values (they're set before init runs)
-	VersionInfo.Version = version
-	VersionInfo.Commit = commit
-	VersionInfo.BuildDate = buildDate
 }
 
 // PrintVersion writes the CLI version details to w. It is the single source of

--- a/internal/dryrun/dryrun.go
+++ b/internal/dryrun/dryrun.go
@@ -78,12 +78,12 @@ func NewDryRunner(eksClient *eks.Client, clusterName string, force, quiet bool) 
 
 	awsCfg, err := dryrunLoadAWSConfig(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load AWS config: %v", err)
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
 	}
 
 	k8sVersion, err := dryrunDescribeCluster(ctx, eksClient, clusterName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to describe cluster: %v", err)
+		return nil, fmt.Errorf("failed to describe cluster: %w", err)
 	}
 
 	return &DryRunner{

--- a/internal/health/balance.go
+++ b/internal/health/balance.go
@@ -103,7 +103,7 @@ func (hc *HealthChecker) getNodeLevelEC2Metrics(ctx context.Context, clusterName
 	// Get instance IDs and names from EKS
 	instanceData, err := hc.getClusterInstanceData(ctx, clusterName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get instance data: %v", err)
+		return nil, fmt.Errorf("failed to get instance data: %w", err)
 	}
 
 	if len(instanceData) == 0 {

--- a/internal/health/capacity.go
+++ b/internal/health/capacity.go
@@ -12,6 +12,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 )
 
+// CPU headroom thresholds for safe rolling updates: at least
+// minSafeCPUHeadroomPercent free is a pass, at least
+// minWarnCPUHeadroomPercent is a warning, anything less is a failure.
+const (
+	minSafeCPUHeadroomPercent = 30.0
+	minWarnCPUHeadroomPercent = 15.0
+)
+
 // CheckClusterCapacity validates that the cluster has sufficient capacity for rolling updates
 func (hc *HealthChecker) CheckClusterCapacity(ctx context.Context, clusterName string) HealthResult {
 	result := HealthResult{
@@ -40,13 +48,12 @@ func (hc *HealthChecker) CheckClusterCapacity(ctx context.Context, clusterName s
 	result.Details = append(result.Details, "Memory utilization: Not available (requires Container Insights)")
 
 	// Calculate score based on CPU headroom only
-	// We want at least 30% headroom for safe rolling updates
 	headroom := 100 - avgCPU
-	if headroom >= 30 {
+	if headroom >= minSafeCPUHeadroomPercent {
 		result.Status = StatusPass
 		result.Score = 100
 		result.Message = fmt.Sprintf("Sufficient CPU capacity (%.1f%% utilization)", avgCPU)
-	} else if headroom >= 15 {
+	} else if headroom >= minWarnCPUHeadroomPercent {
 		result.Status = StatusWarn
 		result.Score = 70
 		result.Message = fmt.Sprintf("Limited CPU capacity (%.1f%% utilization)", avgCPU)
@@ -70,7 +77,7 @@ func (hc *HealthChecker) getEC2ClusterCPUMetrics(ctx context.Context, clusterNam
 	// Get instance IDs from nodegroups
 	instanceIDs, err := hc.getClusterInstanceIDs(ctx, clusterName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get cluster instances: %v", err)
+		return nil, fmt.Errorf("failed to get cluster instances: %w", err)
 	}
 
 	if len(instanceIDs) == 0 {
@@ -139,7 +146,7 @@ func (hc *HealthChecker) getClusterInstanceIDs(ctx context.Context, clusterName 
 		listInput := &eks.ListNodegroupsInput{ClusterName: aws.String(clusterName), NextToken: nextToken}
 		ngOutput, err := hc.eksClient.ListNodegroups(ctx, listInput)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list nodegroups: %v", err)
+			return nil, fmt.Errorf("failed to list nodegroups: %w", err)
 		}
 		nodegroupNames = append(nodegroupNames, ngOutput.Nodegroups...)
 		if ngOutput.NextToken == nil {
@@ -191,7 +198,7 @@ func (hc *HealthChecker) getASGInstanceIDs(ctx context.Context, asgName string) 
 
 	output, err := hc.asgClient.DescribeAutoScalingGroups(ctx, input)
 	if err != nil {
-		return nil, fmt.Errorf("failed to describe ASG %s: %v", asgName, err)
+		return nil, fmt.Errorf("failed to describe ASG %s: %w", asgName, err)
 	}
 
 	if len(output.AutoScalingGroups) == 0 {

--- a/internal/services/addons/service.go
+++ b/internal/services/addons/service.go
@@ -13,6 +13,15 @@ import (
 	"github.com/dantech2000/refresh/internal/services/common"
 )
 
+const (
+	// maxParallelAddonUpdates caps concurrent UpdateAddon calls when
+	// UpdateOptions.Parallel is set.
+	maxParallelAddonUpdates = 3
+	// addonUpdatePollInterval is how often waitForAddonUpdate re-checks an
+	// in-flight addon update.
+	addonUpdatePollInterval = 5 * time.Second
+)
+
 // EKSAPI abstracts the EKS client methods used for addons
 type EKSAPI interface {
 	ListAddons(ctx context.Context, params *eks.ListAddonsInput, optFns ...func(*eks.Options)) (*eks.ListAddonsOutput, error)
@@ -284,7 +293,7 @@ func (s *ServiceImpl) UpdateAll(ctx context.Context, clusterName string, options
 	results := make([]AddonUpdateResult, len(toUpdate))
 	if options.Parallel {
 		var wg sync.WaitGroup
-		semaphore := make(chan struct{}, 3)
+		semaphore := make(chan struct{}, maxParallelAddonUpdates)
 		for i, addon := range toUpdate {
 			// Acquire BEFORE spawning so the cap limits live goroutines, not
 			// just in-flight API calls. Matches cluster.ListAllRegionsWithMeta.

--- a/internal/services/addons/version_analyzer.go
+++ b/internal/services/addons/version_analyzer.go
@@ -52,7 +52,7 @@ func (s *ServiceImpl) GetAvailableVersions(ctx context.Context, addonName string
 
 // waitForAddonUpdate polls until an addon update completes.
 func (s *ServiceImpl) waitForAddonUpdate(ctx context.Context, clusterName, addonName string) error {
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(addonUpdatePollInterval)
 	defer ticker.Stop()
 
 	for {

--- a/internal/services/cluster/service.go
+++ b/internal/services/cluster/service.go
@@ -46,6 +46,10 @@ const (
 	// Default cache TTLs (override via env if needed in future)
 	defaultCacheTTLDescribe = 5 * time.Minute
 	defaultCacheTTLList     = 2 * time.Minute
+
+	// defaultRegionListConcurrency caps concurrent per-region List calls in
+	// ListAllRegionsWithMeta when no --max-concurrency is given.
+	defaultRegionListConcurrency = 8
 )
 
 // NewService creates a new cluster service instance
@@ -301,7 +305,7 @@ func (s *ServiceImpl) ListAllRegionsWithMeta(ctx context.Context, options ListOp
 	eksRegions := s.resolveRegions(options)
 	maxConc := options.MaxConcurrency
 	if maxConc <= 0 {
-		maxConc = 8
+		maxConc = defaultRegionListConcurrency
 	}
 
 	type regionResult struct {

--- a/internal/services/nodegroup/cost_analyzer.go
+++ b/internal/services/nodegroup/cost_analyzer.go
@@ -15,6 +15,10 @@ import (
 	"github.com/dantech2000/refresh/internal/services/common"
 )
 
+// defaultCostCacheTTL is how long pricing lookups are cached; on-demand
+// prices change rarely, so a long TTL is safe.
+const defaultCostCacheTTL = 60 * time.Minute
+
 type CostAnalyzer struct {
 	pricing   *pricing.Client
 	ec2Client *ec2.Client
@@ -25,7 +29,7 @@ type CostAnalyzer struct {
 }
 
 func NewCostAnalyzer(p *pricing.Client, logger *slog.Logger, cache *Cache, region string) *CostAnalyzer {
-	return &CostAnalyzer{pricing: p, logger: logger, cache: cache, cacheTTL: 60 * time.Minute, region: region}
+	return &CostAnalyzer{pricing: p, logger: logger, cache: cache, cacheTTL: defaultCostCacheTTL, region: region}
 }
 
 // SetEC2Client sets the EC2 client for spot pricing queries

--- a/internal/services/nodegroup/nodegroup_scale.go
+++ b/internal/services/nodegroup/nodegroup_scale.go
@@ -14,6 +14,10 @@ import (
 	awsinternal "github.com/dantech2000/refresh/internal/aws"
 )
 
+// scalePollInterval is how often waitForScaleCompletion re-checks nodegroup
+// status while waiting for a scaling operation to finish.
+const scalePollInterval = 5 * time.Second
+
 // Scale updates the desired/min/max size for a nodegroup.
 func (s *ServiceImpl) Scale(ctx context.Context, clusterName, nodegroupName string, desired, min, max *int32, options ScaleOptions) error {
 	s.logger.Info("scaling nodegroup", "cluster", clusterName, "nodegroup", nodegroupName,
@@ -92,7 +96,7 @@ func (s *ServiceImpl) waitForScaleCompletion(ctx context.Context, clusterName, n
 		waitCtx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(scalePollInterval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/internal/services/nodegroup/utilization.go
+++ b/internal/services/nodegroup/utilization.go
@@ -14,6 +14,10 @@ import (
 	"github.com/dantech2000/refresh/internal/services/common"
 )
 
+// defaultUtilizationCacheTTL is how long CloudWatch utilization metrics are
+// cached; kept short so repeated commands still reflect recent load.
+const defaultUtilizationCacheTTL = 2 * time.Minute
+
 type UtilizationCollector struct {
 	cw       *cloudwatch.Client
 	logger   *slog.Logger
@@ -22,7 +26,7 @@ type UtilizationCollector struct {
 }
 
 func NewUtilizationCollector(cw *cloudwatch.Client, logger *slog.Logger, cache *Cache) *UtilizationCollector {
-	return &UtilizationCollector{cw: cw, logger: logger, cache: cache, cacheTTL: 2 * time.Minute}
+	return &UtilizationCollector{cw: cw, logger: logger, cache: cache, cacheTTL: defaultUtilizationCacheTTL}
 }
 
 // metricSpec describes one CloudWatch metric to fetch per instance.


### PR DESCRIPTION
## What

Mechanical hygiene cleanups from the code-quality review. No behavior changes.

### `%v` → `%w` error wrapping

`fmt.Errorf(..., %v, err)` breaks `errors.Is`/`errors.As` for callers. Converted to `%w` in:
- `internal/aws/errors.go` (generic formatter + region/credential/network/permission templates)
- `internal/health/capacity.go`, `internal/health/balance.go`
- `internal/dryrun/dryrun.go`

Pre-checked that nothing compares these error strings, and `AWSError` already implements `Unwrap()`.

### Named constants for behavior-critical magic numbers

| Constant | Was | Where |
|---|---|---|
| `maxParallelAddonUpdates = 3` | bare `3` semaphore cap | addons/service.go |
| `addonUpdatePollInterval = 5s` | bare ticker | addons/version_analyzer.go |
| `scalePollInterval = 5s` | bare ticker | nodegroup/nodegroup_scale.go |
| `defaultCostCacheTTL = 60m` | inline in constructor | nodegroup/cost_analyzer.go |
| `defaultUtilizationCacheTTL = 2m` | inline in constructor | nodegroup/utilization.go |
| `defaultRegionListConcurrency = 8` | bare `8` | cluster/service.go |
| `credentialValidationTimeout = 10s` | inline timeout | aws/errors.go |
| `minSafeCPUHeadroomPercent = 30` / `minWarnCPUHeadroomPercent = 15` | bare thresholds | health/capacity.go |

(The balance-score thresholds live in `computeBalanceScore`, extracted in #18 — left untouched here to avoid cross-PR conflicts.)

### Remove redundant `init()` in `commands/version.go`

ldflags `-X` values are applied at link time; `VersionInfo` initializes after `version`/`commit`/`buildDate` in package dependency order, so the `init()` re-assignment was a no-op. **Verified end-to-end**: `go build -ldflags "-X ...version=9.9.9-test"` → `refresh --version` prints `9.9.9-test` without it.

## Tests

`go build`, `go vet`, `golangci-lint` (0 issues), `go test -race ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
