### PR TITLE
refactor: consolidate duplicated table, timing, filter, pagination, and badge code

### DIFF
--- a/internal/aws/paginate.go
+++ b/internal/aws/paginate.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/dantech2000/refresh/internal/services/common"
+)
+
+// ListAllPages pages through an AWS list API, retrying each page call with
+// common.DefaultRetryConfig and formatting failures with FormatAWSError.
+// call fetches one page for the given token; extract pulls the items and the
+// next token out of the page output.
+//
+// It replaces the Paginate(WithRetry(...)) sandwich previously duplicated by
+// every list-style service method, so the retry and error-formatting policy
+// lives in one place.
+func ListAllPages[O, T any](
+	ctx context.Context,
+	operation string,
+	call func(ctx context.Context, token *string) (O, error),
+	extract func(O) (items []T, next *string),
+) ([]T, error) {
+	return common.Paginate(ctx, func(rc context.Context, token *string) ([]T, *string, error) {
+		out, err := common.WithRetry(rc, common.DefaultRetryConfig, func(rrc context.Context) (O, error) {
+			return call(rrc, token)
+		})
+		if err != nil {
+			return nil, nil, FormatAWSError(err, operation)
+		}
+		items, next := extract(out)
+		return items, next, nil
+	})
+}

--- a/internal/aws/paginate_test.go
+++ b/internal/aws/paginate_test.go
@@ -1,0 +1,53 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakePage struct {
+	items []string
+	next  *string
+}
+
+func TestListAllPages_FollowsTokens(t *testing.T) {
+	token2 := "page2"
+	pages := map[string]fakePage{
+		"":      {items: []string{"a", "b"}, next: &token2},
+		"page2": {items: []string{"c"}, next: nil},
+	}
+
+	got, err := ListAllPages(context.Background(), "listing things",
+		func(_ context.Context, token *string) (fakePage, error) {
+			key := ""
+			if token != nil {
+				key = *token
+			}
+			return pages[key], nil
+		},
+		func(p fakePage) ([]string, *string) { return p.items, p.next },
+	)
+	if err != nil {
+		t.Fatalf("ListAllPages() = %v", err)
+	}
+	if len(got) != 3 || got[0] != "a" || got[2] != "c" {
+		t.Errorf("items = %v, want [a b c]", got)
+	}
+}
+
+func TestListAllPages_FormatsErrorWithOperation(t *testing.T) {
+	_, err := ListAllPages(context.Background(), "listing widgets",
+		func(_ context.Context, _ *string) (fakePage, error) {
+			return fakePage{}, errors.New("boom")
+		},
+		func(p fakePage) ([]string, *string) { return p.items, p.next },
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "listing widgets") {
+		t.Errorf("error %q should mention the operation", err)
+	}
+}

