### PR TITLE
feat: signal cancellation + mechanical hygiene (salvage of #19/#21)

### DIFF
--- a/internal/aws/errors.go
+++ b/internal/aws/errors.go
@@ -195,7 +195,7 @@ func FormatAWSError(err error, operation string) error {
 	}
 
 	// Default case - return the error with context
-	return fmt.Errorf("error while %s: %v", operation, err)
+	return fmt.Errorf("error while %s: %w", operation, err)
 }
 
 func formatRegionError(err error, operation string) error {
@@ -208,7 +208,7 @@ Please verify:
 
 Current error indicates an invalid or unsupported region.
 
-Current error: %v`, operation, err)
+Current error: %w`, operation, err)
 }
 
 func formatCredentialError(err error) error {
@@ -229,7 +229,7 @@ Please set up your AWS credentials using one of these methods:
 4. AWS SSO:
    aws sso login
 
-Current error: %s`, err)
+Current error: %w`, err)
 }
 
 func formatNetworkError(err error, operation string) error {
@@ -241,7 +241,7 @@ Please check:
 - VPC/Security group settings (if running in private network)
 - Regional service availability
 
-Current error: %v`, operation, err)
+Current error: %w`, operation, err)
 }
 
 func formatPermissionError(err error, operation string) error {
@@ -255,13 +255,17 @@ Required permissions for refresh tool:
 - eks:UpdateNodegroupVersion
 - cloudwatch:GetMetricStatistics (for health checks)
 
-Current error: %v`, operation, err)
+Current error: %w`, operation, err)
 }