--- a/internal/commands/addon/actions.go
+++ b/internal/commands/addon/actions.go
@@ -3,8 +3,6 @@ package addon
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -17,9 +15,10 @@ import (
 	"gopkg.in/yaml.v3"
 
 	awsinternal "github.com/dantech2000/refresh/internal/aws"
+	"github.com/dantech2000/refresh/internal/commands/factory"
 	"github.com/dantech2000/refresh/internal/commands/runner"
 	"github.com/dantech2000/refresh/internal/services/addons"
-	"github.com/dantech2000/refresh/internal/services/common"
+	"github.com/dantech2000/refresh/internal/ui"
 )
 
 func runList(c *cli.Context) error {
@@ -218,7 +217,7 @@ func runUpdateAll(c *cli.Context) error {
 	}
 
 	eksClient := eks.NewFromConfig(cfg)
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	logger := factory.NewDefaultLogger(nil)
 	addonSvc := addons.NewService(eksClient, logger)
 
 	options := addons.UpdateAllOptions{
@@ -252,13 +251,12 @@ func runUpdateAll(c *cli.Context) error {
 }
 
 func fetchAddons(ctx context.Context, eksClient *eks.Client, clusterName string, withHealth bool) ([]addonRow, error) {
-	addonNames, err := common.Paginate(ctx, func(rc context.Context, token *string) ([]string, *string, error) {
-		out, err := eksClient.ListAddons(rc, &eks.ListAddonsInput{ClusterName: aws.String(clusterName), NextToken: token})
-		if err != nil {
-			return nil, nil, awsinternal.FormatAWSError(err, "listing add-ons")
-		}
-		return out.Addons, out.NextToken, nil
-	})
+	addonNames, err := awsinternal.ListAllPages(ctx, "listing add-ons",
+		func(rc context.Context, token *string) (*eks.ListAddonsOutput, error) {
+			return eksClient.ListAddons(rc, &eks.ListAddonsInput{ClusterName: aws.String(clusterName), NextToken: token})
+		},
+		func(out *eks.ListAddonsOutput) ([]string, *string) { return out.Addons, out.NextToken },
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -281,14 +279,14 @@ func fetchAddons(ctx context.Context, eksClient *eks.Client, clusterName string,
 func mapAddonHealth(s ekstypes.AddonStatus) string {
 	switch s {
 	case ekstypes.AddonStatusActive:
-		return color.GreenString("PASS")
+		return ui.BadgePass()
 	case ekstypes.AddonStatusDegraded:
-		return color.RedString("FAIL")
+		return ui.BadgeFail()
 	case ekstypes.AddonStatusCreateFailed, ekstypes.AddonStatusDeleteFailed:
-		return color.RedString("FAIL")
+		return ui.BadgeFail()
 	case ekstypes.AddonStatusCreating, ekstypes.AddonStatusDeleting, ekstypes.AddonStatusUpdating:
-		return color.CyanString("[IN PROGRESS]")
+		return ui.BadgeInProgress()
 	default:
-		return color.WhiteString("UNKNOWN")
+		return ui.BadgeUnknown()
 	}
 }

--- a/internal/commands/addon/formatters.go
+++ b/internal/commands/addon/formatters.go
@@ -34,7 +34,7 @@ type addonDetails struct {
 
 func outputAddonsTable(cluster string, rows []addonRow, elapsed time.Duration) error {
 	ui.Outf("Add-ons for cluster: %s\n", color.CyanString(cluster))
-	ui.Outf("Retrieved in %s\n\n", color.GreenString("%.1fs", elapsed.Seconds()))
+	ui.PrintElapsed(elapsed)
 
 	if len(rows) == 0 {
 		color.Yellow("No add-ons found")
@@ -47,7 +47,7 @@ func outputAddonsTable(cluster string, rows []addonRow, elapsed time.Duration) e
 		{Title: "STATUS", Min: 10, Max: 0, Align: ui.AlignLeft},
 		{Title: "HEALTH", Min: 8, Max: 0, Align: ui.AlignLeft},
 	}
-	table := ui.NewPTable(columns, ui.WithPTableHeaderColor(func(s string) string { return color.CyanString(s) }))
+	table := ui.NewPTable(columns, ui.CyanHeaders())
 	for _, r := range rows {
 		table.AddRow(r.Name, r.Version, r.Status, r.Health)
 	}
@@ -97,7 +97,7 @@ func outputUpdateAllResults(cluster string, results []addons.AddonUpdateResult, 
 		{Title: "NEW", Min: 15, Max: 0, Align: ui.AlignLeft},
 		{Title: "STATUS", Min: 10, Max: 0, Align: ui.AlignLeft},
 	}
-	table := ui.NewPTable(columns, ui.WithPTableHeaderColor(func(s string) string { return color.CyanString(s) }))
+	table := ui.NewPTable(columns, ui.CyanHeaders())
 
 	successCount := 0
 	failCount := 0

--- a/internal/commands/cluster/actions.go
+++ b/internal/commands/cluster/actions.go
@@ -28,12 +28,7 @@ func runList(c *cli.Context) error {
 
 	clusterService := factory.NewClusterService(awsCfg, c.Bool("show-health"), nil)
 
-	filters := make(map[string]string)
-	for _, f := range c.StringSlice("filter") {
-		if parts := strings.SplitN(f, "=", 2); len(parts) == 2 {
-			filters[parts[0]] = parts[1]
-		}
-	}
+	filters := runner.ParseFilters(c.StringSlice("filter"))
 	if pattern := strings.TrimSpace(c.Args().First()); pattern != "" {
 		filters["name"] = pattern
 	}

--- a/internal/commands/clusterview/color.go
+++ b/internal/commands/clusterview/color.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dantech2000/refresh/internal/health"
 	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
+	"github.com/dantech2000/refresh/internal/ui"
 )
 
 // colorString is the signature of fatih/color's *String helpers.
@@ -149,13 +150,13 @@ func formatHealth(h *health.HealthSummary) string {
 func formatAddonHealth(h string) string {
 	switch h {
 	case "Healthy":
-		return color.GreenString("PASS")
+		return ui.BadgePass()
 	case "Issues", "Failed":
-		return color.RedString("FAIL")
+		return ui.BadgeFail()
 	case "Updating":
-		return color.CyanString("[IN PROGRESS]")
+		return ui.BadgeInProgress()
 	default:
-		return color.WhiteString("UNKNOWN")
+		return ui.BadgeUnknown()
 	}
 }
 

--- a/internal/commands/clusterview/compare.go
+++ b/internal/commands/clusterview/compare.go
@@ -18,7 +18,7 @@ func OutputComparisonTable(comparison *clustersvc.ClusterComparison, elapsed tim
 		names[i] = c.Name
 	}
 	ui.Outf("Cluster Comparison: %s\n", color.CyanString(strings.Join(names, " vs ")))
-	ui.Outf("Analyzed in %s\n\n", color.GreenString("%.1fs", elapsed.Seconds()))
+	ui.Outf("Analyzed in %s\n\n", ui.ElapsedString(elapsed))
 
 	s := comparison.Summary
 	summaryTbl := ui.NewDynamicTable()
@@ -42,7 +42,7 @@ func OutputComparisonTable(comparison *clustersvc.ClusterComparison, elapsed tim
 		{Title: "VERSION", Min: 7, Align: ui.AlignLeft},
 		{Title: "HEALTH", Min: 15, Align: ui.AlignLeft},
 	}
-	tbl := ui.NewPTable(cols, ui.WithPTableHeaderColor(func(s string) string { return color.CyanString(s) }))
+	tbl := ui.NewPTable(cols, ui.CyanHeaders())
 	for _, cl := range comparison.Clusters {
 		healthStatus := color.WhiteString("UNKNOWN")
 		if cl.Health != nil {

--- a/internal/commands/clusterview/detail.go
+++ b/internal/commands/clusterview/detail.go
@@ -14,7 +14,7 @@ import (
 // OutputClusterDetailsTable renders a single cluster's expanded details.
 func OutputClusterDetailsTable(details *clustersvc.ClusterDetails, elapsed time.Duration) error {
 	ui.Outf("Cluster Information: %s\n", color.CyanString(details.Name))
-	ui.Outf("Retrieved in %s\n\n", color.GreenString("%.1fs", elapsed.Seconds()))
+	ui.PrintElapsed(elapsed)
 
 	tbl := ui.NewDynamicTable()
 	tbl.Add("Status", formatStatus(details.Status)).
@@ -76,7 +76,7 @@ func OutputClusterDetailsTable(details *clustersvc.ClusterDetails, elapsed time.
 			{Title: "STATUS", Min: 10, Align: ui.AlignLeft},
 			{Title: "HEALTH", Min: 8, Align: ui.AlignLeft},
 		}
-		addTbl := ui.NewPTable(cols, ui.WithPTableHeaderColor(func(s string) string { return color.CyanString(s) }))
+		addTbl := ui.NewPTable(cols, ui.CyanHeaders())
 		for _, a := range details.Addons {
 			h := a.Health
 			if h == "" {

--- a/internal/commands/clusterview/list.go
+++ b/internal/commands/clusterview/list.go
@@ -29,10 +29,9 @@ func OutputClustersTable(summaries []clustersvc.ClusterSummary, elapsed time.Dur
 	} else {
 		ui.Outf("EKS Clusters (%d clusters)\n", len(summaries))
 	}
-	ui.Outf("Retrieved in %s\n\n", color.GreenString("%.1fs", elapsed.Seconds()))
+	ui.PrintElapsed(elapsed)
 
-	headerColor := func(s string) string { return color.CyanString(s) }
-	cols := []ui.Column{{Title: "CLUSTER", Min: 14, Align: ui.AlignLeft}}
+		cols := []ui.Column{{Title: "CLUSTER", Min: 14, Align: ui.AlignLeft}}
 	if multiRegion {
 		cols = append(cols, ui.Column{Title: "REGION", Min: 10, Align: ui.AlignLeft})
 	}
@@ -45,7 +44,7 @@ func OutputClustersTable(summaries []clustersvc.ClusterSummary, elapsed time.Dur
 	}
 	cols = append(cols, ui.Column{Title: "READY/DESIRED", Min: 15, Align: ui.AlignRight})
 
-	tbl := ui.NewPTable(cols, ui.WithPTableHeaderColor(headerColor))
+	tbl := ui.NewPTable(cols, ui.CyanHeaders())
 	for _, s := range summaries {
 		row := []string{s.Name}
 		if multiRegion {

--- a/internal/commands/nodegroup/actions.go
+++ b/internal/commands/nodegroup/actions.go
@@ -42,12 +42,7 @@ func runList(c *cli.Context) error {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	svc := factory.NewNodegroupService(awsCfg, false, logger)
 
-	filters := make(map[string]string)
-	for _, f := range c.StringSlice("filter") {
-		if parts := strings.SplitN(f, "=", 2); len(parts) == 2 {
-			filters[parts[0]] = parts[1]
-		}
-	}
+	filters := runner.ParseFilters(c.StringSlice("filter"))
 	opts := nodegroupsvc.ListOptions{
 		ShowHealth:      c.Bool("show-health"),
 		ShowCosts:       c.Bool("show-costs"),
@@ -96,7 +91,7 @@ func runDescribe(c *cli.Context) error {
 		return fmt.Errorf("missing nodegroup name; pass as second argument or --nodegroup <name>")
 	}
 
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	logger := factory.NewDefaultLogger(nil)
 	svc := factory.NewNodegroupService(awsCfg, false, logger)
 
 	opts := nodegroupsvc.DescribeOptions{
@@ -136,7 +131,7 @@ func runScale(c *cli.Context) error {
 		return err
 	}
 
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	logger := factory.NewDefaultLogger(nil)
 	withHealth := c.Bool("health-check") || c.Bool("check-pdbs") || c.Bool("wait")
 	svc := factory.NewNodegroupService(awsCfg, withHealth, logger)
 

--- a/internal/commands/nodegroup/formatters.go
+++ b/internal/commands/nodegroup/formatters.go
@@ -19,9 +19,9 @@ func outputNodegroupsTable(clusterName, timeframe string, items []nodegroupsvc.N
 	}
 	ui.Outf("Nodegroups for cluster: %s\n", clusterName)
 	if opts.ShowUtilization {
-		ui.Outf("Retrieved in %s (utilization window %s)\n", color.GreenString("%.1fs", elapsed.Seconds()), timeframe)
+		ui.Outf("Retrieved in %s (utilization window %s)\n", ui.ElapsedString(elapsed), timeframe)
 	} else {
-		ui.Outf("Retrieved in %s\n", color.GreenString("%.1fs", elapsed.Seconds()))
+		ui.Outf("Retrieved in %s\n", ui.ElapsedString(elapsed))
 	}
 
 	if opts.ShowUtilization || opts.ShowCosts {
@@ -50,7 +50,7 @@ func outputNodegroupsTable(clusterName, timeframe string, items []nodegroupsvc.N
 		columns = append(columns, ui.Column{Title: "COST/MO", Min: 8, Max: 0, Align: ui.AlignRight})
 	}
 
-	table := ui.NewPTable(columns, ui.WithPTableHeaderColor(func(s string) string { return color.CyanString(s) }))
+	table := ui.NewPTable(columns, ui.CyanHeaders())
 	for _, ng := range items {
 		row := []string{
 			ng.Name,
@@ -82,9 +82,9 @@ func outputNodegroupsTable(clusterName, timeframe string, items []nodegroupsvc.N
 func outputNodegroupDetailsTable(details *nodegroupsvc.NodegroupDetails, elapsed time.Duration) error {
 	ui.Outf("Nodegroup: %s\n", color.CyanString(details.Name))
 	if details.Utilization.TimeRange != "" {
-		ui.Outf("Retrieved in %s (utilization window %s)\n\n", color.GreenString("%.1fs", elapsed.Seconds()), details.Utilization.TimeRange)
+		ui.Outf("Retrieved in %s (utilization window %s)\n\n", ui.ElapsedString(elapsed), details.Utilization.TimeRange)
 	} else {
-		ui.Outf("Retrieved in %s\n\n", color.GreenString("%.1fs", elapsed.Seconds()))
+		ui.Outf("Retrieved in %s\n\n", ui.ElapsedString(elapsed))
 	}
 
 	table := ui.NewDynamicTable()
@@ -135,7 +135,7 @@ func outputNodegroupDetailsTable(details *nodegroupsvc.NodegroupDetails, elapsed
 			{Title: "LIFECYCLE", Min: 9, Max: 0, Align: ui.AlignLeft},
 			{Title: "STATE", Min: 8, Max: 0, Align: ui.AlignLeft},
 		}
-		instTable := ui.NewPTable(columns, ui.WithPTableHeaderColor(func(s string) string { return color.CyanString(s) }))
+		instTable := ui.NewPTable(columns, ui.CyanHeaders())
 		for _, inst := range details.Instances {
 			instTable.AddRow(
 				truncate(inst.InstanceID, 22),

--- a/internal/commands/runner/runner.go
+++ b/internal/commands/runner/runner.go
@@ -94,6 +94,18 @@ func SetupAWSStrict(c *cli.Context) (context.Context, context.CancelFunc, aws.Co
 	return setupAWS(c, 0, checkCredentialsStrict)
 }
 
+// ParseFilters parses repeated key=value --filter flag values into a map.
+// Tokens without "=" are ignored.
+func ParseFilters(filters []string) map[string]string {
+	out := make(map[string]string)
+	for _, f := range filters {
+		if parts := strings.SplitN(f, "=", 2); len(parts) == 2 {
+			out[parts[0]] = parts[1]
+		}
+	}
+	return out
+}
+
 // RequestedCluster returns the cluster name requested by the user: first
 // positional arg if present, otherwise --cluster.
 func RequestedCluster(c *cli.Context) string {

--- a/internal/commands/runner/runner_test.go
+++ b/internal/commands/runner/runner_test.go
@@ -122,3 +122,25 @@ func TestPositionalAt_OutOfRangeReturnsEmpty(t *testing.T) {
 		t.Errorf("got %q, want empty", got)
 	}
 }
+
+// ── ParseFilters ──────────────────────────────────────────────────────────────
+
+func TestParseFilters(t *testing.T) {
+	got := ParseFilters([]string{"name=prod", "env=staging", "malformed", "k=v=extra"})
+	if len(got) != 3 {
+		t.Fatalf("ParseFilters returned %d entries, want 3: %v", len(got), got)
+	}
+	if got["name"] != "prod" || got["env"] != "staging" {
+		t.Errorf("ParseFilters = %v", got)
+	}
+	// SplitN(2) keeps everything after the first "=" as the value.
+	if got["k"] != "v=extra" {
+		t.Errorf(`got["k"] = %q, want "v=extra"`, got["k"])
+	}
+}
+
+func TestParseFilters_Empty(t *testing.T) {
+	if got := ParseFilters(nil); len(got) != 0 {
+		t.Errorf("ParseFilters(nil) = %v, want empty map", got)
+	}
+}

--- a/internal/commands/workload/formatters.go
+++ b/internal/commands/workload/formatters.go
@@ -28,7 +28,7 @@ func outputPDBCoverageYAML(result workloads.PDBCoverageResult) error {
 
 func outputPDBCoverageTable(result workloads.PDBCoverageResult, elapsed time.Duration) error {
 	ui.Outf("PDB Coverage\n")
-	ui.Outf("Retrieved in %s\n\n", color.GreenString("%.1fs", elapsed.Seconds()))
+	ui.PrintElapsed(elapsed)
 
 	if result.Summary.TotalDeployments == 0 {
 		color.Yellow("No deployments found")
@@ -41,7 +41,7 @@ func outputPDBCoverageTable(result workloads.PDBCoverageResult, elapsed time.Dur
 		{Title: "STATUS", Min: 9, Align: ui.AlignLeft},
 		{Title: "PDBS", Min: 4, Align: ui.AlignLeft},
 	}
-	table := ui.NewPTable(cols, ui.WithPTableHeaderColor(func(s string) string { return color.CyanString(s) }))
+	table := ui.NewPTable(cols, ui.CyanHeaders())
 	for _, row := range result.Deployments {
 		status := color.RedString("MISSING")
 		if row.HasPDB {

--- a/internal/services/addons/service.go
+++ b/internal/services/addons/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
+	awsinternal "github.com/dantech2000/refresh/internal/aws"
 	"github.com/dantech2000/refresh/internal/services/common"
 )
 
@@ -40,18 +41,15 @@ func NewService(eksClient EKSAPI, logger *slog.Logger) *ServiceImpl {
 func (s *ServiceImpl) List(ctx context.Context, clusterName string, options ListOptions) ([]AddonSummary, error) {
 	s.logger.Info("listing addons", "cluster", clusterName)
 
-	addonNames, err := common.Paginate(ctx, func(rc context.Context, token *string) ([]string, *string, error) {
-		out, err := common.WithRetry(rc, common.DefaultRetryConfig, func(rrc context.Context) (*eks.ListAddonsOutput, error) {
-			return s.eksClient.ListAddons(rrc, &eks.ListAddonsInput{
+	addonNames, err := awsinternal.ListAllPages(ctx, fmt.Sprintf("listing add-ons for cluster %s", clusterName),
+		func(rc context.Context, token *string) (*eks.ListAddonsOutput, error) {
+			return s.eksClient.ListAddons(rc, &eks.ListAddonsInput{
 				ClusterName: aws.String(clusterName),
 				NextToken:   token,
 			})
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("listing addons: %w", err)
-		}
-		return out.Addons, out.NextToken, nil
-	})
+		},
+		func(out *eks.ListAddonsOutput) ([]string, *string) { return out.Addons, out.NextToken },
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cluster/helpers.go
+++ b/internal/services/cluster/helpers.go
@@ -34,18 +34,15 @@ func (s *ServiceImpl) getVpcCidr(ctx context.Context, vpcId string) (string, err
 
 // getClusterAddons retrieves add-on information for a cluster
 func (s *ServiceImpl) getClusterAddons(ctx context.Context, clusterName string) ([]AddonInfo, error) {
-	addonNames, err := common.Paginate(ctx, func(rc context.Context, token *string) ([]string, *string, error) {
-		out, err := common.WithRetry(rc, common.DefaultRetryConfig, func(rrc context.Context) (*eks.ListAddonsOutput, error) {
-			return s.eksClient.ListAddons(rrc, &eks.ListAddonsInput{
+	addonNames, err := awsinternal.ListAllPages(ctx, fmt.Sprintf("listing add-ons for cluster %s", clusterName),
+		func(rc context.Context, token *string) (*eks.ListAddonsOutput, error) {
+			return s.eksClient.ListAddons(rc, &eks.ListAddonsInput{
 				ClusterName: aws.String(clusterName),
 				NextToken:   token,
 			})
-		})
-		if err != nil {
-			return nil, nil, awsinternal.FormatAWSError(err, fmt.Sprintf("listing add-ons for cluster %s", clusterName))
-		}
-		return out.Addons, out.NextToken, nil
-	})
+		},
+		func(out *eks.ListAddonsOutput) ([]string, *string) { return out.Addons, out.NextToken },
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -92,18 +89,15 @@ func (s *ServiceImpl) getClusterAddons(ctx context.Context, clusterName string) 
 
 // getClusterNodegroups retrieves nodegroup information for a cluster
 func (s *ServiceImpl) getClusterNodegroups(ctx context.Context, clusterName string) ([]NodegroupSummary, error) {
-	nodegroupNames, err := common.Paginate(ctx, func(rc context.Context, token *string) ([]string, *string, error) {
-		out, err := common.WithRetry(rc, common.DefaultRetryConfig, func(rrc context.Context) (*eks.ListNodegroupsOutput, error) {
-			return s.eksClient.ListNodegroups(rrc, &eks.ListNodegroupsInput{
+	nodegroupNames, err := awsinternal.ListAllPages(ctx, fmt.Sprintf("listing nodegroups for cluster %s", clusterName),
+		func(rc context.Context, token *string) (*eks.ListNodegroupsOutput, error) {
+			return s.eksClient.ListNodegroups(rc, &eks.ListNodegroupsInput{
 				ClusterName: aws.String(clusterName),
 				NextToken:   token,
 			})
-		})
-		if err != nil {
-			return nil, nil, awsinternal.FormatAWSError(err, fmt.Sprintf("listing nodegroups for cluster %s", clusterName))
-		}
-		return out.Nodegroups, out.NextToken, nil
-	})
+		},
+		func(out *eks.ListNodegroupsOutput) ([]string, *string) { return out.Nodegroups, out.NextToken },
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cluster/service.go
+++ b/internal/services/cluster/service.go
@@ -225,15 +225,12 @@ func (s *ServiceImpl) List(ctx context.Context, options ListOptions) ([]ClusterS
 		}
 	}
 
-	clusterNames, err := common.Paginate(ctx, func(rc context.Context, token *string) ([]string, *string, error) {
-		out, err := common.WithRetry(rc, common.DefaultRetryConfig, func(rrc context.Context) (*eks.ListClustersOutput, error) {
-			return s.eksClient.ListClusters(rrc, &eks.ListClustersInput{NextToken: token})
-		})
-		if err != nil {
-			return nil, nil, awsinternal.FormatAWSError(err, "listing clusters")
-		}
-		return out.Clusters, out.NextToken, nil
-	})
+	clusterNames, err := awsinternal.ListAllPages(ctx, "listing clusters",
+		func(rc context.Context, token *string) (*eks.ListClustersOutput, error) {
+			return s.eksClient.ListClusters(rc, &eks.ListClustersInput{NextToken: token})
+		},
+		func(out *eks.ListClustersOutput) ([]string, *string) { return out.Clusters, out.NextToken },
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/nodegroup/service.go
+++ b/internal/services/nodegroup/service.go
@@ -92,18 +92,15 @@ func (s *ServiceImpl) List(ctx context.Context, clusterName string, options List
 	}
 	k8sVersion := aws.ToString(clusterDesc.Cluster.Version)
 
-	nodegroupNames, err := common.Paginate(ctx, func(rc context.Context, token *string) ([]string, *string, error) {
-		out, err := common.WithRetry(rc, common.DefaultRetryConfig, func(rrc context.Context) (*eks.ListNodegroupsOutput, error) {
-			return s.eksClient.ListNodegroups(rrc, &eks.ListNodegroupsInput{
+	nodegroupNames, err := awsinternal.ListAllPages(ctx, fmt.Sprintf("listing nodegroups for cluster %s", clusterName),
+		func(rc context.Context, token *string) (*eks.ListNodegroupsOutput, error) {
+			return s.eksClient.ListNodegroups(rc, &eks.ListNodegroupsInput{
 				ClusterName: aws.String(clusterName),
 				NextToken:   token,
 			})
-		})
-		if err != nil {
-			return nil, nil, awsinternal.FormatAWSError(err, fmt.Sprintf("listing nodegroups for cluster %s", clusterName))
-		}
-		return out.Nodegroups, out.NextToken, nil
-	})
+		},
+		func(out *eks.ListNodegroupsOutput) ([]string, *string) { return out.Nodegroups, out.NextToken },
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ui/health_badge.go
+++ b/internal/ui/health_badge.go
@@ -1,0 +1,19 @@
+package ui
+
+import "github.com/fatih/color"
+
+// Health badges shared by every command that renders a HEALTH column, so the
+// colored vocabulary (PASS / FAIL / [IN PROGRESS] / UNKNOWN) cannot drift
+// between commands.
+
+// BadgePass renders the green passing-health badge.
+func BadgePass() string { return color.GreenString("PASS") }
+
+// BadgeFail renders the red failing-health badge.
+func BadgeFail() string { return color.RedString("FAIL") }
+
+// BadgeInProgress renders the cyan in-progress badge.
+func BadgeInProgress() string { return color.CyanString("[IN PROGRESS]") }
+
+// BadgeUnknown renders the white unknown-health badge.
+func BadgeUnknown() string { return color.WhiteString("UNKNOWN") }

--- a/internal/ui/print.go
+++ b/internal/ui/print.go
@@ -3,6 +3,9 @@ package ui
 import (
 	"fmt"
 	"os"
+	"time"
+
+	"github.com/fatih/color"
 )
 
 // Outln writes a line to stdout, ignoring write errors intentionally.
@@ -13,6 +16,17 @@ func Outln(a ...any) {
 // Outf writes formatted output to stdout, ignoring write errors intentionally.
 func Outf(format string, a ...any) {
 	_, _ = fmt.Fprintf(os.Stdout, format, a...)
+}
+
+// ElapsedString renders an elapsed duration as green seconds, e.g. "1.2s".
+func ElapsedString(elapsed time.Duration) string {
+	return color.GreenString("%.1fs", elapsed.Seconds())
+}
+
+// PrintElapsed prints the standard "Retrieved in X.Xs" line followed by a
+// blank line — the shared trailer between a command's heading and its table.
+func PrintElapsed(elapsed time.Duration) {
+	Outf("Retrieved in %s\n\n", ElapsedString(elapsed))
 }
 
 // Errln writes a line to stderr, ignoring write errors intentionally.

--- a/internal/ui/ptable.go
+++ b/internal/ui/ptable.go
@@ -98,6 +98,12 @@ func truncateString(s string, maxLen int) string {
 	return s[:maxLen-3] + "..."
 }
 
+// CyanHeaders returns the standard cyan header-color option used by all
+// command tables.
+func CyanHeaders() PTableOption {
+	return WithPTableHeaderColor(func(s string) string { return color.CyanString(s) })
+}
+
 // CreateCompatibleTable is a convenience function that creates a PTable with the same
 // interface as the original ui.NewTable function, making migration easier.
 func CreateCompatibleTable(columns []Column, headerColor func(string) string) *PTable {
@@ -116,5 +122,5 @@ func NewPTableWithHeaders(headers []string) *PTable {
 		}
 	}
 
-	return NewPTable(columns, WithPTableHeaderColor(func(s string) string { return color.CyanString(s) }))
+	return NewPTable(columns, CyanHeaders())
 }


### PR DESCRIPTION
## What

Duplication consolidation from the code-quality review — the final PR in the series (#18, #19, #20, #21).

### New helpers and what they replace

| Helper | Replaces | Sites |
|---|---|---|
| `aws.ListAllPages[O,T]` | the `Paginate(WithRetry(FormatAWSError(...)))` triple-nested closure | 6 |
| `ui.CyanHeaders()` | identical cyan header lambdas | 8 |
| `ui.ElapsedString` / `ui.PrintElapsed` | green `"Retrieved in %.1fs"` formatting | 9 |
| `ui.BadgePass/Fail/InProgress/Unknown` | duplicated PASS/FAIL/[IN PROGRESS]/UNKNOWN switches in addon + clusterview | 2 |
| `runner.ParseFilters` | duplicated `key=value` --filter parsing | 2 |
| `factory.NewDefaultLogger` | hand-rolled `slog.New(...)` warn-level construction | 3 |

### Deliberate behavior changes (improvements)

- `addons.List` page failures now go through `FormatAWSError` (friendly categorized messages) instead of a plain `fmt.Errorf` wrap
- The addon command's `fetchAddons` pagination gains the same retry policy as the services (it previously paginated without retry)
- `nodegroup list` keeps its quieter error-level logger on purpose (warnings would garble the spinner output); the other action sites now share the factory default

### Deliberately not done

The plan's last item (migrating `addons/service_test.go`'s `mockEKSClient` to `mocks.EKSAPI`) was dropped on inspection: that mock is a *stateful behavioral fake* (map-backed addon store shared by many tests), not per-test function stubs. Porting it would re-implement the same behavior as closures in every test — more boilerplate, not less.

## Tests

- New table test for `runner.ParseFilters` (incl. malformed tokens and `k=v=extra`)
- New tests for `aws.ListAllPages` (token-following across pages; operation in formatted errors)
- `go build`, `go vet`, `golangci-lint` (0 issues), `go test -race ./...` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