+
+// credentialValidationTimeout bounds the STS GetCallerIdentity call used to
+// validate credentials, so a misconfigured environment fails fast.
+const credentialValidationTimeout = 10 * time.Second
 
 // ValidateAWSCredentials performs a basic validation of AWS credentials.
 func ValidateAWSCredentials(ctx context.Context, awsCfg aws.Config) error {
 	// Create a short timeout context for validation
-	validationCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	validationCtx, cancel := context.WithTimeout(ctx, credentialValidationTimeout)
 	defer cancel()
 
 	stsClient := sts.NewFromConfig(awsCfg)

--- a/internal/commands/runner/runner.go
+++ b/internal/commands/runner/runner.go
@@ -56,14 +56,21 @@ func setupAWS(c *cli.Context, defaultTimeout time.Duration, check credentialChec
 	if timeout == 0 {
 		timeout = defaultTimeout
 	}
+	// Derive from the CLI's context (cancelled on Ctrl+C / SIGTERM by main) so
+	// signal handling propagates to in-flight AWS calls. c.Context is nil only
+	// for hand-constructed contexts in tests.
+	base := c.Context
+	if base == nil {
+		base = context.Background()
+	}
 	var (
 		ctx    context.Context
 		cancel context.CancelFunc
 	)
 	if timeout > 0 {
-		ctx, cancel = context.WithTimeout(context.Background(), timeout)
+		ctx, cancel = context.WithTimeout(base, timeout)
 	} else {
-		ctx, cancel = context.WithCancel(context.Background())
+		ctx, cancel = context.WithCancel(base)
 	}
 
 	cfg, err := awsconfig.Load(ctx, c)

--- a/internal/commands/runner/runner_test.go
+++ b/internal/commands/runner/runner_test.go
@@ -1,11 +1,64 @@
 package runner
 
 import (
+	"context"
 	"flag"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/urfave/cli/v2"
 )
+
+// ── setupAWS context propagation ──────────────────────────────────────────────
+
+// Regression: setupAWS must derive its context from c.Context (cancelled on
+// Ctrl+C / SIGTERM by main) rather than context.Background(), so signal
+// cancellation propagates to in-flight AWS calls.
+func TestSetupAWS_DerivesFromCLIContext(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	set.Duration("timeout", time.Minute, "")
+	c := cli.NewContext(cli.NewApp(), set, nil)
+	c.Context = parent
+
+	var got context.Context
+	_, cancel, _, err := setupAWS(c, 0, func(ctx context.Context, _ aws.Config) error {
+		got = ctx
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("setupAWS() = %v", err)
+	}
+	defer cancel()
+
+	select {
+	case <-got.Done():
+		t.Fatal("context cancelled prematurely")
+	default:
+	}
+	cancelParent()
+	select {
+	case <-got.Done():
+		// parent cancellation propagated — correct
+	case <-time.After(time.Second):
+		t.Fatal("parent cancellation did not propagate to setupAWS context")
+	}
+}
+
+// setupAWS must tolerate a nil c.Context (hand-constructed contexts in tests).
+func TestSetupAWS_NilCLIContextFallsBack(t *testing.T) {
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	set.Duration("timeout", time.Minute, "")
+	c := cli.NewContext(cli.NewApp(), set, nil)
+	c.Context = nil
+
+	_, cancel, _, err := setupAWS(c, 0, func(context.Context, aws.Config) error { return nil })
+	if err != nil {
+		t.Fatalf("setupAWS() = %v", err)
+	}
+	cancel()
+}
 
 // newTestContext builds a *cli.Context with the given flags pre-registered and
 // args parsed. flags is name→value; "" value means the flag is registered but

--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -18,18 +18,14 @@ var (
 	buildDate = ""    // overridden by GoReleaser: -X ...commands.buildDate={{.Date}}
 )
 
-// VersionInfo provides access to version information
+// VersionInfo provides access to version information. ldflags -X values are
+// applied at link time, so this package-level initializer (which runs after
+// version/commit/buildDate in dependency order) already sees them — no init()
+// re-assignment is needed.
 var VersionInfo = types.VersionInfo{
 	Version:   version,
 	Commit:    commit,
 	BuildDate: buildDate,
-}
-
-func init() {
-	// Update VersionInfo with ldflags values (they're set before init runs)
-	VersionInfo.Version = version
-	VersionInfo.Commit = commit
-	VersionInfo.BuildDate = buildDate
 }
 
 // PrintVersion writes the CLI version details to w. It is the single source of

--- a/internal/dryrun/dryrun.go
+++ b/internal/dryrun/dryrun.go
@@ -77,7 +77,7 @@ func NewDryRunner(ctx context.Context, awsCfg aws.Config, eksClient *eks.Client,
 
 	k8sVersion, err := dryrunDescribeCluster(ctx, eksClient, clusterName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to describe cluster: %v", err)
+		return nil, fmt.Errorf("failed to describe cluster: %w", err)
 	}
 
 	return &DryRunner{

--- a/internal/health/capacity.go
+++ b/internal/health/capacity.go
@@ -15,6 +15,14 @@ import (
 	"github.com/dantech2000/refresh/internal/services/common"
 )
 
+// CPU headroom thresholds for safe rolling updates: at least
+// minSafeCPUHeadroomPercent free is a pass, at least
+// minWarnCPUHeadroomPercent is a warning, anything less is a failure.
+const (
+	minSafeCPUHeadroomPercent = 30.0
+	minWarnCPUHeadroomPercent = 15.0
+)
+
 // CheckClusterCapacity validates that the cluster has sufficient capacity for rolling updates
 func (hc *HealthChecker) CheckClusterCapacity(ctx context.Context, clusterName string) HealthResult {
 	return hc.checkClusterCapacityWith(ctx, hc.newCPUSnapshot(clusterName))
@@ -54,13 +62,12 @@ func (hc *HealthChecker) checkClusterCapacityWith(ctx context.Context, snap *cpu
 	result.Details = append(result.Details, "Memory utilization: Not available (requires Container Insights)")
 
 	// Calculate score based on CPU headroom only
-	// We want at least 30% headroom for safe rolling updates
 	headroom := 100 - avgCPU
-	if headroom >= 30 {
+	if headroom >= minSafeCPUHeadroomPercent {
 		result.Status = StatusPass
 		result.Score = 100
 		result.Message = fmt.Sprintf("Sufficient CPU capacity (%.1f%% utilization)", avgCPU)
-	} else if headroom >= 15 {
+	} else if headroom >= minWarnCPUHeadroomPercent {
 		result.Status = StatusWarn
 		result.Score = 70
 		result.Message = fmt.Sprintf("Limited CPU capacity (%.1f%% utilization)", avgCPU)
@@ -112,7 +119,7 @@ func (hc *HealthChecker) clusterCPUByInstance(ctx context.Context, clusterName s
 
 	instanceIDs, err := hc.getClusterInstanceIDs(ctx, clusterName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get cluster instances: %v", err)
+		return nil, fmt.Errorf("failed to get cluster instances: %w", err)
 	}
 	if len(instanceIDs) == 0 {
 		return nil, fmt.Errorf("no instances found in cluster")
@@ -151,7 +158,7 @@ func (hc *HealthChecker) clusterCPUByInstance(ctx context.Context, clusterName s
 				NextToken:         nextToken,
 			})
 			if err != nil {
-				return nil, fmt.Errorf("fetching CPU metrics: %v", err)
+				return nil, fmt.Errorf("fetching CPU metrics: %w", err)
 			}
 			for _, r := range out.MetricDataResults {
 				var idx int
@@ -208,7 +215,7 @@ func (hc *HealthChecker) getClusterInstanceIDs(ctx context.Context, clusterName 
 		listInput := &eks.ListNodegroupsInput{ClusterName: aws.String(clusterName), NextToken: nextToken}
 		ngOutput, err := hc.eksClient.ListNodegroups(ctx, listInput)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list nodegroups: %v", err)
+			return nil, fmt.Errorf("failed to list nodegroups: %w", err)
 		}
 		nodegroupNames = append(nodegroupNames, ngOutput.Nodegroups...)
 		if ngOutput.NextToken == nil {
@@ -261,7 +268,7 @@ func (hc *HealthChecker) getASGInstanceIDs(ctx context.Context, asgName string) 
 
 	output, err := hc.asgClient.DescribeAutoScalingGroups(ctx, input)
 	if err != nil {
-		return nil, fmt.Errorf("failed to describe ASG %s: %v", asgName, err)
+		return nil, fmt.Errorf("failed to describe ASG %s: %w", asgName, err)
 	}
 
 	if len(output.AutoScalingGroups) == 0 {

--- a/internal/monitoring/monitor.go
+++ b/internal/monitoring/monitor.go
@@ -4,6 +4,7 @@ package monitoring
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -73,6 +74,12 @@ func MonitorUpdates(ctx context.Context, eksClient *eks.Client, monitor *refresh
 			return handleUserCancellation(monitor, config)
 
 		case <-monitorCtx.Done():
+			// The parent context is cancelled by main on Ctrl+C / SIGTERM, which
+			// races with sigChan above — treat plain cancellation as the user
+			// stopping, and only a deadline as a timeout.
+			if errors.Is(monitorCtx.Err(), context.Canceled) {
+				return handleUserCancellation(monitor, config)
+			}
 			return handleTimeout(config)
 
 		case <-ticker.C:

--- a/internal/services/addons/service.go
+++ b/internal/services/addons/service.go
@@ -16,6 +16,15 @@ import (
 	"github.com/dantech2000/refresh/internal/services/common"
 )
 
+const (
+	// maxParallelAddonUpdates caps concurrent UpdateAddon calls when
+	// UpdateOptions.Parallel is set.
+	maxParallelAddonUpdates = 3
+	// addonUpdatePollInterval is how often waitForAddonUpdate re-checks an
+	// in-flight addon update.
+	addonUpdatePollInterval = 5 * time.Second
+)
+
 // EKSAPI abstracts the EKS client methods used for addons
 type EKSAPI interface {
 	ListAddons(ctx context.Context, params *eks.ListAddonsInput, optFns ...func(*eks.Options)) (*eks.ListAddonsOutput, error)
@@ -296,7 +305,7 @@ func (s *ServiceImpl) UpdateAll(ctx context.Context, clusterName string, options
 	results := make([]AddonUpdateResult, len(toUpdate))
 	if options.Parallel {
 		var wg sync.WaitGroup
-		semaphore := make(chan struct{}, 3)
+		semaphore := make(chan struct{}, maxParallelAddonUpdates)
 		for i, addon := range toUpdate {
 			// Acquire BEFORE spawning so the cap limits live goroutines, not
 			// just in-flight API calls. Matches cluster.ListAllRegionsWithMeta.

--- a/internal/services/addons/version_analyzer.go
+++ b/internal/services/addons/version_analyzer.go
@@ -104,7 +104,7 @@ func compareAddonVersions(a, b string) int {
 
 // waitForAddonUpdate polls until an addon update completes.
 func (s *ServiceImpl) waitForAddonUpdate(ctx context.Context, clusterName, addonName string) error {
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(addonUpdatePollInterval)
 	defer ticker.Stop()
 
 	for {

--- a/internal/services/cluster/service.go
+++ b/internal/services/cluster/service.go
@@ -48,6 +48,10 @@ const (
 	// Default cache TTLs (override via env if needed in future)
 	defaultCacheTTLDescribe = 5 * time.Minute
 	defaultCacheTTLList     = 2 * time.Minute
+
+	// defaultRegionListConcurrency caps concurrent per-region List calls in
+	// ListAllRegionsWithMeta when no --max-concurrency is given.
+	defaultRegionListConcurrency = 8
 )
 
 // NewService creates a new cluster service instance
@@ -318,7 +322,7 @@ func (s *ServiceImpl) ListAllRegionsWithMeta(ctx context.Context, options ListOp
 	eksRegions := s.resolveRegions(options)
 	maxConc := options.MaxConcurrency
 	if maxConc <= 0 {
-		maxConc = 8
+		maxConc = defaultRegionListConcurrency
 	}
 
 	type regionResult struct {

--- a/internal/services/nodegroup/cost_analyzer.go
+++ b/internal/services/nodegroup/cost_analyzer.go
@@ -14,6 +14,10 @@ import (
 	"github.com/dantech2000/refresh/internal/services/common"
 )
 
+// defaultCostCacheTTL is how long pricing lookups are cached; on-demand
+// prices change rarely, so a long TTL is safe.
+const defaultCostCacheTTL = 60 * time.Minute
+
 type CostAnalyzer struct {
 	pricing  *pricing.Client
 	logger   *slog.Logger
@@ -23,7 +27,7 @@ type CostAnalyzer struct {
 }
 
 func NewCostAnalyzer(p *pricing.Client, logger *slog.Logger, cache *Cache, region string) *CostAnalyzer {
-	return &CostAnalyzer{pricing: p, logger: logger, cache: cache, cacheTTL: 60 * time.Minute, region: region}
+	return &CostAnalyzer{pricing: p, logger: logger, cache: cache, cacheTTL: defaultCostCacheTTL, region: region}
 }
 
 // EstimateOnDemandUSD returns monthly and per-hour costs for an instance type (Linux/on-demand).

--- a/internal/services/nodegroup/nodegroup_scale.go
+++ b/internal/services/nodegroup/nodegroup_scale.go
@@ -14,6 +14,10 @@ import (
 	awsinternal "github.com/dantech2000/refresh/internal/aws"
 )
 
+// scalePollInterval is how often waitForScaleCompletion re-checks nodegroup
+// status while waiting for a scaling operation to finish.
+const scalePollInterval = 5 * time.Second
+
 // Scale updates the desired/min/max size for a nodegroup.
 func (s *ServiceImpl) Scale(ctx context.Context, clusterName, nodegroupName string, desired, min, max *int32, options ScaleOptions) error {
 	s.logger.Info("scaling nodegroup", "cluster", clusterName, "nodegroup", nodegroupName,
@@ -102,7 +106,7 @@ func (s *ServiceImpl) waitForScaleCompletion(ctx context.Context, clusterName, n
 		waitCtx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(scalePollInterval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/internal/services/nodegroup/utilization.go
+++ b/internal/services/nodegroup/utilization.go
@@ -14,6 +14,10 @@ import (
 	"github.com/dantech2000/refresh/internal/services/common"
 )
 
+// defaultUtilizationCacheTTL is how long CloudWatch utilization metrics are
+// cached; kept short so repeated commands still reflect recent load.
+const defaultUtilizationCacheTTL = 2 * time.Minute
+
 type UtilizationCollector struct {
 	cw       *cloudwatch.Client
 	logger   *slog.Logger
@@ -22,7 +26,7 @@ type UtilizationCollector struct {
 }
 
 func NewUtilizationCollector(cw *cloudwatch.Client, logger *slog.Logger, cache *Cache) *UtilizationCollector {
-	return &UtilizationCollector{cw: cw, logger: logger, cache: cache, cacheTTL: 2 * time.Minute}
+	return &UtilizationCollector{cw: cw, logger: logger, cache: cache, cacheTTL: defaultUtilizationCacheTTL}
 }
 
 // metricSpec describes one CloudWatch metric to fetch per instance.

--- a/main.go
+++ b/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"regexp"
+	"syscall"
 
 	"github.com/fatih/color"
 	"github.com/pterm/pterm"
@@ -105,7 +108,7 @@ func newApp() *cli.App {
 	}
 }
 
-func run(args []string, out, errOut io.Writer) error {
+func run(ctx context.Context, args []string, out, errOut io.Writer) error {
 	// Set custom help printer for colored output
 	cli.HelpPrinter = coloredHelpPrinter
 
@@ -117,11 +120,18 @@ func run(args []string, out, errOut io.Writer) error {
 	app := newApp()
 	app.Writer = out
 	app.ErrWriter = errOut
-	return app.Run(args)
+	// RunContext threads ctx into every command's c.Context, so signal
+	// cancellation from main propagates to in-flight AWS calls.
+	return app.RunContext(ctx, args)
 }
 
 func main() {
-	if err := run(os.Args, os.Stdout, os.Stderr); err != nil {
+	// Cancel the root context on Ctrl+C / SIGTERM so in-flight AWS calls are
+	// aborted instead of running to their timeout.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx, os.Args, os.Stdout, os.Stderr); err != nil {
 		// Errors belong on stderr: scripted consumers piping stdout must not
 		// find error text mixed into their data.
 		fmt.Fprintln(os.Stderr, color.RedString("Error: %v", err))

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -225,7 +226,7 @@ func TestNewAppAndRun(t *testing.T) {
 	}
 
 	var out, errOut bytes.Buffer
-	if err := run([]string{"refresh", "version"}, &out, &errOut); err != nil {
+	if err := run(context.Background(), []string{"refresh", "version"}, &out, &errOut); err != nil {
 		t.Fatalf("run version: %v", err)
 	}
 	if !strings.Contains(out.String(), "refresh version:") {
@@ -234,7 +235,7 @@ func TestNewAppAndRun(t *testing.T) {
 
 	// The global --version flag must produce the same output as the subcommand.
 	out.Reset()
-	if err := run([]string{"refresh", "--version"}, &out, &errOut); err != nil {
+	if err := run(context.Background(), []string{"refresh", "--version"}, &out, &errOut); err != nil {
 		t.Fatalf("run --version: %v", err)
 	}
 	if !strings.Contains(out.String(), "refresh version:") {
@@ -242,7 +243,7 @@ func TestNewAppAndRun(t *testing.T) {
 	}
 
 	out.Reset()
-	if err := run([]string{"refresh", "--timeout", "not-a-duration", "version"}, &out, &errOut); err == nil {
+	if err := run(context.Background(), []string{"refresh", "--timeout", "not-a-duration", "version"}, &out, &errOut); err == nil {
 		t.Fatal("expected invalid flag error")
 	}
 }


### PR DESCRIPTION
## What

The #24 full-app refactor already absorbed PRs #18 and #20 outright, plus the dryrun-context portion of #19. This PR reimplements the parts of **#19** and **#21** that the refactor did *not* cover, freshly on top of current `main` (cleaner than rebasing those branches through the refactor conflicts).

### Signal cancellation (from #19) — the real user-facing win
Before this, Ctrl+C killed the process via the default handler without cancelling in-flight AWS calls.
- `main.go`: install `signal.NotifyContext(SIGINT/SIGTERM)` and run via `app.RunContext`, so every command handler gets a cancellable `c.Context`
- `runner.setupAWS`: derive the command context from `c.Context` instead of `context.Background()` — signal cancellation now propagates to all AWS SDK calls (nil-Context fallback kept for hand-constructed test contexts)
- `monitoring`: treat `context.Canceled` as user cancellation so the friendly "monitoring cancelled, updates continue in AWS" message wins over a misleading "timeout reached"
- New regression tests: parent-cancellation propagation + nil-context fallback

### Mechanical hygiene (from #21) — no behavior change
- `%v` → `%w` error wrapping in `aws/errors.go`, `dryrun.go`, `health/capacity.go` so `errors.Is`/`errors.As` work for callers (`fmt.Sprintf` sites left as `%v` — Sprintf can't take `%w`)
- Remove redundant `init()` in `commands/version.go` (ldflags `-X` applied at link time; the package-level initializer already sees them)
- Name behavior-critical magic numbers: `maxParallelAddonUpdates`, `addonUpdatePollInterval`, `scalePollInterval`, `defaultCostCacheTTL`, `defaultUtilizationCacheTTL`, `defaultRegionListConcurrency`, `credentialValidationTimeout`, `min{Safe,Warn}CPUHeadroomPercent`

## Supersedes
- Closes #19 (signal/context plumbing) — salvaged here; dryrun-context part already in #24
- Closes #21 (mechanical hygiene) — salvaged here

## Tests
`go build`, `go vet`, `gofmt`, `golangci-lint` (0 issues), `go test -race ./...` — all green.

Note: end-to-end Ctrl-C-aborts-AWS behavior is unit-tested at the wiring level; a manual check with real credentials (`refresh cluster list` + Ctrl-C) is a good extra validation before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
