### PR TITLE
feat: refresh cluster upgrade — the upgrade orchestrator (REF-81)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,9 @@ command (CLI wiring)  internal/commands/{cluster,nodegroup,addon,ctxcmd,workload
 Supporting packages: `internal/aws` (SDK abstractions, error formatting), `internal/awsconfig`
 (unified config loading), `internal/cliconfig` (YAML context store), `internal/health`
 (pre-flight checks), `internal/monitoring` (update progress), `internal/dryrun`,
-`internal/types`, `internal/mocks`.
+`internal/types`, `internal/mocks`, `internal/services/upgrade` (cluster upgrade
+orchestrator: plan generation + control-plane/addon/nodegroup phases + sequencing
+engine; resumable by re-deriving the plan from live cluster state, not state files).
 
 ## Conventions (follow these when editing)
 

--- a/README.md
+++ b/README.md
@@ -406,6 +406,40 @@ refresh cluster diff -c prod -c staging --interactive
 The picker lets you space-toggle clusters and confirm with Enter. At least 2 must
 be selected for the comparison to proceed.
 
+#### Upgrade Cluster (Orchestrated)
+
+Plan and execute a full cluster upgrade — control plane, then addons in
+dependency order (versions compatible with the *target* Kubernetes version),
+then nodegroup rolls — with a health gate after every phase:
+
+```bash
+# Print the full ordered plan without mutating anything
+# (exits non-zero if anything blocks the upgrade)
+refresh cluster upgrade -c prod-east --to 1.33 --dry-run
+
+# Execute, confirming each mutating phase
+refresh cluster upgrade -c prod-east --to 1.33
+
+# Non-interactive (CI) run, skipping a Helm-managed addon
+refresh cluster upgrade -c prod-east --to 1.33 --yes --skip aws-ebs-csi-driver
+
+# Leave specific nodegroups alone
+refresh cluster upgrade -c prod-east --to 1.33 --skip-nodegroup spot-
+```
+
+Key behaviors:
+
+- **Sequential minors** — EKS upgrades one minor at a time, so `--to 1.33` from
+  1.31 expands into two hops (1.32, then 1.33), each with its own gates.
+- **Readiness gates** — each hop checks EKS Cluster Insights (upgrade
+  readiness) and kubelet version skew before touching anything; blockers
+  render in the plan and the command exits non-zero without mutating.
+- **Resumable by re-derivation** — no state files. Rerunning the same command
+  re-inspects the cluster and skips already-satisfied steps, so resuming after
+  a failure or Ctrl+C (in-flight EKS updates continue server-side) is just
+  running the command again; rerunning after success is a no-op.
+- **Custom-AMI nodegroups** are surfaced as manual actions, never mutated.
+
 ### Nodegroup Management
 
 #### List Nodegroups

--- a/internal/aws/errors.go
+++ b/internal/aws/errors.go
@@ -253,6 +253,10 @@ Required permissions for refresh tool:
 - eks:ListNodegroups
 - eks:DescribeNodegroup
 - eks:UpdateNodegroupVersion
+- eks:UpdateClusterVersion (for cluster upgrade)
+- eks:DescribeUpdate (for cluster upgrade)
+- eks:DescribeClusterVersions (for cluster upgrade)
+- eks:ListInsights (for cluster upgrade readiness)
 - cloudwatch:GetMetricStatistics (for health checks)
 
 Current error: %w`, operation, err)

--- a/internal/commands/cluster/command.go
+++ b/internal/commands/cluster/command.go
@@ -14,11 +14,12 @@ import (
 func Command() *cli.Command {
 	return &cli.Command{
 		Name:  "cluster",
-		Usage: "Cluster operations (list, get, diff)",
+		Usage: "Cluster operations (list, get, diff, upgrade)",
 		Commands: []*cli.Command{
 			listCommand(),
 			describeCommand(),
 			diffCommand(),
+			upgradeCommand(),
 		},
 	}
 }

--- a/internal/commands/cluster/upgrade.go
+++ b/internal/commands/cluster/upgrade.go
@@ -1,0 +1,226 @@
+package cluster
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/fatih/color"
+	"github.com/urfave/cli/v3"
+
+	"github.com/dantech2000/refresh/internal/commands/factory"
+	"github.com/dantech2000/refresh/internal/commands/runner"
+	"github.com/dantech2000/refresh/internal/services/upgrade"
+	"github.com/dantech2000/refresh/internal/ui"
+)
+
+// upgradeDefaultTimeout bounds a full orchestrated upgrade. Control-plane
+// hops run ~10m each and nodegroup rolls ~10-20m per group, so multi-hop
+// upgrades legitimately run for hours.
+const upgradeDefaultTimeout = 4 * time.Hour
+
+func upgradeCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "upgrade",
+		Usage:     "Orchestrate a cluster upgrade: control plane → addons → nodegroups, with gates",
+		ArgsUsage: "[cluster]",
+		Description: `Plan and execute a full EKS cluster upgrade to a target Kubernetes version.
+
+EKS upgrades one minor version at a time, so a multi-minor upgrade expands
+into sequential hops. Each hop runs: readiness (cluster insights + kubelet
+version skew) → control plane → addons (dependency order, versions compatible
+with the hop target) → nodegroup rolls, with a health gate after every phase.
+
+The plan is re-derived from live cluster state on every run, so rerunning the
+same command after a failure (or Ctrl+C) resumes where it left off, and
+rerunning after success is a no-op.
+
+Examples:
+   # Print the plan only (exits non-zero if anything blocks the upgrade)
+   refresh cluster upgrade -c prod-east --to 1.33 --dry-run
+
+   # Execute, confirming each mutating phase
+   refresh cluster upgrade -c prod-east --to 1.33
+
+   # Non-interactive (CI) run
+   refresh cluster upgrade -c prod-east --to 1.33 --yes`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "cluster", Aliases: []string{"c"}, Usage: "EKS cluster name or pattern"},
+			&cli.StringFlag{Name: "to", Usage: "Target Kubernetes version (e.g. 1.33)", Required: true},
+			&cli.BoolFlag{Name: "dry-run", Aliases: []string{"d"}, Usage: "Print the full ordered plan without mutating anything"},
+			&cli.BoolFlag{Name: "yes", Aliases: []string{"y"}, Usage: "Skip per-phase confirmation prompts"},
+			&cli.BoolFlag{Name: "force", Usage: "Force nodegroup rolls when pods can't be drained due to PDBs"},
+			&cli.StringSliceFlag{Name: "skip", Aliases: []string{"s"}, Usage: "Addon to skip (repeatable; for addons managed via Helm/GitOps)"},
+			&cli.StringSliceFlag{Name: "skip-nodegroup", Usage: "Nodegroup name pattern to skip (repeatable)"},
+			&cli.BoolFlag{Name: "quiet", Aliases: []string{"q"}, Usage: "Suppress progress output"},
+			&cli.DurationFlag{Name: "timeout", Aliases: []string{"t"}, Usage: "Overall operation timeout", Value: upgradeDefaultTimeout, Sources: cli.EnvVars("REFRESH_TIMEOUT")},
+			&cli.DurationFlag{Name: "poll-interval", Aliases: []string{"p"}, Usage: "How often to poll in-flight updates", Value: 15 * time.Second},
+			&cli.StringFlag{Name: "format", Aliases: []string{"o"}, Usage: "Plan output format (table, json, yaml, plain)", Value: "table"},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error { return runUpgrade(ctx, cmd) },
+	}
+}
+
+func runUpgrade(ctx context.Context, cmd *cli.Command) error {
+	// Strict credential validation: this command mutates the control plane.
+	ctx, cancel, awsCfg, err := runner.SetupAWSStrict(ctx, cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	clusterName, listed, err := runner.ResolveClusterOrList(ctx, awsCfg, cmd)
+	if err != nil || listed {
+		return err
+	}
+
+	svc := upgrade.NewService(eks.NewFromConfig(awsCfg), factory.NewDefaultLogger(nil))
+	if pi := cmd.Duration("poll-interval"); pi > 0 {
+		svc.PollInterval = pi
+	}
+
+	planOpts := upgrade.PlanOptions{
+		SkipAddons:     cmd.StringSlice("skip"),
+		SkipNodegroups: cmd.StringSlice("skip-nodegroup"),
+	}
+
+	var plan *upgrade.Plan
+	err = runner.WithSpinner("cluster", "Upgrade plan computed!", func() error {
+		var perr error
+		plan, perr = svc.BuildPlan(ctx, clusterName, cmd.String("to"), planOpts)
+		return perr
+	})
+	if err != nil {
+		return err
+	}
+
+	format := cmd.String("format")
+	if handled, eerr := runner.EncodeStdout(format, plan); handled || eerr != nil {
+		if eerr != nil {
+			return eerr
+		}
+		if plan.Blocked() {
+			return cli.Exit("", 1)
+		}
+		if cmd.Bool("dry-run") {
+			return nil
+		}
+	} else {
+		renderPlan(plan)
+	}
+
+	// A plan with blockers prints and exits non-zero without mutating.
+	if plan.Blocked() {
+		return cli.Exit(color.RedString("Upgrade blocked — resolve the blockers above and re-run."), 1)
+	}
+	if cmd.Bool("dry-run") {
+		return nil
+	}
+	if plan.PendingSteps() == 0 {
+		ui.Outln()
+		ui.Outf("Nothing to do: %s already satisfies %s.\n", clusterName, plan.TargetVersion)
+		return nil
+	}
+
+	progress := func(format string, args ...any) {
+		if !cmd.Bool("quiet") {
+			ui.Outf("  "+format+"\n", args...)
+		}
+	}
+
+	report, err := svc.Execute(ctx, plan, upgrade.ExecuteOptions{
+		Yes:            cmd.Bool("yes"),
+		Confirm:        promptPhase,
+		Progress:       progress,
+		SkipAddons:     cmd.StringSlice("skip"),
+		SkipNodegroups: cmd.StringSlice("skip-nodegroup"),
+		Force:          cmd.Bool("force"),
+	})
+
+	renderReport(report)
+	if err != nil {
+		resume := fmt.Sprintf("refresh cluster upgrade -c %s --to %s", clusterName, plan.TargetVersion)
+		ui.Outln()
+		ui.Outf("Resume with: %s\n", color.CyanString(resume))
+		return err
+	}
+
+	ui.Outln()
+	ui.Outf("%s\n", color.GreenString("Upgrade complete: %s is at %s.", clusterName, plan.TargetVersion))
+	return nil
+}
+
+// promptPhase asks for confirmation before a mutating phase. Bare Enter or a
+// read error declines (safe default).
+func promptPhase(label string) bool {
+	fmt.Printf("\nProceed with %s? (y/N): ", label)
+	reader := bufio.NewReader(os.Stdin)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	return answer == "y" || answer == "yes"
+}
+
+// renderPlan prints the human-readable plan.
+func renderPlan(plan *upgrade.Plan) {
+	ui.Outln()
+	path := plan.CurrentVersion
+	for _, hop := range plan.Hops {
+		path += " → " + hop.To
+	}
+	ui.Outf("Upgrade plan: %s %s (EKS upgrades are sequential minors)\n", color.New(color.Bold).Sprint(plan.ClusterName), path)
+
+	for _, w := range plan.Warnings {
+		ui.Outf("  %s %s\n", color.YellowString("▸ warning:"), w)
+	}
+
+	for _, hop := range plan.Hops {
+		ui.Outln()
+		ui.Outf("%s\n", color.New(color.Bold).Sprintf("Hop %s → %s", hop.From, hop.To))
+		for i, step := range hop.Steps {
+			marker, note := stepMarkerAndNote(step)
+			line := fmt.Sprintf("  %2d. %s %s", i+1, marker, step.Description)
+			if note != "" {
+				line += " — " + note
+			}
+			ui.Outf("%s\n", line)
+		}
+	}
+}
+
+// stepMarkerAndNote maps a step's status to its display marker and note.
+func stepMarkerAndNote(step upgrade.Step) (string, string) {
+	switch step.Status {
+	case upgrade.StatusCompleted:
+		return color.GreenString("[done]   "), step.Reason
+	case upgrade.StatusBlocked:
+		return color.RedString("[BLOCKED]"), step.Reason
+	case upgrade.StatusManual:
+		return color.YellowString("[manual] "), step.Reason
+	default:
+		return color.CyanString("[pending]"), step.Reason
+	}
+}
+
+// renderReport prints the completed / failed-at / remaining summary.
+func renderReport(report *upgrade.Report) {
+	if report == nil {
+		return
+	}
+	ui.Outln()
+	for _, c := range report.Completed {
+		ui.Outf("%s %s\n", color.GreenString("completed:"), c)
+	}
+	if report.FailedAt != "" {
+		ui.Outf("%s %s\n", color.RedString("failed at:"), report.FailedAt)
+	}
+	for _, r := range report.Remaining {
+		ui.Outf("%s %s\n", color.YellowString("remaining:"), r)
+	}
+}

--- a/internal/mocks/builders.go
+++ b/internal/mocks/builders.go
@@ -29,6 +29,23 @@ func NewEKSAPI() *EKSAPIBuilder {
 	b.m.ListNodegroupsFn = func(_ context.Context, _ *eks.ListNodegroupsInput, _ ...func(*eks.Options)) (*eks.ListNodegroupsOutput, error) {
 		return &eks.ListNodegroupsOutput{}, nil
 	}
+	b.m.ListInsightsFn = func(_ context.Context, _ *eks.ListInsightsInput, _ ...func(*eks.Options)) (*eks.ListInsightsOutput, error) {
+		return &eks.ListInsightsOutput{}, nil
+	}
+	b.m.DescribeAddonVersionsFn = func(_ context.Context, _ *eks.DescribeAddonVersionsInput, _ ...func(*eks.Options)) (*eks.DescribeAddonVersionsOutput, error) {
+		return &eks.DescribeAddonVersionsOutput{}, nil
+	}
+	// Echo requested versions back as offered, so upgrade tests don't all
+	// need to enumerate the EKS version catalogue.
+	b.m.DescribeClusterVersionsFn = func(_ context.Context, in *eks.DescribeClusterVersionsInput, _ ...func(*eks.Options)) (*eks.DescribeClusterVersionsOutput, error) {
+		out := &eks.DescribeClusterVersionsOutput{}
+		for _, v := range in.ClusterVersions {
+			out.ClusterVersions = append(out.ClusterVersions, ekstypes.ClusterVersionInformation{
+				ClusterVersion: aws.String(v),
+			})
+		}
+		return out, nil
+	}
 
 	return b
 }
@@ -115,6 +132,116 @@ func (b *EKSAPIBuilder) WithUpdateAddon(updateID string) *EKSAPIBuilder {
 			Update: &ekstypes.Update{
 				Id:     aws.String(updateID),
 				Status: ekstypes.UpdateStatusInProgress,
+			},
+		}, nil
+	}
+	return b
+}
+
+// WithNodegroup registers a nodegroup so ListNodegroups includes it and
+// DescribeNodegroup returns its details (ACTIVE, no health issues). Calling
+// WithNodegroup multiple times accumulates nodegroups in order.
+func (b *EKSAPIBuilder) WithNodegroup(name, k8sVersion string, amiType ekstypes.AMITypes) *EKSAPIBuilder {
+	prevList := b.m.ListNodegroupsFn
+	prevDescribe := b.m.DescribeNodegroupFn
+
+	b.m.ListNodegroupsFn = func(ctx context.Context, in *eks.ListNodegroupsInput, opts ...func(*eks.Options)) (*eks.ListNodegroupsOutput, error) {
+		out, err := prevList(ctx, in, opts...)
+		if err != nil {
+			return nil, err
+		}
+		out.Nodegroups = append(out.Nodegroups, name)
+		return out, nil
+	}
+
+	b.m.DescribeNodegroupFn = func(ctx context.Context, in *eks.DescribeNodegroupInput, opts ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error) {
+		if aws.ToString(in.NodegroupName) == name {
+			return &eks.DescribeNodegroupOutput{
+				Nodegroup: &ekstypes.Nodegroup{
+					NodegroupName: aws.String(name),
+					Version:       aws.String(k8sVersion),
+					AmiType:       amiType,
+					Status:        ekstypes.NodegroupStatusActive,
+				},
+			}, nil
+		}
+		if prevDescribe != nil {
+			return prevDescribe(ctx, in, opts...)
+		}
+		return nil, &ekstypes.ResourceNotFoundException{Message: aws.String("nodegroup not found: " + aws.ToString(in.NodegroupName))}
+	}
+	return b
+}
+
+// WithInsight registers an UPGRADE_READINESS insight returned for the given
+// Kubernetes version. Calling WithInsight multiple times accumulates.
+func (b *EKSAPIBuilder) WithInsight(name string, status ekstypes.InsightStatusValue, k8sVersion string) *EKSAPIBuilder {
+	prev := b.m.ListInsightsFn
+
+	b.m.ListInsightsFn = func(ctx context.Context, in *eks.ListInsightsInput, opts ...func(*eks.Options)) (*eks.ListInsightsOutput, error) {
+		out, err := prev(ctx, in, opts...)
+		if err != nil {
+			return nil, err
+		}
+		if in.Filter != nil && len(in.Filter.KubernetesVersions) > 0 {
+			match := false
+			for _, v := range in.Filter.KubernetesVersions {
+				if v == k8sVersion {
+					match = true
+				}
+			}
+			if !match {
+				return out, nil
+			}
+		}
+		out.Insights = append(out.Insights, ekstypes.InsightSummary{
+			Name:          aws.String(name),
+			Category:      ekstypes.CategoryUpgradeReadiness,
+			InsightStatus: &ekstypes.InsightStatus{Status: status},
+		})
+		return out, nil
+	}
+	return b
+}
+
+// WithUpdateClusterVersion sets UpdateClusterVersion to return a successful
+// in-progress update with the given ID.
+func (b *EKSAPIBuilder) WithUpdateClusterVersion(updateID string) *EKSAPIBuilder {
+	b.m.UpdateClusterVersionFn = func(_ context.Context, _ *eks.UpdateClusterVersionInput, _ ...func(*eks.Options)) (*eks.UpdateClusterVersionOutput, error) {
+		return &eks.UpdateClusterVersionOutput{
+			Update: &ekstypes.Update{
+				Id:     aws.String(updateID),
+				Status: ekstypes.UpdateStatusInProgress,
+				Type:   ekstypes.UpdateTypeVersionUpdate,
+			},
+		}, nil
+	}
+	return b
+}
+
+// WithUpdateNodegroupVersion sets UpdateNodegroupVersion to return a
+// successful in-progress update with the given ID.
+func (b *EKSAPIBuilder) WithUpdateNodegroupVersion(updateID string) *EKSAPIBuilder {
+	b.m.UpdateNodegroupVersionFn = func(_ context.Context, _ *eks.UpdateNodegroupVersionInput, _ ...func(*eks.Options)) (*eks.UpdateNodegroupVersionOutput, error) {
+		return &eks.UpdateNodegroupVersionOutput{
+			Update: &ekstypes.Update{
+				Id:     aws.String(updateID),
+				Status: ekstypes.UpdateStatusInProgress,
+				Type:   ekstypes.UpdateTypeVersionUpdate,
+			},
+		}, nil
+	}
+	return b
+}
+
+// WithDescribeUpdate sets DescribeUpdate to report every update with the
+// given terminal status.
+func (b *EKSAPIBuilder) WithDescribeUpdate(status ekstypes.UpdateStatus) *EKSAPIBuilder {
+	b.m.DescribeUpdateFn = func(_ context.Context, in *eks.DescribeUpdateInput, _ ...func(*eks.Options)) (*eks.DescribeUpdateOutput, error) {
+		return &eks.DescribeUpdateOutput{
+			Update: &ekstypes.Update{
+				Id:     in.UpdateId,
+				Status: status,
 			},
 		}, nil
 	}

--- a/internal/mocks/eksapi.go
+++ b/internal/mocks/eksapi.go
@@ -30,21 +30,32 @@ type EKSAPI struct {
 	UpdateNodegroupConfigFn func(ctx context.Context, in *eks.UpdateNodegroupConfigInput, optFns ...func(*eks.Options)) (*eks.UpdateNodegroupConfigOutput, error)
 	ListClustersFn          func(ctx context.Context, in *eks.ListClustersInput, optFns ...func(*eks.Options)) (*eks.ListClustersOutput, error)
 
+	UpdateClusterVersionFn    func(ctx context.Context, in *eks.UpdateClusterVersionInput, optFns ...func(*eks.Options)) (*eks.UpdateClusterVersionOutput, error)
+	UpdateNodegroupVersionFn  func(ctx context.Context, in *eks.UpdateNodegroupVersionInput, optFns ...func(*eks.Options)) (*eks.UpdateNodegroupVersionOutput, error)
+	DescribeUpdateFn          func(ctx context.Context, in *eks.DescribeUpdateInput, optFns ...func(*eks.Options)) (*eks.DescribeUpdateOutput, error)
+	DescribeClusterVersionsFn func(ctx context.Context, in *eks.DescribeClusterVersionsInput, optFns ...func(*eks.Options)) (*eks.DescribeClusterVersionsOutput, error)
+	ListInsightsFn            func(ctx context.Context, in *eks.ListInsightsInput, optFns ...func(*eks.Options)) (*eks.ListInsightsOutput, error)
+
 	// mu guards Calls: services fan out describe calls concurrently, so the
 	// counters must be safe to increment from multiple goroutines. Read them
 	// only after the operation under test has returned.
 	mu sync.Mutex
 
 	Calls struct {
-		ListAddons            int
-		DescribeAddon         int
-		DescribeAddonVersions int
-		UpdateAddon           int
-		DescribeCluster       int
-		ListNodegroups        int
-		DescribeNodegroup     int
-		UpdateNodegroupConfig int
-		ListClusters          int
+		ListAddons              int
+		DescribeAddon           int
+		DescribeAddonVersions   int
+		UpdateAddon             int
+		DescribeCluster         int
+		ListNodegroups          int
+		DescribeNodegroup       int
+		UpdateNodegroupConfig   int
+		ListClusters            int
+		UpdateClusterVersion    int
+		UpdateNodegroupVersion  int
+		DescribeUpdate          int
+		DescribeClusterVersions int
+		ListInsights            int
 	}
 }
 
@@ -118,6 +129,46 @@ func (m *EKSAPI) ListClusters(ctx context.Context, in *eks.ListClustersInput, op
 		panic("mocks.EKSAPI: unexpected call to ListClusters")
 	}
 	return m.ListClustersFn(ctx, in, optFns...)
+}
+
+func (m *EKSAPI) UpdateClusterVersion(ctx context.Context, in *eks.UpdateClusterVersionInput, optFns ...func(*eks.Options)) (*eks.UpdateClusterVersionOutput, error) {
+	m.inc(&m.Calls.UpdateClusterVersion)
+	if m.UpdateClusterVersionFn == nil {
+		panic(fmt.Sprintf("mocks.EKSAPI: unexpected call to UpdateClusterVersion (cluster=%s)", ptrStr(in.Name)))
+	}
+	return m.UpdateClusterVersionFn(ctx, in, optFns...)
+}
+
+func (m *EKSAPI) UpdateNodegroupVersion(ctx context.Context, in *eks.UpdateNodegroupVersionInput, optFns ...func(*eks.Options)) (*eks.UpdateNodegroupVersionOutput, error) {
+	m.inc(&m.Calls.UpdateNodegroupVersion)
+	if m.UpdateNodegroupVersionFn == nil {
+		panic(fmt.Sprintf("mocks.EKSAPI: unexpected call to UpdateNodegroupVersion (ng=%s)", ptrStr(in.NodegroupName)))
+	}
+	return m.UpdateNodegroupVersionFn(ctx, in, optFns...)
+}
+
+func (m *EKSAPI) DescribeUpdate(ctx context.Context, in *eks.DescribeUpdateInput, optFns ...func(*eks.Options)) (*eks.DescribeUpdateOutput, error) {
+	m.inc(&m.Calls.DescribeUpdate)
+	if m.DescribeUpdateFn == nil {
+		panic(fmt.Sprintf("mocks.EKSAPI: unexpected call to DescribeUpdate (id=%s)", ptrStr(in.UpdateId)))
+	}
+	return m.DescribeUpdateFn(ctx, in, optFns...)
+}
+
+func (m *EKSAPI) DescribeClusterVersions(ctx context.Context, in *eks.DescribeClusterVersionsInput, optFns ...func(*eks.Options)) (*eks.DescribeClusterVersionsOutput, error) {
+	m.inc(&m.Calls.DescribeClusterVersions)
+	if m.DescribeClusterVersionsFn == nil {
+		panic("mocks.EKSAPI: unexpected call to DescribeClusterVersions")
+	}
+	return m.DescribeClusterVersionsFn(ctx, in, optFns...)
+}
+
+func (m *EKSAPI) ListInsights(ctx context.Context, in *eks.ListInsightsInput, optFns ...func(*eks.Options)) (*eks.ListInsightsOutput, error) {
+	m.inc(&m.Calls.ListInsights)
+	if m.ListInsightsFn == nil {
+		panic(fmt.Sprintf("mocks.EKSAPI: unexpected call to ListInsights (cluster=%s)", ptrStr(in.ClusterName)))
+	}
+	return m.ListInsightsFn(ctx, in, optFns...)
 }
 
 func (m *EKSAPI) inc(counter *int) {

--- a/internal/services/addons/addon_dependencies.go
+++ b/internal/services/addons/addon_dependencies.go
@@ -28,6 +28,13 @@ var addonDependencies = map[string][]string{
 	"aws-guardduty-agent": {"vpc-cni"},
 }
 
+// SortByDependency returns the addons reordered so that dependencies update
+// before their dependents (vpc-cni before coredns/kube-proxy, etc.). Exported
+// for the upgrade orchestrator, which sequences per-addon updates itself.
+func SortByDependency(addons []AddonSummary) []AddonSummary {
+	return sortByDependency(addons)
+}
+
 // sortByDependency returns addons in a safe update order using Kahn's algorithm.
 // Addons absent from the dependency map are treated as having no deps and are
 // appended after the ordered set.

--- a/internal/services/addons/service.go
+++ b/internal/services/addons/service.go
@@ -241,7 +241,7 @@ func (s *ServiceImpl) Update(ctx context.Context, clusterName, addonName string,
 			waitCtx, cancel = context.WithTimeout(ctx, options.WaitTimeout)
 			defer cancel()
 		}
-		if err := s.waitForAddonUpdate(waitCtx, clusterName, addonName); err != nil {
+		if err := s.waitForAddonUpdate(waitCtx, clusterName, addonName, options.PollInterval); err != nil {
 			result.Status = "WAIT_FAILED"
 			return result, err
 		}

--- a/internal/services/addons/types.go
+++ b/internal/services/addons/types.go
@@ -72,6 +72,7 @@ type UpdateOptions struct {
 	HealthCheck   bool          `json:"healthCheck"`
 	Wait          bool          `json:"wait"`
 	WaitTimeout   time.Duration `json:"waitTimeout"`
+	PollInterval  time.Duration `json:"pollInterval,omitempty"` // re-check cadence while waiting (default 5s)
 	Configuration string        `json:"configuration,omitempty"`
 }
 

--- a/internal/services/addons/version_analyzer.go
+++ b/internal/services/addons/version_analyzer.go
@@ -72,6 +72,13 @@ func (s *ServiceImpl) GetAvailableVersions(ctx context.Context, addonName string
 	return versions, nil
 }
 
+// CompareVersions compares EKS addon version strings such as
+// "v1.18.1-eksbuild.3", returning >0 when a is newer than b. Exported for the
+// upgrade orchestrator's already-satisfied checks.
+func CompareVersions(a, b string) int {
+	return compareAddonVersions(a, b)
+}
+
 // compareAddonVersions compares EKS addon version strings such as
 // "v1.18.1-eksbuild.3", returning >0 when a is newer than b. Numeric segments
 // are compared numerically; non-numeric segments lexically.
@@ -102,9 +109,13 @@ func compareAddonVersions(a, b string) int {
 	return len(as) - len(bs)
 }
 
-// waitForAddonUpdate polls until an addon update completes.
-func (s *ServiceImpl) waitForAddonUpdate(ctx context.Context, clusterName, addonName string) error {
-	ticker := time.NewTicker(addonUpdatePollInterval)
+// waitForAddonUpdate polls until an addon update completes. pollInterval
+// falls back to addonUpdatePollInterval when zero.
+func (s *ServiceImpl) waitForAddonUpdate(ctx context.Context, clusterName, addonName string, pollInterval time.Duration) error {
+	if pollInterval <= 0 {
+		pollInterval = addonUpdatePollInterval
+	}
+	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
 	for {

--- a/internal/services/upgrade/addons.go
+++ b/internal/services/upgrade/addons.go
@@ -1,0 +1,69 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/dantech2000/refresh/internal/services/addons"
+)
+
+// addonWaitTimeout bounds how long a single addon update may take before the
+// phase is considered failed.
+const addonWaitTimeout = 20 * time.Minute
+
+// UpgradeAddons updates every installed addon (minus the skip list) to the
+// latest version compatible with targetVersion, serially in dependency order
+// (vpc-cni → coredns/kube-proxy → the rest), waiting for each to go ACTIVE.
+//
+// It runs after the control-plane step of a hop, so targetVersion is also the
+// cluster's (new) current version; versions are still chosen explicitly
+// against targetVersion rather than "latest for whatever the cluster runs"
+// so the intent survives mid-phase retries. The addon service's built-in
+// pre/post health checks act as the phase gate: the first failure halts the
+// phase (and therefore the hop) with the failing addon named.
+func (s *Service) UpgradeAddons(ctx context.Context, clusterName, targetVersion string, skip []string, progress ProgressFunc) error {
+	progress = ensureProgress(progress)
+	svc := s.addonsService()
+
+	addonList, err := svc.List(ctx, clusterName, addons.ListOptions{})
+	if err != nil {
+		return err
+	}
+	addonList = addons.SortByDependency(addonList)
+
+	for _, a := range addonList {
+		if matchesAny(a.Name, skip) {
+			progress("addon %s: skipped (managed out-of-band)", a.Name)
+			continue
+		}
+
+		versions, err := svc.GetAvailableVersions(ctx, a.Name, targetVersion)
+		if err != nil {
+			return fmt.Errorf("addon %s: no version compatible with %s: %w", a.Name, targetVersion, err)
+		}
+		chosen := versions[0].Version
+
+		if addons.CompareVersions(a.Version, chosen) >= 0 {
+			progress("addon %s already at %s (latest compatible with %s), skipping", a.Name, a.Version, targetVersion)
+			continue
+		}
+
+		progress("addon %s: %s → %s", a.Name, a.Version, chosen)
+		result, err := svc.Update(ctx, clusterName, a.Name, addons.UpdateOptions{
+			Version:      chosen,
+			HealthCheck:  true,
+			Wait:         true,
+			WaitTimeout:  addonWaitTimeout,
+			PollInterval: s.PollInterval,
+		})
+		if err != nil {
+			return fmt.Errorf("addon %s update to %s failed: %w", a.Name, chosen, err)
+		}
+		if result.HealthIssues != "" {
+			return fmt.Errorf("addon %s updated to %s but failed its health gate: %s", a.Name, chosen, result.HealthIssues)
+		}
+		progress("addon %s is ACTIVE at %s", a.Name, chosen)
+	}
+	return nil
+}

--- a/internal/services/upgrade/addons_test.go
+++ b/internal/services/upgrade/addons_test.go
@@ -1,0 +1,194 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	"github.com/dantech2000/refresh/internal/mocks"
+)
+
+// versionsByK8s wires DescribeAddonVersions so the returned versions depend
+// on the KubernetesVersion in the request — the heart of target-version
+// compatibility.
+func versionsByK8s(m *mocks.EKSAPI, addonName string, byK8s map[string][]string) {
+	m.DescribeAddonVersionsFn = func(_ context.Context, in *eks.DescribeAddonVersionsInput, _ ...func(*eks.Options)) (*eks.DescribeAddonVersionsOutput, error) {
+		if aws.ToString(in.AddonName) != addonName {
+			return &eks.DescribeAddonVersionsOutput{}, nil
+		}
+		k8s := aws.ToString(in.KubernetesVersion)
+		var infos []ekstypes.AddonVersionInfo
+		for _, v := range byK8s[k8s] {
+			infos = append(infos, ekstypes.AddonVersionInfo{
+				AddonVersion:    aws.String(v),
+				Compatibilities: []ekstypes.Compatibility{{ClusterVersion: aws.String(k8s)}},
+			})
+		}
+		return &eks.DescribeAddonVersionsOutput{
+			Addons: []ekstypes.AddonInfo{{AddonName: aws.String(addonName), AddonVersions: infos}},
+		}, nil
+	}
+}
+
+// Acceptance (REF-100): the chosen addon version is the one compatible with
+// the NEW (target) control-plane version, not merely "latest for current".
+func TestUpgradeAddons_ChoosesTargetCompatibleVersion(t *testing.T) {
+	var mu sync.Mutex
+	var captured *eks.UpdateAddonInput
+
+	// Cluster's control plane has just been upgraded to 1.32 (the addon
+	// phase runs after the control-plane step of the hop).
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.32").
+		WithAddon("vpc-cni", "v1.31.5-eksbuild.1", ekstypes.AddonStatusActive).
+		Build()
+	versionsByK8s(m, "vpc-cni", map[string][]string{
+		"1.31": {"v1.31.9-eksbuild.1"},
+		"1.32": {"v1.32.2-eksbuild.1"},
+	})
+	m.UpdateAddonFn = func(_ context.Context, in *eks.UpdateAddonInput, _ ...func(*eks.Options)) (*eks.UpdateAddonOutput, error) {
+		mu.Lock()
+		captured = in
+		mu.Unlock()
+		return &eks.UpdateAddonOutput{Update: &ekstypes.Update{
+			Id:     aws.String("update-addon-1"),
+			Status: ekstypes.UpdateStatusInProgress,
+		}}, nil
+	}
+	svc := newTestService(m)
+
+	if err := svc.UpgradeAddons(context.Background(), "prod-east", "1.32", nil, nil); err != nil {
+		t.Fatalf("UpgradeAddons: %v", err)
+	}
+
+	if captured == nil {
+		t.Fatal("UpdateAddon was never called")
+	}
+	if got := aws.ToString(captured.AddonVersion); got != "v1.32.2-eksbuild.1" {
+		t.Fatalf("chosen addon version = %q, want v1.32.2-eksbuild.1 (compatible with target 1.32)", got)
+	}
+	if captured.ClientRequestToken == nil || *captured.ClientRequestToken == "" {
+		t.Fatal("ClientRequestToken must be set on UpdateAddon")
+	}
+}
+
+// Addons already at the latest target-compatible version are skipped.
+func TestUpgradeAddons_AlreadyLatestSkipped(t *testing.T) {
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.32").
+		WithAddon("vpc-cni", "v1.32.2-eksbuild.1", ekstypes.AddonStatusActive).
+		Build()
+	versionsByK8s(m, "vpc-cni", map[string][]string{
+		"1.32": {"v1.32.2-eksbuild.1"},
+	})
+	svc := newTestService(m)
+
+	if err := svc.UpgradeAddons(context.Background(), "prod-east", "1.32", nil, nil); err != nil {
+		t.Fatalf("UpgradeAddons: %v", err)
+	}
+	if m.Calls.UpdateAddon != 0 {
+		t.Fatalf("UpdateAddon calls = %d, want 0", m.Calls.UpdateAddon)
+	}
+}
+
+// Acceptance (REF-100): the --skip list passes through; skipped addons are
+// never mutated.
+func TestUpgradeAddons_SkipListRespected(t *testing.T) {
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.32").
+		WithAddon("vpc-cni", "v1.31.5-eksbuild.1", ekstypes.AddonStatusActive).
+		Build()
+	versionsByK8s(m, "vpc-cni", map[string][]string{
+		"1.32": {"v1.32.2-eksbuild.1"},
+	})
+	svc := newTestService(m)
+
+	if err := svc.UpgradeAddons(context.Background(), "prod-east", "1.32", []string{"vpc-cni"}, nil); err != nil {
+		t.Fatalf("UpgradeAddons: %v", err)
+	}
+	if m.Calls.UpdateAddon != 0 {
+		t.Fatalf("UpdateAddon calls = %d, want 0 (skipped)", m.Calls.UpdateAddon)
+	}
+}
+
+// Updates run serially in dependency order: vpc-cni before coredns.
+func TestUpgradeAddons_DependencyOrder(t *testing.T) {
+	var mu sync.Mutex
+	var order []string
+
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.32").
+		WithAddon("coredns", "v1.10.0-eksbuild.1", ekstypes.AddonStatusActive).
+		WithAddon("vpc-cni", "v1.31.5-eksbuild.1", ekstypes.AddonStatusActive).
+		Build()
+	m.DescribeAddonVersionsFn = func(_ context.Context, in *eks.DescribeAddonVersionsInput, _ ...func(*eks.Options)) (*eks.DescribeAddonVersionsOutput, error) {
+		name := aws.ToString(in.AddonName)
+		v := map[string]string{"vpc-cni": "v1.32.2-eksbuild.1", "coredns": "v1.11.0-eksbuild.1"}[name]
+		return &eks.DescribeAddonVersionsOutput{
+			Addons: []ekstypes.AddonInfo{{
+				AddonName:     in.AddonName,
+				AddonVersions: []ekstypes.AddonVersionInfo{{AddonVersion: aws.String(v)}},
+			}},
+		}, nil
+	}
+	m.UpdateAddonFn = func(_ context.Context, in *eks.UpdateAddonInput, _ ...func(*eks.Options)) (*eks.UpdateAddonOutput, error) {
+		mu.Lock()
+		order = append(order, aws.ToString(in.AddonName))
+		mu.Unlock()
+		return &eks.UpdateAddonOutput{Update: &ekstypes.Update{
+			Id:     aws.String("u-" + aws.ToString(in.AddonName)),
+			Status: ekstypes.UpdateStatusInProgress,
+		}}, nil
+	}
+	svc := newTestService(m)
+
+	if err := svc.UpgradeAddons(context.Background(), "prod-east", "1.32", nil, nil); err != nil {
+		t.Fatalf("UpgradeAddons: %v", err)
+	}
+	if len(order) != 2 || order[0] != "vpc-cni" || order[1] != "coredns" {
+		t.Fatalf("update order = %v, want [vpc-cni coredns]", order)
+	}
+}
+
+// A failed addon update halts the phase with the addon named.
+func TestUpgradeAddons_FailureHaltsPhase(t *testing.T) {
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.32").
+		WithAddon("vpc-cni", "v1.31.5-eksbuild.1", ekstypes.AddonStatusActive).
+		Build()
+	versionsByK8s(m, "vpc-cni", map[string][]string{
+		"1.32": {"v1.32.2-eksbuild.1"},
+	})
+	m.UpdateAddonFn = func(_ context.Context, _ *eks.UpdateAddonInput, _ ...func(*eks.Options)) (*eks.UpdateAddonOutput, error) {
+		return nil, errors.New("addon update rejected")
+	}
+	svc := newTestService(m)
+
+	err := svc.UpgradeAddons(context.Background(), "prod-east", "1.32", nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "vpc-cni") {
+		t.Fatalf("err = %v, want failure naming vpc-cni", err)
+	}
+}
+
+// An addon with no target-compatible version fails the phase up front.
+func TestUpgradeAddons_NoCompatibleVersionFails(t *testing.T) {
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.32").
+		WithAddon("legacy-addon", "v0.9.0", ekstypes.AddonStatusActive).
+		Build()
+	svc := newTestService(m)
+
+	err := svc.UpgradeAddons(context.Background(), "prod-east", "1.32", nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "legacy-addon") {
+		t.Fatalf("err = %v, want failure naming legacy-addon", err)
+	}
+	if m.Calls.UpdateAddon != 0 {
+		t.Fatalf("UpdateAddon calls = %d, want 0", m.Calls.UpdateAddon)
+	}
+}

--- a/internal/services/upgrade/controlplane.go
+++ b/internal/services/upgrade/controlplane.go
@@ -1,0 +1,127 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	awsinternal "github.com/dantech2000/refresh/internal/aws"
+	"github.com/dantech2000/refresh/internal/services/common"
+)
+
+// UpgradeControlPlane moves the cluster's control plane to targetVersion and
+// waits until the update finishes and the cluster is ACTIVE again.
+//
+// Idempotent: if the control plane already runs targetVersion (or newer) it
+// returns immediately; if an update is already in flight it attaches and
+// watches instead of failing. On context cancellation (Ctrl+C) it returns
+// ctx.Err() — the upgrade keeps running server-side and a rerun re-attaches.
+func (s *Service) UpgradeControlPlane(ctx context.Context, clusterName, targetVersion string, progress ProgressFunc) error {
+	progress = ensureProgress(progress)
+
+	cluster, err := s.describeCluster(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	if versionAtLeast(aws.ToString(cluster.Version), targetVersion) {
+		progress("control plane already at %s, skipping", aws.ToString(cluster.Version))
+		return nil
+	}
+
+	if cluster.Status == ekstypes.ClusterStatusUpdating {
+		// Another update (possibly a previous run of this orchestrator) is in
+		// flight; attach and watch rather than fail.
+		progress("cluster is already UPDATING; attaching to the in-flight update")
+		if err := s.waitForClusterActive(ctx, clusterName, progress); err != nil {
+			return err
+		}
+		cluster, err = s.describeCluster(ctx, clusterName)
+		if err != nil {
+			return err
+		}
+		if versionAtLeast(aws.ToString(cluster.Version), targetVersion) {
+			progress("control plane reached %s", aws.ToString(cluster.Version))
+			return nil
+		}
+		// The in-flight update was something else (e.g. config change);
+		// fall through and start the version upgrade.
+	}
+
+	input := &eks.UpdateClusterVersionInput{
+		Name:    aws.String(clusterName),
+		Version: aws.String(targetVersion),
+		// Pin the idempotency token so WithRetry re-issues the SAME request
+		// instead of submitting a fresh update per attempt.
+		ClientRequestToken: aws.String(common.IdempotencyToken()),
+	}
+	out, err := common.WithRetry(ctx, common.DefaultRetryConfig, func(rc context.Context) (*eks.UpdateClusterVersionOutput, error) {
+		return s.eksClient.UpdateClusterVersion(rc, input)
+	})
+	if err != nil {
+		return awsinternal.FormatAWSError(err, fmt.Sprintf("upgrading control plane of %s to %s", clusterName, targetVersion))
+	}
+
+	updateID := ""
+	if out.Update != nil {
+		updateID = aws.ToString(out.Update.Id)
+	}
+	progress("control plane upgrade to %s started (update %s); this typically takes ~10 minutes", targetVersion, updateID)
+
+	if updateID != "" {
+		if err := s.waitForUpdate(ctx, &eks.DescribeUpdateInput{
+			Name:     aws.String(clusterName),
+			UpdateId: aws.String(updateID),
+		}, fmt.Sprintf("control plane upgrade to %s", targetVersion), progress); err != nil {
+			return err
+		}
+	}
+
+	// Gate: the cluster itself must be ACTIVE at the new version before the
+	// addon phase may start.
+	if err := s.waitForClusterActive(ctx, clusterName, progress); err != nil {
+		return err
+	}
+	cluster, err = s.describeCluster(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+	if !versionAtLeast(aws.ToString(cluster.Version), targetVersion) {
+		return fmt.Errorf("control plane reports version %s after the upgrade to %s finished", aws.ToString(cluster.Version), targetVersion)
+	}
+	progress("control plane is ACTIVE at %s", aws.ToString(cluster.Version))
+	return nil
+}
+
+// waitForClusterActive polls the cluster until its status is ACTIVE.
+func (s *Service) waitForClusterActive(ctx context.Context, clusterName string, progress ProgressFunc) error {
+	interval := s.PollInterval
+	if interval <= 0 {
+		interval = defaultPollInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		cluster, err := s.describeCluster(ctx, clusterName)
+		if err != nil {
+			return err
+		}
+		switch cluster.Status {
+		case ekstypes.ClusterStatusActive:
+			return nil
+		case ekstypes.ClusterStatusFailed:
+			return fmt.Errorf("cluster %s entered FAILED status", clusterName)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/services/upgrade/controlplane_test.go
+++ b/internal/services/upgrade/controlplane_test.go
@@ -1,0 +1,190 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	"github.com/dantech2000/refresh/internal/mocks"
+)
+
+// controlPlaneWorld is a stateful mock cluster whose version flips once
+// UpdateClusterVersion is called and its update polled.
+type controlPlaneWorld struct {
+	mu            sync.Mutex
+	version       string
+	status        ekstypes.ClusterStatus
+	updateStarted bool
+	capturedInput *eks.UpdateClusterVersionInput
+}
+
+func newControlPlaneMock(w *controlPlaneWorld) *mocks.EKSAPI {
+	m := mocks.NewEKSAPI().Build()
+	m.DescribeClusterFn = func(_ context.Context, in *eks.DescribeClusterInput, _ ...func(*eks.Options)) (*eks.DescribeClusterOutput, error) {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		return &eks.DescribeClusterOutput{Cluster: &ekstypes.Cluster{
+			Name:    in.Name,
+			Version: aws.String(w.version),
+			Status:  w.status,
+		}}, nil
+	}
+	m.UpdateClusterVersionFn = func(_ context.Context, in *eks.UpdateClusterVersionInput, _ ...func(*eks.Options)) (*eks.UpdateClusterVersionOutput, error) {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		w.capturedInput = in
+		w.updateStarted = true
+		w.status = ekstypes.ClusterStatusUpdating
+		return &eks.UpdateClusterVersionOutput{Update: &ekstypes.Update{
+			Id:     aws.String("update-cp-1"),
+			Status: ekstypes.UpdateStatusInProgress,
+			Type:   ekstypes.UpdateTypeVersionUpdate,
+		}}, nil
+	}
+	m.DescribeUpdateFn = func(_ context.Context, in *eks.DescribeUpdateInput, _ ...func(*eks.Options)) (*eks.DescribeUpdateOutput, error) {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		// First poll completes the update server-side.
+		if w.updateStarted {
+			w.version = aws.ToString(w.capturedInput.Version)
+			w.status = ekstypes.ClusterStatusActive
+		}
+		return &eks.DescribeUpdateOutput{Update: &ekstypes.Update{
+			Id:     in.UpdateId,
+			Status: ekstypes.UpdateStatusSuccessful,
+		}}, nil
+	}
+	return m
+}
+
+// Acceptance (REF-99): start → monitor → complete, with the idempotency
+// token asserted on the mutating call.
+func TestUpgradeControlPlane_StartMonitorComplete(t *testing.T) {
+	w := &controlPlaneWorld{version: "1.31", status: ekstypes.ClusterStatusActive}
+	m := newControlPlaneMock(w)
+	svc := newTestService(m)
+
+	if err := svc.UpgradeControlPlane(context.Background(), "prod-east", "1.32", nil); err != nil {
+		t.Fatalf("UpgradeControlPlane: %v", err)
+	}
+
+	if m.Calls.UpdateClusterVersion != 1 {
+		t.Fatalf("UpdateClusterVersion calls = %d, want 1", m.Calls.UpdateClusterVersion)
+	}
+	if w.capturedInput.ClientRequestToken == nil || *w.capturedInput.ClientRequestToken == "" {
+		t.Fatal("ClientRequestToken must be set (idempotency across retries)")
+	}
+	if aws.ToString(w.capturedInput.Version) != "1.32" {
+		t.Fatalf("requested version = %q, want 1.32", aws.ToString(w.capturedInput.Version))
+	}
+	if w.version != "1.32" {
+		t.Fatalf("cluster version after upgrade = %q, want 1.32", w.version)
+	}
+	if m.Calls.DescribeUpdate == 0 {
+		t.Fatal("expected DescribeUpdate polling")
+	}
+}
+
+// Acceptance (REF-99): a Failed update surfaces its error details.
+func TestUpgradeControlPlane_FailureSurfaces(t *testing.T) {
+	w := &controlPlaneWorld{version: "1.31", status: ekstypes.ClusterStatusActive}
+	m := newControlPlaneMock(w)
+	m.DescribeUpdateFn = func(_ context.Context, in *eks.DescribeUpdateInput, _ ...func(*eks.Options)) (*eks.DescribeUpdateOutput, error) {
+		return &eks.DescribeUpdateOutput{Update: &ekstypes.Update{
+			Id:     in.UpdateId,
+			Status: ekstypes.UpdateStatusFailed,
+			Errors: []ekstypes.ErrorDetail{{
+				ErrorCode:    ekstypes.ErrorCodeOperationNotPermitted,
+				ErrorMessage: aws.String("insufficient subnet IPs"),
+			}},
+		}}, nil
+	}
+	svc := newTestService(m)
+
+	err := svc.UpgradeControlPlane(context.Background(), "prod-east", "1.32", nil)
+	if err == nil || !strings.Contains(err.Error(), "insufficient subnet IPs") {
+		t.Fatalf("err = %v, want the update's error details surfaced", err)
+	}
+}
+
+// Acceptance (REF-99): an already-UPDATING cluster is attached and watched,
+// not failed and not double-updated.
+func TestUpgradeControlPlane_AttachesToInFlightUpdate(t *testing.T) {
+	w := &controlPlaneWorld{version: "1.31", status: ekstypes.ClusterStatusUpdating}
+	m := newControlPlaneMock(w)
+	polls := 0
+	m.DescribeClusterFn = func(_ context.Context, in *eks.DescribeClusterInput, _ ...func(*eks.Options)) (*eks.DescribeClusterOutput, error) {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		polls++
+		// The in-flight (externally started) upgrade completes after a couple
+		// of polls.
+		if polls >= 3 {
+			w.version = "1.32"
+			w.status = ekstypes.ClusterStatusActive
+		}
+		return &eks.DescribeClusterOutput{Cluster: &ekstypes.Cluster{
+			Name:    in.Name,
+			Version: aws.String(w.version),
+			Status:  w.status,
+		}}, nil
+	}
+	svc := newTestService(m)
+
+	if err := svc.UpgradeControlPlane(context.Background(), "prod-east", "1.32", nil); err != nil {
+		t.Fatalf("UpgradeControlPlane: %v", err)
+	}
+	if m.Calls.UpdateClusterVersion != 0 {
+		t.Fatalf("UpdateClusterVersion calls = %d, want 0 (attached to in-flight update)", m.Calls.UpdateClusterVersion)
+	}
+}
+
+// Idempotency: a control plane already at (or past) the target is a no-op.
+func TestUpgradeControlPlane_AlreadyAtTargetIsNoOp(t *testing.T) {
+	w := &controlPlaneWorld{version: "1.33", status: ekstypes.ClusterStatusActive}
+	m := newControlPlaneMock(w)
+	svc := newTestService(m)
+
+	if err := svc.UpgradeControlPlane(context.Background(), "prod-east", "1.32", nil); err != nil {
+		t.Fatalf("UpgradeControlPlane: %v", err)
+	}
+	if m.Calls.UpdateClusterVersion != 0 {
+		t.Fatalf("UpdateClusterVersion calls = %d, want 0", m.Calls.UpdateClusterVersion)
+	}
+}
+
+// SIGINT behavior: cancelling the context stops the watch and reports that
+// the upgrade continues server-side (the engine wraps this for the user).
+func TestUpgradeControlPlane_ContextCancelStopsWatching(t *testing.T) {
+	w := &controlPlaneWorld{version: "1.31", status: ekstypes.ClusterStatusActive}
+	m := newControlPlaneMock(w)
+	m.DescribeUpdateFn = func(_ context.Context, in *eks.DescribeUpdateInput, _ ...func(*eks.Options)) (*eks.DescribeUpdateOutput, error) {
+		return &eks.DescribeUpdateOutput{Update: &ekstypes.Update{
+			Id:     in.UpdateId,
+			Status: ekstypes.UpdateStatusInProgress, // never completes
+		}}, nil
+	}
+	svc := newTestService(m)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	err := svc.UpgradeControlPlane(ctx, "prod-east", "1.32", nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	// The mutation was still issued exactly once before cancellation.
+	if m.Calls.UpdateClusterVersion != 1 {
+		t.Fatalf("UpdateClusterVersion calls = %d, want 1", m.Calls.UpdateClusterVersion)
+	}
+}

--- a/internal/services/upgrade/engine.go
+++ b/internal/services/upgrade/engine.go
@@ -1,0 +1,171 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ErrAborted is returned by Execute when the user declines a phase
+// confirmation. The cluster was not touched by the declined phase.
+var ErrAborted = errors.New("upgrade aborted by user")
+
+// ConfirmFunc asks the user to approve a mutating phase; returning false
+// aborts the run before the phase starts.
+type ConfirmFunc func(prompt string) bool
+
+// ExecuteOptions tunes plan execution.
+type ExecuteOptions struct {
+	// Yes skips all phase confirmations (--yes).
+	Yes bool
+	// Confirm prompts before each mutating phase when Yes is false. Required
+	// unless Yes is true.
+	Confirm ConfirmFunc
+	// Progress receives human-readable progress lines.
+	Progress ProgressFunc
+	// SkipAddons / SkipNodegroups / Force mirror the plan options and are
+	// passed through to the phase executors.
+	SkipAddons     []string
+	SkipNodegroups []string
+	Force          bool
+	// NodegroupGate overrides the built-in pre-roll health gate.
+	NodegroupGate NodegroupGate
+}
+
+// Report describes how far an execution got: what ran, where it stopped, and
+// what remains. Rerunning the same command resumes from live cluster state.
+type Report struct {
+	Completed []string `json:"completed,omitempty" yaml:"completed,omitempty"`
+	FailedAt  string   `json:"failedAt,omitempty" yaml:"failedAt,omitempty"`
+	Remaining []string `json:"remaining,omitempty" yaml:"remaining,omitempty"`
+}
+
+// phase is one confirm-gate-execute unit within a hop.
+type phase struct {
+	label string
+	steps []Step // the plan steps this phase covers (pending ones only)
+	run   func(ctx context.Context) error
+}
+
+// Execute runs the plan: hops in order, phases (control plane → addons →
+// nodegroups) in order within each hop, a confirmation before every mutating
+// phase unless opts.Yes, and a halt with a precise completed / failed-at /
+// remaining report on the first failure.
+//
+// Execution state lives in the cluster itself, not in Execute: steps already
+// marked completed by BuildPlan are skipped, and each phase executor
+// re-checks live state, so rerunning after a failure (or a SIGINT, or a
+// complete success) is safe and only performs the remaining work.
+func (s *Service) Execute(ctx context.Context, plan *Plan, opts ExecuteOptions) (*Report, error) {
+	progress := ensureProgress(opts.Progress)
+	report := &Report{}
+
+	if plan.Blocked() {
+		return report, fmt.Errorf("plan has unresolved blockers; refusing to execute:\n  %s",
+			joinLines(plan.Blockers()))
+	}
+
+	phases := s.phases(plan, opts)
+
+	for i, ph := range phases {
+		if len(ph.steps) == 0 {
+			continue // nothing pending in this phase
+		}
+
+		if !opts.Yes {
+			if opts.Confirm == nil {
+				return report, fmt.Errorf("confirmation required for %q but no prompt available (use --yes for non-interactive runs)", ph.label)
+			}
+			if !opts.Confirm(ph.label) {
+				report.Remaining = pendingLabels(phases[i:])
+				return report, ErrAborted
+			}
+		}
+
+		progress("▸ %s", ph.label)
+		if err := ph.run(ctx); err != nil {
+			report.FailedAt = ph.label
+			report.Remaining = pendingLabels(phases[i+1:])
+			if ctx.Err() != nil {
+				// SIGINT / timeout: anything started keeps running
+				// server-side; a rerun re-attaches and resumes.
+				return report, fmt.Errorf("interrupted during %s (in-flight EKS updates continue server-side; rerun the same command to resume): %w", ph.label, err)
+			}
+			return report, fmt.Errorf("%s failed: %w", ph.label, err)
+		}
+		report.Completed = append(report.Completed, ph.label)
+	}
+
+	return report, nil
+}
+
+// phases flattens the plan into the ordered list of executable phases.
+func (s *Service) phases(plan *Plan, opts ExecuteOptions) []phase {
+	var out []phase
+	for _, hop := range plan.Hops {
+		hop := hop
+		var cpSteps, addonSteps, ngSteps []Step
+		for _, st := range hop.Steps {
+			if st.Status != StatusPending {
+				continue
+			}
+			switch st.Type {
+			case StepControlPlane:
+				cpSteps = append(cpSteps, st)
+			case StepAddon:
+				addonSteps = append(addonSteps, st)
+			case StepNodegroup:
+				ngSteps = append(ngSteps, st)
+			}
+		}
+
+		out = append(out, phase{
+			label: fmt.Sprintf("control plane %s → %s", hop.From, hop.To),
+			steps: cpSteps,
+			run: func(ctx context.Context) error {
+				return s.UpgradeControlPlane(ctx, plan.ClusterName, hop.To, opts.Progress)
+			},
+		})
+		out = append(out, phase{
+			label: fmt.Sprintf("addons for %s (%d update(s), dependency order)", hop.To, len(addonSteps)),
+			steps: addonSteps,
+			run: func(ctx context.Context) error {
+				return s.UpgradeAddons(ctx, plan.ClusterName, hop.To, opts.SkipAddons, opts.Progress)
+			},
+		})
+		out = append(out, phase{
+			label: fmt.Sprintf("nodegroup rolls to %s (%d nodegroup(s))", hop.To, len(ngSteps)),
+			steps: ngSteps,
+			run: func(ctx context.Context) error {
+				return s.UpgradeNodegroups(ctx, plan.ClusterName, hop.To, NodegroupRollOptions{
+					SkipPatterns: opts.SkipNodegroups,
+					Force:        opts.Force,
+					Gate:         opts.NodegroupGate,
+				}, opts.Progress)
+			},
+		})
+	}
+	return out
+}
+
+// pendingLabels lists the labels of phases that still have pending steps.
+func pendingLabels(phases []phase) []string {
+	var out []string
+	for _, ph := range phases {
+		if len(ph.steps) > 0 {
+			out = append(out, ph.label)
+		}
+	}
+	return out
+}
+
+func joinLines(lines []string) string {
+	out := ""
+	for i, l := range lines {
+		if i > 0 {
+			out += "\n  "
+		}
+		out += l
+	}
+	return out
+}

--- a/internal/services/upgrade/engine_test.go
+++ b/internal/services/upgrade/engine_test.go
@@ -1,0 +1,328 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	"github.com/dantech2000/refresh/internal/mocks"
+)
+
+// fakeWorld is a mutable in-memory EKS cluster. The mock's Fn closures read
+// and write it, so the engine's mutations actually change what BuildPlan
+// re-derives — exactly how resume works against a real cluster.
+type fakeWorld struct {
+	mu             sync.Mutex
+	clusterVersion string
+	addonVersions  map[string]string // name -> installed version
+	ngVersions     map[string]string // name -> k8s version
+	failAddons     bool              // make UpdateAddon fail (gate failure simulation)
+	hangUpdates    bool              // make DescribeUpdate never complete (SIGINT simulation)
+}
+
+// latestFor maps a k8s version to the fake addon catalogue's latest
+// compatible version, e.g. 1.32 -> "v1.32.0-eksbuild.1".
+func latestFor(k8s string) string { return "v" + k8s + ".0-eksbuild.1" }
+
+func newWorldMock(w *fakeWorld) *mocks.EKSAPI {
+	m := mocks.NewEKSAPI().Build()
+
+	m.DescribeClusterFn = func(_ context.Context, in *eks.DescribeClusterInput, _ ...func(*eks.Options)) (*eks.DescribeClusterOutput, error) {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		return &eks.DescribeClusterOutput{Cluster: &ekstypes.Cluster{
+			Name:    in.Name,
+			Version: aws.String(w.clusterVersion),
+			Status:  ekstypes.ClusterStatusActive,
+		}}, nil
+	}
+	m.UpdateClusterVersionFn = func(_ context.Context, in *eks.UpdateClusterVersionInput, _ ...func(*eks.Options)) (*eks.UpdateClusterVersionOutput, error) {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		w.clusterVersion = aws.ToString(in.Version)
+		return &eks.UpdateClusterVersionOutput{Update: &ekstypes.Update{
+			Id: aws.String("u-cp"), Status: ekstypes.UpdateStatusInProgress,
+		}}, nil
+	}
+	m.DescribeUpdateFn = func(_ context.Context, in *eks.DescribeUpdateInput, _ ...func(*eks.Options)) (*eks.DescribeUpdateOutput, error) {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		status := ekstypes.UpdateStatusSuccessful
+		if w.hangUpdates {
+			status = ekstypes.UpdateStatusInProgress
+		}
+		return &eks.DescribeUpdateOutput{Update: &ekstypes.Update{Id: in.UpdateId, Status: status}}, nil
+	}
+
+	m.ListAddonsFn = func(_ context.Context, _ *eks.ListAddonsInput, _ ...func(*eks.Options)) (*eks.ListAddonsOutput, error) {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		out := &eks.ListAddonsOutput{}
+		for name := range w.addonVersions {
+			out.Addons = append(out.Addons, name)
+		}
+		return out, nil
+	}
+	m.DescribeAddonFn = func(_ context.Context, in *eks.DescribeAddonInput, _ ...func(*eks.Options)) (*eks.DescribeAddonOutput, error) {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		name := aws.ToString(in.AddonName)
+		return &eks.DescribeAddonOutput{Addon: &ekstypes.Addon{
+			AddonName:    in.AddonName,
+			AddonVersion: aws.String(w.addonVersions[name]),
+			Status:       ekstypes.AddonStatusActive,
+		}}, nil
+	}
+	m.DescribeAddonVersionsFn = func(_ context.Context, in *eks.DescribeAddonVersionsInput, _ ...func(*eks.Options)) (*eks.DescribeAddonVersionsOutput, error) {
+		k8s := aws.ToString(in.KubernetesVersion)
+		return &eks.DescribeAddonVersionsOutput{Addons: []ekstypes.AddonInfo{{
+			AddonName: in.AddonName,
+			AddonVersions: []ekstypes.AddonVersionInfo{{
+				AddonVersion:    aws.String(latestFor(k8s)),
+				Compatibilities: []ekstypes.Compatibility{{ClusterVersion: in.KubernetesVersion}},
+			}},
+		}}}, nil
+	}
+	m.UpdateAddonFn = func(_ context.Context, in *eks.UpdateAddonInput, _ ...func(*eks.Options)) (*eks.UpdateAddonOutput, error) {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		if w.failAddons {
+			return nil, errors.New("addon update rejected by fake world")
+		}
+		w.addonVersions[aws.ToString(in.AddonName)] = aws.ToString(in.AddonVersion)
+		return &eks.UpdateAddonOutput{Update: &ekstypes.Update{
+			Id: aws.String("u-addon"), Status: ekstypes.UpdateStatusInProgress,
+		}}, nil
+	}
+
+	m.ListNodegroupsFn = func(_ context.Context, _ *eks.ListNodegroupsInput, _ ...func(*eks.Options)) (*eks.ListNodegroupsOutput, error) {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		out := &eks.ListNodegroupsOutput{}
+		for name := range w.ngVersions {
+			out.Nodegroups = append(out.Nodegroups, name)
+		}
+		return out, nil
+	}
+	m.DescribeNodegroupFn = func(_ context.Context, in *eks.DescribeNodegroupInput, _ ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error) {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		name := aws.ToString(in.NodegroupName)
+		return &eks.DescribeNodegroupOutput{Nodegroup: &ekstypes.Nodegroup{
+			NodegroupName: in.NodegroupName,
+			Version:       aws.String(w.ngVersions[name]),
+			AmiType:       ekstypes.AMITypesAl2023X8664Standard,
+			Status:        ekstypes.NodegroupStatusActive,
+		}}, nil
+	}
+	m.UpdateNodegroupVersionFn = func(_ context.Context, in *eks.UpdateNodegroupVersionInput, _ ...func(*eks.Options)) (*eks.UpdateNodegroupVersionOutput, error) {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		w.ngVersions[aws.ToString(in.NodegroupName)] = aws.ToString(in.Version)
+		return &eks.UpdateNodegroupVersionOutput{Update: &ekstypes.Update{
+			Id: aws.String("u-ng"), Status: ekstypes.UpdateStatusInProgress,
+		}}, nil
+	}
+	return m
+}
+
+func newWorld() *fakeWorld {
+	return &fakeWorld{
+		clusterVersion: "1.31",
+		addonVersions:  map[string]string{"vpc-cni": latestFor("1.31")},
+		ngVersions:     map[string]string{"workers-a": "1.31"},
+	}
+}
+
+// Acceptance (REF-102): a simulated mid-plan failure, then a rerun that
+// skips completed steps and continues to the end.
+func TestExecute_MidPlanFailureThenResumedRerun(t *testing.T) {
+	w := newWorld()
+	m := newWorldMock(w)
+	svc := newTestService(m)
+	ctx := context.Background()
+
+	// First run: the addon phase fails after the control plane upgraded.
+	w.failAddons = true
+	plan, err := svc.BuildPlan(ctx, "prod-east", "1.32", PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	report, err := svc.Execute(ctx, plan, ExecuteOptions{Yes: true})
+	if err == nil {
+		t.Fatal("first run should fail in the addon phase")
+	}
+	if len(report.Completed) != 1 || !strings.Contains(report.Completed[0], "control plane") {
+		t.Fatalf("completed = %v, want the control-plane phase", report.Completed)
+	}
+	if !strings.Contains(report.FailedAt, "addons") {
+		t.Fatalf("failedAt = %q, want the addon phase", report.FailedAt)
+	}
+	if len(report.Remaining) != 1 || !strings.Contains(report.Remaining[0], "nodegroup") {
+		t.Fatalf("remaining = %v, want the nodegroup phase (halted before it)", report.Remaining)
+	}
+	if w.clusterVersion != "1.32" {
+		t.Fatalf("cluster version = %s, want 1.32 (control plane completed)", w.clusterVersion)
+	}
+	if m.Calls.UpdateNodegroupVersion != 0 {
+		t.Fatal("gate failure must halt before the nodegroup phase")
+	}
+	cpCallsAfterFirstRun := m.Calls.UpdateClusterVersion
+
+	// Rerun after the cause is fixed: the control-plane step derives as
+	// completed and is NOT re-executed; the rest continues to success.
+	w.failAddons = false
+	plan, err = svc.BuildPlan(ctx, "prod-east", "1.32", PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildPlan (rerun): %v", err)
+	}
+	report, err = svc.Execute(ctx, plan, ExecuteOptions{Yes: true})
+	if err != nil {
+		t.Fatalf("Execute (rerun): %v", err)
+	}
+	if m.Calls.UpdateClusterVersion != cpCallsAfterFirstRun {
+		t.Fatalf("UpdateClusterVersion calls grew from %d to %d on rerun — completed step was re-executed",
+			cpCallsAfterFirstRun, m.Calls.UpdateClusterVersion)
+	}
+	if w.addonVersions["vpc-cni"] != latestFor("1.32") {
+		t.Fatalf("addon version = %s, want %s", w.addonVersions["vpc-cni"], latestFor("1.32"))
+	}
+	if w.ngVersions["workers-a"] != "1.32" {
+		t.Fatalf("nodegroup version = %s, want 1.32", w.ngVersions["workers-a"])
+	}
+	if report.FailedAt != "" || len(report.Remaining) != 0 {
+		t.Fatalf("rerun report = %+v, want clean completion", report)
+	}
+}
+
+// Acceptance (REF-102): a double-run of a completed upgrade is a no-op.
+func TestExecute_DoubleRunIsNoOp(t *testing.T) {
+	w := newWorld()
+	m := newWorldMock(w)
+	svc := newTestService(m)
+	ctx := context.Background()
+
+	plan, err := svc.BuildPlan(ctx, "prod-east", "1.32", PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	if _, err := svc.Execute(ctx, plan, ExecuteOptions{Yes: true}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	mutationsAfterFirst := m.Calls.UpdateClusterVersion + m.Calls.UpdateAddon + m.Calls.UpdateNodegroupVersion
+
+	plan, err = svc.BuildPlan(ctx, "prod-east", "1.32", PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildPlan (second run): %v", err)
+	}
+	if plan.PendingSteps() != 0 {
+		t.Fatalf("second plan has %d pending steps, want 0", plan.PendingSteps())
+	}
+	if _, err := svc.Execute(ctx, plan, ExecuteOptions{Yes: true}); err != nil {
+		t.Fatalf("Execute (second run): %v", err)
+	}
+
+	mutationsAfterSecond := m.Calls.UpdateClusterVersion + m.Calls.UpdateAddon + m.Calls.UpdateNodegroupVersion
+	if mutationsAfterSecond != mutationsAfterFirst {
+		t.Fatalf("second run performed %d extra mutations, want 0", mutationsAfterSecond-mutationsAfterFirst)
+	}
+}
+
+// Acceptance (REF-102): SIGINT mid-phase stops cleanly and the error tells
+// the user what continues server-side and how to resume.
+func TestExecute_InterruptLeavesResumeGuidance(t *testing.T) {
+	w := newWorld()
+	w.hangUpdates = true // control-plane update never completes
+	m := newWorldMock(w)
+	svc := newTestService(m)
+
+	plan, err := svc.BuildPlan(context.Background(), "prod-east", "1.32", PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		cancel() // simulates Ctrl+C via signal.NotifyContext in main
+	}()
+
+	report, err := svc.Execute(ctx, plan, ExecuteOptions{Yes: true})
+	if err == nil {
+		t.Fatal("interrupted run must return an error")
+	}
+	if !strings.Contains(err.Error(), "continue server-side") || !strings.Contains(err.Error(), "rerun") {
+		t.Fatalf("err = %v, want server-side continuation + resume guidance", err)
+	}
+	if !strings.Contains(report.FailedAt, "control plane") {
+		t.Fatalf("failedAt = %q, want the control-plane phase", report.FailedAt)
+	}
+}
+
+// Confirmation prompts gate every mutating phase; declining aborts cleanly
+// before anything is touched.
+func TestExecute_DeclineConfirmationAborts(t *testing.T) {
+	w := newWorld()
+	m := newWorldMock(w)
+	svc := newTestService(m)
+	ctx := context.Background()
+
+	plan, err := svc.BuildPlan(ctx, "prod-east", "1.32", PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+
+	var prompted []string
+	report, err := svc.Execute(ctx, plan, ExecuteOptions{
+		Confirm: func(label string) bool {
+			prompted = append(prompted, label)
+			return false
+		},
+	})
+	if !errors.Is(err, ErrAborted) {
+		t.Fatalf("err = %v, want ErrAborted", err)
+	}
+	if len(prompted) != 1 {
+		t.Fatalf("prompted %d times, want 1 (declined the first phase)", len(prompted))
+	}
+	if m.Calls.UpdateClusterVersion+m.Calls.UpdateAddon+m.Calls.UpdateNodegroupVersion != 0 {
+		t.Fatal("declining the prompt must not mutate anything")
+	}
+	if len(report.Remaining) == 0 {
+		t.Fatalf("report.Remaining = %v, want the declined work listed", report.Remaining)
+	}
+}
+
+// A blocked plan refuses to execute at all.
+func TestExecute_BlockedPlanRefuses(t *testing.T) {
+	w := newWorld()
+	m := newWorldMock(w)
+	svc := newTestService(m)
+
+	plan := &Plan{
+		ClusterName:    "prod-east",
+		CurrentVersion: "1.31",
+		TargetVersion:  "1.32",
+		Hops: []Hop{{From: "1.31", To: "1.32", Steps: []Step{
+			{Type: StepReadiness, Description: "readiness", Status: StatusBlocked, Reason: "2 blocking insights"},
+			{Type: StepControlPlane, Description: "control plane → 1.32", Status: StatusPending},
+		}}},
+	}
+
+	_, err := svc.Execute(context.Background(), plan, ExecuteOptions{Yes: true})
+	if err == nil || !strings.Contains(err.Error(), "blockers") {
+		t.Fatalf("err = %v, want blocker refusal", err)
+	}
+	if m.Calls.UpdateClusterVersion != 0 {
+		t.Fatal("blocked plan must not mutate anything")
+	}
+	_ = w
+}

--- a/internal/services/upgrade/nodegroups.go
+++ b/internal/services/upgrade/nodegroups.go
@@ -1,0 +1,140 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	awsinternal "github.com/dantech2000/refresh/internal/aws"
+	"github.com/dantech2000/refresh/internal/services/common"
+)
+
+// NodegroupGate is a pre-flight check run before each nodegroup roll. A nil
+// gate falls back to the built-in check (nodegroup ACTIVE with no reported
+// health issues).
+type NodegroupGate func(ctx context.Context, nodegroupName string) error
+
+// NodegroupRollOptions tunes the nodegroup phase.
+type NodegroupRollOptions struct {
+	// SkipPatterns are substring patterns for nodegroups to leave alone.
+	SkipPatterns []string
+	// Force terminates pods that can't be drained due to PDBs (passed
+	// through to UpdateNodegroupVersion).
+	Force bool
+	// Gate overrides the built-in pre-flight health gate.
+	Gate NodegroupGate
+}
+
+// UpgradeNodegroups rolls every managed nodegroup to targetVersion, serially
+// and in listing order, with a pre-flight gate before each roll. It is the
+// same UpdateNodegroupVersion machinery as the AMI refresh — a version roll
+// IS an AMI refresh with Version set.
+//
+// Already-current nodegroups are skipped (idempotent rerun); custom-AMI
+// nodegroups are surfaced as manual actions, never mutated. A gate failure
+// halts the remaining nodegroups so the operator can intervene.
+func (s *Service) UpgradeNodegroups(ctx context.Context, clusterName, targetVersion string, opts NodegroupRollOptions, progress ProgressFunc) error {
+	progress = ensureProgress(progress)
+
+	nodegroups, err := s.listNodegroupStates(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	gate := opts.Gate
+	if gate == nil {
+		gate = s.defaultNodegroupGate(clusterName)
+	}
+
+	for _, ng := range nodegroups {
+		switch {
+		case versionAtLeast(ng.Version, targetVersion):
+			progress("nodegroup %s already at %s, skipping", ng.Name, ng.Version)
+			continue
+		case matchesAny(ng.Name, opts.SkipPatterns):
+			progress("nodegroup %s: skipped via --skip-nodegroup", ng.Name)
+			continue
+		case ng.CustomAMI:
+			progress("nodegroup %s: MANUAL — custom AMI; build and roll a %s-compatible AMI yourself", ng.Name, targetVersion)
+			continue
+		}
+
+		if err := gate(ctx, ng.Name); err != nil {
+			return fmt.Errorf("pre-flight gate failed for nodegroup %s (remaining nodegroups not attempted): %w", ng.Name, err)
+		}
+
+		if err := s.rollNodegroup(ctx, clusterName, ng.Name, targetVersion, opts.Force, progress); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// rollNodegroup starts and watches a single nodegroup version roll.
+func (s *Service) rollNodegroup(ctx context.Context, clusterName, nodegroupName, targetVersion string, force bool, progress ProgressFunc) error {
+	input := &eks.UpdateNodegroupVersionInput{
+		ClusterName:   aws.String(clusterName),
+		NodegroupName: aws.String(nodegroupName),
+		Version:       aws.String(targetVersion),
+		Force:         force,
+		// Pin the idempotency token so WithRetry re-issues the SAME request
+		// instead of submitting a fresh update per attempt.
+		ClientRequestToken: aws.String(common.IdempotencyToken()),
+	}
+	out, err := common.WithRetry(ctx, common.DefaultRetryConfig, func(rc context.Context) (*eks.UpdateNodegroupVersionOutput, error) {
+		return s.eksClient.UpdateNodegroupVersion(rc, input)
+	})
+	if err != nil {
+		return awsinternal.FormatAWSError(err, fmt.Sprintf("rolling nodegroup %s to %s", nodegroupName, targetVersion))
+	}
+
+	updateID := ""
+	if out.Update != nil {
+		updateID = aws.ToString(out.Update.Id)
+	}
+	progress("nodegroup %s roll to %s started (update %s)", nodegroupName, targetVersion, updateID)
+
+	if updateID != "" {
+		if err := s.waitForUpdate(ctx, &eks.DescribeUpdateInput{
+			Name:          aws.String(clusterName),
+			NodegroupName: aws.String(nodegroupName),
+			UpdateId:      aws.String(updateID),
+		}, fmt.Sprintf("nodegroup %s roll to %s", nodegroupName, targetVersion), progress); err != nil {
+			return err
+		}
+	}
+	progress("nodegroup %s is at %s", nodegroupName, targetVersion)
+	return nil
+}
+
+// defaultNodegroupGate verifies the nodegroup is ACTIVE and reports no
+// health issues before a roll starts.
+func (s *Service) defaultNodegroupGate(clusterName string) NodegroupGate {
+	return func(ctx context.Context, nodegroupName string) error {
+		out, err := common.WithRetry(ctx, common.DefaultRetryConfig, func(rc context.Context) (*eks.DescribeNodegroupOutput, error) {
+			return s.eksClient.DescribeNodegroup(rc, &eks.DescribeNodegroupInput{
+				ClusterName:   aws.String(clusterName),
+				NodegroupName: aws.String(nodegroupName),
+			})
+		})
+		if err != nil {
+			return awsinternal.FormatAWSError(err, fmt.Sprintf("checking nodegroup %s", nodegroupName))
+		}
+		ng := out.Nodegroup
+		if ng == nil {
+			return fmt.Errorf("nodegroup %s not found", nodegroupName)
+		}
+		if ng.Status != ekstypes.NodegroupStatusActive {
+			return fmt.Errorf("nodegroup %s is %s, not ACTIVE", nodegroupName, ng.Status)
+		}
+		if ng.Health != nil && len(ng.Health.Issues) > 0 {
+			issue := ng.Health.Issues[0]
+			return fmt.Errorf("nodegroup %s has %d health issue(s), first: %s: %s",
+				nodegroupName, len(ng.Health.Issues), issue.Code, aws.ToString(issue.Message))
+		}
+		return nil
+	}
+}

--- a/internal/services/upgrade/nodegroups_test.go
+++ b/internal/services/upgrade/nodegroups_test.go
@@ -1,0 +1,223 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	"github.com/dantech2000/refresh/internal/mocks"
+)
+
+// captureNodegroupRolls records UpdateNodegroupVersion calls in order.
+func captureNodegroupRolls(m *mocks.EKSAPI) *[]eks.UpdateNodegroupVersionInput {
+	var mu sync.Mutex
+	captured := &[]eks.UpdateNodegroupVersionInput{}
+	m.UpdateNodegroupVersionFn = func(_ context.Context, in *eks.UpdateNodegroupVersionInput, _ ...func(*eks.Options)) (*eks.UpdateNodegroupVersionOutput, error) {
+		mu.Lock()
+		*captured = append(*captured, *in)
+		mu.Unlock()
+		return &eks.UpdateNodegroupVersionOutput{Update: &ekstypes.Update{
+			Id:     aws.String("u-" + aws.ToString(in.NodegroupName)),
+			Status: ekstypes.UpdateStatusInProgress,
+		}}, nil
+	}
+	return captured
+}
+
+// Acceptance (REF-101): a multi-nodegroup cluster rolls in order with gates,
+// version and idempotency token set on each call.
+func TestUpgradeNodegroups_RollsInOrderWithGates(t *testing.T) {
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.32").
+		WithNodegroup("workers-a", "1.31", ekstypes.AMITypesAl2023X8664Standard).
+		WithNodegroup("workers-b", "1.31", ekstypes.AMITypesAl2023X8664Standard).
+		WithNodegroup("workers-c", "1.31", ekstypes.AMITypesAl2023X8664Standard).
+		WithDescribeUpdate(ekstypes.UpdateStatusSuccessful).
+		Build()
+	rolls := captureNodegroupRolls(m)
+
+	var mu sync.Mutex
+	var gated []string
+	gate := func(_ context.Context, ng string) error {
+		mu.Lock()
+		gated = append(gated, ng)
+		mu.Unlock()
+		return nil
+	}
+
+	svc := newTestService(m)
+	err := svc.UpgradeNodegroups(context.Background(), "prod-east", "1.32",
+		NodegroupRollOptions{Gate: gate}, nil)
+	if err != nil {
+		t.Fatalf("UpgradeNodegroups: %v", err)
+	}
+
+	if len(*rolls) != 3 {
+		t.Fatalf("rolls = %d, want 3", len(*rolls))
+	}
+	for i, want := range []string{"workers-a", "workers-b", "workers-c"} {
+		in := (*rolls)[i]
+		if aws.ToString(in.NodegroupName) != want {
+			t.Fatalf("roll %d = %s, want %s (listing order)", i, aws.ToString(in.NodegroupName), want)
+		}
+		if aws.ToString(in.Version) != "1.32" {
+			t.Fatalf("roll %d version = %q, want 1.32", i, aws.ToString(in.Version))
+		}
+		if in.ClientRequestToken == nil || *in.ClientRequestToken == "" {
+			t.Fatalf("roll %d missing ClientRequestToken", i)
+		}
+	}
+	// The gate ran before every roll.
+	if len(gated) != 3 {
+		t.Fatalf("gate ran %d times, want 3", len(gated))
+	}
+}
+
+// Acceptance (REF-101): a custom-AMI nodegroup appears as a manual-action
+// item, not an API call.
+func TestUpgradeNodegroups_CustomAMIIsManualNotAPI(t *testing.T) {
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.32").
+		WithNodegroup("byo-ami", "1.31", ekstypes.AMITypesCustom).
+		WithNodegroup("workers-a", "1.31", ekstypes.AMITypesAl2023X8664Standard).
+		WithDescribeUpdate(ekstypes.UpdateStatusSuccessful).
+		Build()
+	rolls := captureNodegroupRolls(m)
+
+	var lines []string
+	progress := func(format string, args ...any) {
+		lines = append(lines, sprintf(format, args...))
+	}
+
+	svc := newTestService(m)
+	if err := svc.UpgradeNodegroups(context.Background(), "prod-east", "1.32",
+		NodegroupRollOptions{}, progress); err != nil {
+		t.Fatalf("UpgradeNodegroups: %v", err)
+	}
+
+	if len(*rolls) != 1 || aws.ToString((*rolls)[0].NodegroupName) != "workers-a" {
+		t.Fatalf("rolls = %+v, want only workers-a", rolls)
+	}
+	manualMentioned := false
+	for _, l := range lines {
+		if strings.Contains(l, "byo-ami") && strings.Contains(l, "MANUAL") {
+			manualMentioned = true
+		}
+	}
+	if !manualMentioned {
+		t.Fatalf("progress lines %v should surface byo-ami as a manual action", lines)
+	}
+}
+
+// A gate failure halts the remaining nodegroups with a clear message.
+func TestUpgradeNodegroups_GateFailureHaltsRemaining(t *testing.T) {
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.32").
+		WithNodegroup("workers-a", "1.31", ekstypes.AMITypesAl2023X8664Standard).
+		WithNodegroup("workers-b", "1.31", ekstypes.AMITypesAl2023X8664Standard).
+		WithNodegroup("workers-c", "1.31", ekstypes.AMITypesAl2023X8664Standard).
+		WithDescribeUpdate(ekstypes.UpdateStatusSuccessful).
+		Build()
+	rolls := captureNodegroupRolls(m)
+
+	gate := func(_ context.Context, ng string) error {
+		if ng == "workers-b" {
+			return sprintfErr("nodegroup %s has 2 unhealthy nodes", ng)
+		}
+		return nil
+	}
+
+	svc := newTestService(m)
+	err := svc.UpgradeNodegroups(context.Background(), "prod-east", "1.32",
+		NodegroupRollOptions{Gate: gate}, nil)
+	if err == nil || !strings.Contains(err.Error(), "workers-b") {
+		t.Fatalf("err = %v, want gate failure naming workers-b", err)
+	}
+	if !strings.Contains(err.Error(), "remaining nodegroups not attempted") {
+		t.Fatalf("err = %v, want halt message", err)
+	}
+	if len(*rolls) != 1 {
+		t.Fatalf("rolls = %d, want 1 (workers-a only; halt before b, c never attempted)", len(*rolls))
+	}
+}
+
+// The built-in gate blocks rolls of nodegroups that aren't ACTIVE.
+func TestUpgradeNodegroups_DefaultGateChecksHealth(t *testing.T) {
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.32").
+		WithDescribeUpdate(ekstypes.UpdateStatusSuccessful).
+		Build()
+	// One degraded nodegroup, hand-wired (the builder always returns ACTIVE).
+	m.ListNodegroupsFn = func(_ context.Context, _ *eks.ListNodegroupsInput, _ ...func(*eks.Options)) (*eks.ListNodegroupsOutput, error) {
+		return &eks.ListNodegroupsOutput{Nodegroups: []string{"workers-a"}}, nil
+	}
+	m.DescribeNodegroupFn = func(_ context.Context, in *eks.DescribeNodegroupInput, _ ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error) {
+		return &eks.DescribeNodegroupOutput{Nodegroup: &ekstypes.Nodegroup{
+			NodegroupName: in.NodegroupName,
+			Version:       aws.String("1.31"),
+			AmiType:       ekstypes.AMITypesAl2023X8664Standard,
+			Status:        ekstypes.NodegroupStatusDegraded,
+		}}, nil
+	}
+	rolls := captureNodegroupRolls(m)
+
+	svc := newTestService(m)
+	err := svc.UpgradeNodegroups(context.Background(), "prod-east", "1.32",
+		NodegroupRollOptions{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "DEGRADED") {
+		t.Fatalf("err = %v, want DEGRADED gate failure", err)
+	}
+	if len(*rolls) != 0 {
+		t.Fatalf("rolls = %d, want 0", len(*rolls))
+	}
+}
+
+// Skip patterns and already-current nodegroups are not rolled.
+func TestUpgradeNodegroups_SkipAndAlreadyCurrent(t *testing.T) {
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.32").
+		WithNodegroup("workers-a", "1.32", ekstypes.AMITypesAl2023X8664Standard). // current
+		WithNodegroup("spot-pool", "1.31", ekstypes.AMITypesAl2023X8664Standard). // skipped
+		WithNodegroup("workers-b", "1.31", ekstypes.AMITypesAl2023X8664Standard). // rolled
+		WithDescribeUpdate(ekstypes.UpdateStatusSuccessful).
+		Build()
+	rolls := captureNodegroupRolls(m)
+
+	svc := newTestService(m)
+	if err := svc.UpgradeNodegroups(context.Background(), "prod-east", "1.32",
+		NodegroupRollOptions{SkipPatterns: []string{"spot"}}, nil); err != nil {
+		t.Fatalf("UpgradeNodegroups: %v", err)
+	}
+	if len(*rolls) != 1 || aws.ToString((*rolls)[0].NodegroupName) != "workers-b" {
+		t.Fatalf("rolls = %+v, want only workers-b", rolls)
+	}
+}
+
+// Force passes through to the API call.
+func TestUpgradeNodegroups_ForcePassthrough(t *testing.T) {
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.32").
+		WithNodegroup("workers-a", "1.31", ekstypes.AMITypesAl2023X8664Standard).
+		WithDescribeUpdate(ekstypes.UpdateStatusSuccessful).
+		Build()
+	rolls := captureNodegroupRolls(m)
+
+	svc := newTestService(m)
+	if err := svc.UpgradeNodegroups(context.Background(), "prod-east", "1.32",
+		NodegroupRollOptions{Force: true}, nil); err != nil {
+		t.Fatalf("UpgradeNodegroups: %v", err)
+	}
+	if len(*rolls) != 1 || !(*rolls)[0].Force {
+		t.Fatalf("rolls = %+v, want Force=true", rolls)
+	}
+}
+
+func sprintf(format string, args ...any) string { return fmt.Sprintf(format, args...) }
+
+func sprintfErr(format string, args ...any) error { return fmt.Errorf(format, args...) }

--- a/internal/services/upgrade/plan.go
+++ b/internal/services/upgrade/plan.go
@@ -1,0 +1,313 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	awsinternal "github.com/dantech2000/refresh/internal/aws"
+	"github.com/dantech2000/refresh/internal/services/addons"
+	"github.com/dantech2000/refresh/internal/services/common"
+)
+
+// PlanOptions tunes plan generation.
+type PlanOptions struct {
+	// SkipAddons are addon names the user manages out-of-band (Helm/GitOps);
+	// they appear in the plan as manual steps and are never mutated.
+	SkipAddons []string
+	// SkipNodegroups are substring patterns for nodegroups to leave alone.
+	SkipNodegroups []string
+}
+
+// BuildPlan derives the full ordered upgrade plan for clusterName to reach
+// targetVersion. The plan is also the resume mechanism: steps whose desired
+// state is already satisfied by the live cluster are marked completed, so a
+// rerun after a partial upgrade (or a second run after success) executes only
+// what remains.
+func (s *Service) BuildPlan(ctx context.Context, clusterName, targetVersion string, opts PlanOptions) (*Plan, error) {
+	cluster, err := s.describeCluster(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+	currentVersion := aws.ToString(cluster.Version)
+
+	hops, err := expandHops(currentVersion, targetVersion)
+	if err != nil {
+		return nil, err
+	}
+	if len(hops) == 0 {
+		// Control plane already at the target. Still plan a same-version hop
+		// so addons/nodegroups that lag behind it (e.g. after an interrupted
+		// run) get caught up; a fully-current cluster derives every step as
+		// completed and the run is a no-op.
+		hops = []string{targetVersion}
+	}
+
+	plan := &Plan{
+		ClusterName:    clusterName,
+		CurrentVersion: currentVersion,
+		TargetVersion:  targetVersion,
+	}
+
+	if err := s.checkVersionOffered(ctx, targetVersion, plan); err != nil {
+		return nil, err
+	}
+
+	nodegroups, err := s.listNodegroupStates(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	addonsSvc := s.addonsService()
+	addonList, err := addonsSvc.List(ctx, clusterName, addons.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	addonList = addons.SortByDependency(addonList)
+
+	// Simulated state advances hop by hop so later hops plan against where
+	// the cluster WILL be, while completed-step detection uses live state.
+	simNodegroups := make(map[string]string, len(nodegroups))
+	for _, ng := range nodegroups {
+		simNodegroups[ng.Name] = ng.Version
+	}
+
+	for _, hopTo := range hops {
+		hop := Hop{From: prevVersion(plan, hopTo), To: hopTo}
+
+		hop.Steps = append(hop.Steps, s.readinessStep(ctx, clusterName, hopTo, nodegroups, simNodegroups, plan))
+		hop.Steps = append(hop.Steps, controlPlaneStep(currentVersion, aws.ToString(cluster.Version), hopTo, cluster.Status))
+		hop.Steps = append(hop.Steps, s.addonSteps(ctx, addonsSvc, addonList, hopTo, opts.SkipAddons)...)
+		hop.Steps = append(hop.Steps, nodegroupSteps(nodegroups, hopTo, opts.SkipNodegroups)...)
+
+		plan.Hops = append(plan.Hops, hop)
+
+		// Advance the simulation: after this hop, rollable nodegroups sit at
+		// the hop target.
+		for _, ng := range nodegroups {
+			if !ng.CustomAMI && !matchesAny(ng.Name, opts.SkipNodegroups) && !versionAtLeast(simNodegroups[ng.Name], hopTo) {
+				simNodegroups[ng.Name] = hopTo
+			}
+		}
+	}
+
+	return plan, nil
+}
+
+// prevVersion returns the From version for the next hop: the previous hop's
+// target, or the plan's current version for the first hop.
+func prevVersion(plan *Plan, _ string) string {
+	if len(plan.Hops) == 0 {
+		return plan.CurrentVersion
+	}
+	return plan.Hops[len(plan.Hops)-1].To
+}
+
+// checkVersionOffered verifies EKS offers the target version. An API error
+// degrades to a plan warning (older SDK endpoints/permissions); an explicit
+// "not offered" answer is a hard error.
+func (s *Service) checkVersionOffered(ctx context.Context, targetVersion string, plan *Plan) error {
+	out, err := common.WithRetry(ctx, common.DefaultRetryConfig, func(rc context.Context) (*eks.DescribeClusterVersionsOutput, error) {
+		return s.eksClient.DescribeClusterVersions(rc, &eks.DescribeClusterVersionsInput{
+			ClusterVersions: []string{targetVersion},
+		})
+	})
+	if err != nil {
+		plan.Warnings = append(plan.Warnings,
+			fmt.Sprintf("could not verify that EKS offers %s (continuing): %v", targetVersion, err))
+		return nil
+	}
+	for _, v := range out.ClusterVersions {
+		if aws.ToString(v.ClusterVersion) == targetVersion {
+			return nil
+		}
+	}
+	return fmt.Errorf("version %s is not offered by EKS", targetVersion)
+}
+
+// readinessStep builds the per-hop readiness gate: kubelet version skew plus
+// EKS Cluster Insights (UPGRADE_READINESS) for the hop target.
+func (s *Service) readinessStep(ctx context.Context, clusterName, hopTo string, nodegroups []nodegroupState, simNodegroups map[string]string, plan *Plan) Step {
+	step := Step{
+		Type:        StepReadiness,
+		Description: fmt.Sprintf("readiness for %s (insights + version skew)", hopTo),
+		Version:     hopTo,
+		Status:      StatusPending,
+	}
+
+	// Version skew: every nodegroup must stay within the supported kubelet
+	// skew of the hop target once the control plane moves.
+	hopMinor, err := minorVersion(hopTo)
+	if err != nil {
+		step.Status = StatusBlocked
+		step.Reason = err.Error()
+		return step
+	}
+	var skewViolations []string
+	for _, ng := range nodegroups {
+		simVersion := simNodegroups[ng.Name]
+		ngMinor, err := minorVersion(simVersion)
+		if err != nil {
+			continue
+		}
+		if hopMinor-ngMinor > kubeletSkew {
+			skewViolations = append(skewViolations,
+				fmt.Sprintf("nodegroup %s at %s would exceed the kubelet skew limit (%d minors) against %s", ng.Name, simVersion, kubeletSkew, hopTo))
+		}
+	}
+	if len(skewViolations) > 0 {
+		step.Status = StatusBlocked
+		step.Reason = strings.Join(skewViolations, "; ")
+		return step
+	}
+
+	// Cluster Insights: blocking on ERROR, warn on WARNING; unavailable
+	// insights degrade to a plan warning rather than blocking the upgrade.
+	insights, err := s.listUpgradeInsights(ctx, clusterName, hopTo)
+	if err != nil {
+		plan.Warnings = append(plan.Warnings,
+			fmt.Sprintf("cluster insights unavailable for %s (continuing): %v", hopTo, err))
+		step.Reason = "insights unavailable; skew OK"
+		return step
+	}
+
+	var errorsFound, warningsFound []string
+	for _, in := range insights {
+		if in.InsightStatus == nil {
+			continue
+		}
+		name := aws.ToString(in.Name)
+		if name == "" {
+			name = aws.ToString(in.Id)
+		}
+		switch in.InsightStatus.Status {
+		case ekstypes.InsightStatusValueError:
+			errorsFound = append(errorsFound, name)
+		case ekstypes.InsightStatusValueWarning:
+			warningsFound = append(warningsFound, name)
+		}
+	}
+	if len(errorsFound) > 0 {
+		step.Status = StatusBlocked
+		step.Reason = fmt.Sprintf("%d blocking insight(s): %s", len(errorsFound), strings.Join(errorsFound, ", "))
+		return step
+	}
+	if len(warningsFound) > 0 {
+		step.Reason = fmt.Sprintf("%d insight warning(s): %s", len(warningsFound), strings.Join(warningsFound, ", "))
+		plan.Warnings = append(plan.Warnings,
+			fmt.Sprintf("insight warnings for %s: %s", hopTo, strings.Join(warningsFound, ", ")))
+	} else {
+		step.Reason = "0 blocking insights; skew OK"
+	}
+	return step
+}
+
+// listUpgradeInsights fetches UPGRADE_READINESS insights for the given
+// Kubernetes version.
+func (s *Service) listUpgradeInsights(ctx context.Context, clusterName, k8sVersion string) ([]ekstypes.InsightSummary, error) {
+	return awsinternal.ListAllPages(ctx, fmt.Sprintf("listing upgrade insights for cluster %s", clusterName),
+		func(rc context.Context, token *string) (*eks.ListInsightsOutput, error) {
+			return s.eksClient.ListInsights(rc, &eks.ListInsightsInput{
+				ClusterName: aws.String(clusterName),
+				Filter: &ekstypes.InsightsFilter{
+					Categories:         []ekstypes.Category{ekstypes.CategoryUpgradeReadiness},
+					KubernetesVersions: []string{k8sVersion},
+				},
+				NextToken: token,
+			})
+		},
+		func(out *eks.ListInsightsOutput) ([]ekstypes.InsightSummary, *string) {
+			return out.Insights, out.NextToken
+		},
+	)
+}
+
+// controlPlaneStep derives the control-plane step for a hop, marking it
+// completed when the live cluster is already at or past the hop target.
+func controlPlaneStep(_, liveVersion, hopTo string, status ekstypes.ClusterStatus) Step {
+	step := Step{
+		Type:        StepControlPlane,
+		Description: fmt.Sprintf("control plane → %s", hopTo),
+		Version:     hopTo,
+		Status:      StatusPending,
+	}
+	if versionAtLeast(liveVersion, hopTo) {
+		step.Status = StatusCompleted
+		step.Reason = fmt.Sprintf("control plane already at %s", liveVersion)
+		return step
+	}
+	if status == ekstypes.ClusterStatusUpdating {
+		step.Reason = "an update is already in progress; the orchestrator will attach and watch"
+	}
+	return step
+}
+
+// addonSteps derives one step per addon for the hop: the latest version
+// compatible with the hop target, completed when the addon already runs it,
+// blocked when no compatible version exists.
+func (s *Service) addonSteps(ctx context.Context, svc *addons.ServiceImpl, addonList []addons.AddonSummary, hopTo string, skip []string) []Step {
+	steps := make([]Step, 0, len(addonList))
+	for _, a := range addonList {
+		step := Step{
+			Type:        StepAddon,
+			Target:      a.Name,
+			Description: fmt.Sprintf("addon %s → latest compatible with %s", a.Name, hopTo),
+			Status:      StatusPending,
+		}
+		if matchesAny(a.Name, skip) {
+			step.Status = StatusManual
+			step.Reason = "skipped via --skip (managed out-of-band)"
+			steps = append(steps, step)
+			continue
+		}
+		versions, err := svc.GetAvailableVersions(ctx, a.Name, hopTo)
+		if err != nil {
+			step.Status = StatusBlocked
+			step.Reason = fmt.Sprintf("no version of %s is compatible with %s: %v", a.Name, hopTo, err)
+			steps = append(steps, step)
+			continue
+		}
+		chosen := versions[0].Version
+		step.Version = chosen
+		step.Description = fmt.Sprintf("addon %s → %s (compatible with %s)", a.Name, chosen, hopTo)
+		if addons.CompareVersions(a.Version, chosen) >= 0 {
+			step.Status = StatusCompleted
+			step.Reason = fmt.Sprintf("already at %s", a.Version)
+		}
+		steps = append(steps, step)
+	}
+	return steps
+}
+
+// nodegroupSteps derives one step per nodegroup for the hop. Custom-AMI
+// nodegroups surface as manual actions (the operator owns their AMI
+// lifecycle); skipped patterns likewise are never mutated.
+func nodegroupSteps(nodegroups []nodegroupState, hopTo string, skipPatterns []string) []Step {
+	steps := make([]Step, 0, len(nodegroups))
+	for _, ng := range nodegroups {
+		step := Step{
+			Type:        StepNodegroup,
+			Target:      ng.Name,
+			Description: fmt.Sprintf("nodegroup %s → %s", ng.Name, hopTo),
+			Version:     hopTo,
+			Status:      StatusPending,
+		}
+		switch {
+		case versionAtLeast(ng.Version, hopTo):
+			step.Status = StatusCompleted
+			step.Reason = fmt.Sprintf("already at %s", ng.Version)
+		case matchesAny(ng.Name, skipPatterns):
+			step.Status = StatusManual
+			step.Reason = "skipped via --skip-nodegroup"
+		case ng.CustomAMI:
+			step.Status = StatusManual
+			step.Reason = fmt.Sprintf("custom AMI nodegroup: build and roll a %s-compatible AMI yourself", hopTo)
+		}
+		steps = append(steps, step)
+	}
+	return steps
+}

--- a/internal/services/upgrade/plan_test.go
+++ b/internal/services/upgrade/plan_test.go
@@ -1,0 +1,307 @@
+package upgrade
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	"github.com/dantech2000/refresh/internal/mocks"
+)
+
+func testLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+func newTestService(m *mocks.EKSAPI) *Service {
+	s := NewService(m, testLogger())
+	s.PollInterval = time.Millisecond
+	return s
+}
+
+// twoHopMock builds a cluster two minors behind target with one addon and
+// one nodegroup, everything healthy.
+func twoHopMock() *mocks.EKSAPI {
+	return mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.31").
+		WithAddon("vpc-cni", "v1.31.0-eksbuild.1", ekstypes.AddonStatusActive).
+		WithAddonVersions("vpc-cni", []string{"v1.33.0-eksbuild.1"}, "1.32").
+		WithNodegroup("workers-a", "1.31", ekstypes.AMITypesAl2023X8664Standard).
+		Build()
+}
+
+// Acceptance (REF-98): a fixture cluster two minors behind yields a two-cycle
+// plan with the gates shown per hop.
+func TestBuildPlan_TwoMinorsBehindYieldsTwoHops(t *testing.T) {
+	svc := newTestService(twoHopMock())
+
+	plan, err := svc.BuildPlan(context.Background(), "prod-east", "1.33", PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+
+	if len(plan.Hops) != 2 {
+		t.Fatalf("hops = %d, want 2 (1.31→1.32→1.33)", len(plan.Hops))
+	}
+	if plan.Hops[0].From != "1.31" || plan.Hops[0].To != "1.32" ||
+		plan.Hops[1].From != "1.32" || plan.Hops[1].To != "1.33" {
+		t.Fatalf("hop versions = %+v", plan.Hops)
+	}
+
+	// Every hop shows the full gated sequence: readiness → control plane →
+	// addons → nodegroups, in that order.
+	for _, hop := range plan.Hops {
+		var order []StepType
+		for _, s := range hop.Steps {
+			order = append(order, s.Type)
+		}
+		want := []StepType{StepReadiness, StepControlPlane, StepAddon, StepNodegroup}
+		if len(order) != len(want) {
+			t.Fatalf("hop %s→%s steps = %v, want %v", hop.From, hop.To, order, want)
+		}
+		for i := range want {
+			if order[i] != want[i] {
+				t.Fatalf("hop %s→%s step order = %v, want %v", hop.From, hop.To, order, want)
+			}
+		}
+	}
+
+	if plan.Blocked() {
+		t.Fatalf("plan unexpectedly blocked: %v", plan.Blockers())
+	}
+	if plan.PendingSteps() == 0 {
+		t.Fatal("plan should have pending steps")
+	}
+}
+
+// Acceptance (REF-98): a blocker (lagging nodegroup beyond the kubelet skew)
+// renders the plan with the blocker called out; the command layer exits
+// non-zero on Blocked().
+func TestBuildPlan_LaggingNodegroupBlocks(t *testing.T) {
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.31").
+		WithAddon("vpc-cni", "v1.31.0-eksbuild.1", ekstypes.AddonStatusActive).
+		WithAddonVersions("vpc-cni", []string{"v1.33.0-eksbuild.1"}, "1.32").
+		WithNodegroup("ancient", "1.28", ekstypes.AMITypesAl2023X8664Standard).
+		Build()
+	svc := newTestService(m)
+
+	plan, err := svc.BuildPlan(context.Background(), "prod-east", "1.32", PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	if !plan.Blocked() {
+		t.Fatal("plan should be blocked: nodegroup at 1.28 vs target 1.32 exceeds skew 3")
+	}
+	blockers := plan.Blockers()
+	if len(blockers) == 0 || !strings.Contains(blockers[0], "ancient") {
+		t.Fatalf("blockers = %v, want mention of nodegroup 'ancient'", blockers)
+	}
+}
+
+func TestBuildPlan_OlderTargetRejected(t *testing.T) {
+	svc := newTestService(twoHopMock())
+
+	if _, err := svc.BuildPlan(context.Background(), "prod-east", "1.30", PlanOptions{}); err == nil {
+		t.Fatal("expected error for target < current")
+	}
+}
+
+// Rerunning against the version the cluster already runs (with addons and
+// nodegroups current too) derives every step completed: a no-op, not an error.
+func TestBuildPlan_FullySatisfiedClusterIsNoOp(t *testing.T) {
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.31").
+		WithAddon("vpc-cni", "v1.33.0-eksbuild.1", ekstypes.AddonStatusActive).
+		WithAddonVersions("vpc-cni", []string{"v1.33.0-eksbuild.1"}, "1.31").
+		WithNodegroup("workers-a", "1.31", ekstypes.AMITypesAl2023X8664Standard).
+		Build()
+	svc := newTestService(m)
+
+	plan, err := svc.BuildPlan(context.Background(), "prod-east", "1.31", PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildPlan to current version: %v", err)
+	}
+	if plan.PendingSteps() != 0 {
+		t.Fatalf("PendingSteps = %d, want 0 (no-op): %+v", plan.PendingSteps(), plan.Hops)
+	}
+	if plan.Blocked() {
+		t.Fatalf("plan blocked: %v", plan.Blockers())
+	}
+}
+
+func TestBuildPlan_VersionNotOfferedRejected(t *testing.T) {
+	m := twoHopMock()
+	m.DescribeClusterVersionsFn = func(_ context.Context, _ *eks.DescribeClusterVersionsInput, _ ...func(*eks.Options)) (*eks.DescribeClusterVersionsOutput, error) {
+		return &eks.DescribeClusterVersionsOutput{}, nil
+	}
+	svc := newTestService(m)
+
+	_, err := svc.BuildPlan(context.Background(), "prod-east", "1.99", PlanOptions{})
+	if err == nil || !strings.Contains(err.Error(), "not offered") {
+		t.Fatalf("err = %v, want 'not offered'", err)
+	}
+}
+
+// A blocking (ERROR) upgrade insight blocks the hop's readiness gate.
+func TestBuildPlan_BlockingInsight(t *testing.T) {
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.31").
+		WithAddon("vpc-cni", "v1.31.0-eksbuild.1", ekstypes.AddonStatusActive).
+		WithAddonVersions("vpc-cni", []string{"v1.33.0-eksbuild.1"}, "1.32").
+		WithNodegroup("workers-a", "1.31", ekstypes.AMITypesAl2023X8664Standard).
+		WithInsight("Deprecated APIs removed in 1.32", ekstypes.InsightStatusValueError, "1.32").
+		Build()
+	svc := newTestService(m)
+
+	plan, err := svc.BuildPlan(context.Background(), "prod-east", "1.32", PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	if !plan.Blocked() {
+		t.Fatal("plan should be blocked by ERROR insight")
+	}
+	if b := plan.Blockers(); !strings.Contains(b[0], "Deprecated APIs") {
+		t.Fatalf("blockers = %v, want the insight named", b)
+	}
+}
+
+// WARNING insights don't block; they surface as plan warnings.
+func TestBuildPlan_WarningInsightDoesNotBlock(t *testing.T) {
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.31").
+		WithAddon("vpc-cni", "v1.31.0-eksbuild.1", ekstypes.AddonStatusActive).
+		WithAddonVersions("vpc-cni", []string{"v1.33.0-eksbuild.1"}, "1.32").
+		WithNodegroup("workers-a", "1.31", ekstypes.AMITypesAl2023X8664Standard).
+		WithInsight("Deprecated APIs in 2 manifests", ekstypes.InsightStatusValueWarning, "1.32").
+		Build()
+	svc := newTestService(m)
+
+	plan, err := svc.BuildPlan(context.Background(), "prod-east", "1.32", PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	if plan.Blocked() {
+		t.Fatalf("WARNING insight must not block: %v", plan.Blockers())
+	}
+	found := false
+	for _, w := range plan.Warnings {
+		if strings.Contains(w, "Deprecated APIs") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("warnings = %v, want the insight surfaced", plan.Warnings)
+	}
+}
+
+// Custom-AMI nodegroups appear as manual steps, never as API mutations.
+func TestBuildPlan_CustomAMINodegroupIsManual(t *testing.T) {
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.31").
+		WithAddon("vpc-cni", "v1.31.0-eksbuild.1", ekstypes.AddonStatusActive).
+		WithAddonVersions("vpc-cni", []string{"v1.33.0-eksbuild.1"}, "1.32").
+		WithNodegroup("byo-ami", "1.31", ekstypes.AMITypesCustom).
+		Build()
+	svc := newTestService(m)
+
+	plan, err := svc.BuildPlan(context.Background(), "prod-east", "1.32", PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	step := findStep(t, plan.Hops[0].Steps, StepNodegroup, "byo-ami")
+	if step.Status != StatusManual {
+		t.Fatalf("custom-AMI nodegroup step status = %s, want manual", step.Status)
+	}
+	if !strings.Contains(step.Reason, "custom AMI") {
+		t.Fatalf("reason = %q, want custom AMI explanation", step.Reason)
+	}
+}
+
+// An addon with no version compatible with the hop target blocks the plan.
+func TestBuildPlan_AddonWithoutCompatibleVersionBlocks(t *testing.T) {
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.31").
+		WithAddon("legacy-addon", "v0.9.0", ekstypes.AddonStatusActive).
+		WithNodegroup("workers-a", "1.31", ekstypes.AMITypesAl2023X8664Standard).
+		Build()
+	// No WithAddonVersions: DescribeAddonVersions returns nothing for it.
+	svc := newTestService(m)
+
+	plan, err := svc.BuildPlan(context.Background(), "prod-east", "1.32", PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	if !plan.Blocked() {
+		t.Fatal("plan should be blocked: no compatible addon version")
+	}
+}
+
+// Resume-by-re-derivation: when control plane, addons, and nodegroups all
+// already satisfy a hop, every step in it derives as completed.
+func TestBuildPlan_PartiallyUpgradedClusterMarksCompletedSteps(t *testing.T) {
+	// Cluster mid-upgrade: control plane already on 1.32, addon and
+	// nodegroup still behind.
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.32").
+		WithAddon("vpc-cni", "v1.31.0-eksbuild.1", ekstypes.AddonStatusActive).
+		WithAddonVersions("vpc-cni", []string{"v1.33.0-eksbuild.1"}, "1.32").
+		WithNodegroup("workers-a", "1.31", ekstypes.AMITypesAl2023X8664Standard).
+		Build()
+	svc := newTestService(m)
+
+	plan, err := svc.BuildPlan(context.Background(), "prod-east", "1.32", PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	if len(plan.Hops) != 1 {
+		t.Fatalf("hops = %d, want 1", len(plan.Hops))
+	}
+	var cp Step
+	for _, s := range plan.Hops[0].Steps {
+		if s.Type == StepControlPlane {
+			cp = s
+		}
+	}
+	if cp.Status != StatusCompleted {
+		t.Fatalf("control-plane step status = %s, want completed (already at 1.32)", cp.Status)
+	}
+	if s := findStep(t, plan.Hops[0].Steps, StepAddon, "vpc-cni"); s.Status != StatusPending {
+		t.Fatalf("addon step status = %s, want pending", s.Status)
+	}
+	if s := findStep(t, plan.Hops[0].Steps, StepNodegroup, "workers-a"); s.Status != StatusPending {
+		t.Fatalf("nodegroup step status = %s, want pending", s.Status)
+	}
+}
+
+// Skipped addons and nodegroups surface as manual steps.
+func TestBuildPlan_SkipListsAreManualSteps(t *testing.T) {
+	svc := newTestService(twoHopMock())
+
+	plan, err := svc.BuildPlan(context.Background(), "prod-east", "1.32", PlanOptions{
+		SkipAddons:     []string{"vpc-cni"},
+		SkipNodegroups: []string{"workers"},
+	})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	if s := findStep(t, plan.Hops[0].Steps, StepAddon, "vpc-cni"); s.Status != StatusManual {
+		t.Fatalf("skipped addon status = %s, want manual", s.Status)
+	}
+	if s := findStep(t, plan.Hops[0].Steps, StepNodegroup, "workers-a"); s.Status != StatusManual {
+		t.Fatalf("skipped nodegroup status = %s, want manual", s.Status)
+	}
+}
+
+func findStep(t *testing.T, steps []Step, typ StepType, target string) Step {
+	t.Helper()
+	for _, s := range steps {
+		if s.Type == typ && s.Target == target {
+			return s
+		}
+	}
+	t.Fatalf("no %s step for %q in %+v", typ, target, steps)
+	return Step{}
+}

--- a/internal/services/upgrade/service.go
+++ b/internal/services/upgrade/service.go
@@ -1,0 +1,203 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	awsinternal "github.com/dantech2000/refresh/internal/aws"
+	"github.com/dantech2000/refresh/internal/services/addons"
+	"github.com/dantech2000/refresh/internal/services/common"
+)
+
+// defaultPollInterval is how often in-flight EKS updates are re-checked.
+const defaultPollInterval = 15 * time.Second
+
+// EKSAPI abstracts the EKS client methods the upgrade orchestrator uses.
+// It is a superset of addons.EKSAPI so one client (or mock) serves both.
+type EKSAPI interface {
+	DescribeCluster(ctx context.Context, params *eks.DescribeClusterInput, optFns ...func(*eks.Options)) (*eks.DescribeClusterOutput, error)
+	UpdateClusterVersion(ctx context.Context, params *eks.UpdateClusterVersionInput, optFns ...func(*eks.Options)) (*eks.UpdateClusterVersionOutput, error)
+	DescribeUpdate(ctx context.Context, params *eks.DescribeUpdateInput, optFns ...func(*eks.Options)) (*eks.DescribeUpdateOutput, error)
+	DescribeClusterVersions(ctx context.Context, params *eks.DescribeClusterVersionsInput, optFns ...func(*eks.Options)) (*eks.DescribeClusterVersionsOutput, error)
+	ListInsights(ctx context.Context, params *eks.ListInsightsInput, optFns ...func(*eks.Options)) (*eks.ListInsightsOutput, error)
+	ListAddons(ctx context.Context, params *eks.ListAddonsInput, optFns ...func(*eks.Options)) (*eks.ListAddonsOutput, error)
+	DescribeAddon(ctx context.Context, params *eks.DescribeAddonInput, optFns ...func(*eks.Options)) (*eks.DescribeAddonOutput, error)
+	DescribeAddonVersions(ctx context.Context, params *eks.DescribeAddonVersionsInput, optFns ...func(*eks.Options)) (*eks.DescribeAddonVersionsOutput, error)
+	UpdateAddon(ctx context.Context, params *eks.UpdateAddonInput, optFns ...func(*eks.Options)) (*eks.UpdateAddonOutput, error)
+	ListNodegroups(ctx context.Context, params *eks.ListNodegroupsInput, optFns ...func(*eks.Options)) (*eks.ListNodegroupsOutput, error)
+	DescribeNodegroup(ctx context.Context, params *eks.DescribeNodegroupInput, optFns ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error)
+	UpdateNodegroupVersion(ctx context.Context, params *eks.UpdateNodegroupVersionInput, optFns ...func(*eks.Options)) (*eks.UpdateNodegroupVersionOutput, error)
+}
+
+// ProgressFunc receives human-readable progress lines during execution.
+type ProgressFunc func(format string, args ...any)
+
+// Service builds and executes cluster upgrade plans.
+type Service struct {
+	eksClient EKSAPI
+	logger    *slog.Logger
+
+	// PollInterval is how often in-flight updates are re-checked.
+	// Tests shrink it; defaults to defaultPollInterval.
+	PollInterval time.Duration
+}
+
+// NewService creates the upgrade orchestrator service.
+func NewService(eksClient EKSAPI, logger *slog.Logger) *Service {
+	return &Service{
+		eksClient:    eksClient,
+		logger:       logger,
+		PollInterval: defaultPollInterval,
+	}
+}
+
+// addonsService returns a fresh addon service. Fresh per call (not cached)
+// because addons.ServiceImpl memoizes the cluster's Kubernetes version, which
+// goes stale between hops of a multi-minor upgrade.
+func (s *Service) addonsService() *addons.ServiceImpl {
+	return addons.NewService(s.eksClient, s.logger)
+}
+
+// describeCluster fetches the cluster with retry + error formatting.
+func (s *Service) describeCluster(ctx context.Context, clusterName string) (*ekstypes.Cluster, error) {
+	out, err := common.WithRetry(ctx, common.DefaultRetryConfig, func(rc context.Context) (*eks.DescribeClusterOutput, error) {
+		return s.eksClient.DescribeCluster(rc, &eks.DescribeClusterInput{Name: aws.String(clusterName)})
+	})
+	if err != nil {
+		return nil, awsinternal.FormatAWSError(err, fmt.Sprintf("describing cluster %s", clusterName))
+	}
+	if out.Cluster == nil {
+		return nil, fmt.Errorf("cluster %s not found", clusterName)
+	}
+	return out.Cluster, nil
+}
+
+// nodegroupState is the per-nodegroup snapshot the planner works from.
+type nodegroupState struct {
+	Name      string
+	Version   string
+	AmiType   ekstypes.AMITypes
+	Status    ekstypes.NodegroupStatus
+	CustomAMI bool
+}
+
+// listNodegroupStates describes every nodegroup in the cluster.
+func (s *Service) listNodegroupStates(ctx context.Context, clusterName string) ([]nodegroupState, error) {
+	names, err := awsinternal.ListAllPages(ctx, fmt.Sprintf("listing nodegroups for cluster %s", clusterName),
+		func(rc context.Context, token *string) (*eks.ListNodegroupsOutput, error) {
+			return s.eksClient.ListNodegroups(rc, &eks.ListNodegroupsInput{
+				ClusterName: aws.String(clusterName),
+				NextToken:   token,
+			})
+		},
+		func(out *eks.ListNodegroupsOutput) ([]string, *string) { return out.Nodegroups, out.NextToken },
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	states := make([]nodegroupState, 0, len(names))
+	for _, name := range names {
+		out, err := common.WithRetry(ctx, common.DefaultRetryConfig, func(rc context.Context) (*eks.DescribeNodegroupOutput, error) {
+			return s.eksClient.DescribeNodegroup(rc, &eks.DescribeNodegroupInput{
+				ClusterName:   aws.String(clusterName),
+				NodegroupName: aws.String(name),
+			})
+		})
+		if err != nil {
+			return nil, awsinternal.FormatAWSError(err, fmt.Sprintf("describing nodegroup %s", name))
+		}
+		ng := out.Nodegroup
+		if ng == nil {
+			continue
+		}
+		states = append(states, nodegroupState{
+			Name:      name,
+			Version:   aws.ToString(ng.Version),
+			AmiType:   ng.AmiType,
+			Status:    ng.Status,
+			CustomAMI: ng.AmiType == ekstypes.AMITypesCustom,
+		})
+	}
+	return states, nil
+}
+
+// matchesAny reports whether name matches any of the substring patterns.
+func matchesAny(name string, patterns []string) bool {
+	for _, p := range patterns {
+		if p != "" && strings.Contains(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// waitForUpdate polls DescribeUpdate until the update succeeds, fails, or the
+// context is cancelled. what labels the update in error messages.
+func (s *Service) waitForUpdate(ctx context.Context, in *eks.DescribeUpdateInput, what string, progress ProgressFunc) error {
+	interval := s.PollInterval
+	if interval <= 0 {
+		interval = defaultPollInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			out, err := common.WithRetry(ctx, common.DefaultRetryConfig, func(rc context.Context) (*eks.DescribeUpdateOutput, error) {
+				return s.eksClient.DescribeUpdate(rc, in)
+			})
+			if err != nil {
+				// Transient describe failures shouldn't kill a long-running
+				// upgrade watch; report and keep polling.
+				progress("warning: checking %s: %v", what, err)
+				continue
+			}
+			if out.Update == nil {
+				continue
+			}
+			switch out.Update.Status {
+			case ekstypes.UpdateStatusSuccessful:
+				return nil
+			case ekstypes.UpdateStatusFailed, ekstypes.UpdateStatusCancelled:
+				return fmt.Errorf("%s %s: %s", what, strings.ToLower(string(out.Update.Status)), updateErrors(out.Update))
+			}
+		}
+	}
+}
+
+// updateErrors flattens an update's error details for display.
+func updateErrors(u *ekstypes.Update) string {
+	if u == nil || len(u.Errors) == 0 {
+		return "no error details reported"
+	}
+	msgs := make([]string, 0, len(u.Errors))
+	for _, e := range u.Errors {
+		msg := aws.ToString(e.ErrorMessage)
+		if msg == "" {
+			msg = string(e.ErrorCode)
+		}
+		msgs = append(msgs, msg)
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// noopProgress is used when the caller passes a nil ProgressFunc.
+func noopProgress(string, ...any) {}
+
+func ensureProgress(p ProgressFunc) ProgressFunc {
+	if p == nil {
+		return noopProgress
+	}
+	return p
+}

--- a/internal/services/upgrade/types.go
+++ b/internal/services/upgrade/types.go
@@ -1,0 +1,154 @@
+// Package upgrade implements the cluster upgrade orchestrator: plan
+// generation, the control-plane / addon / nodegroup phases, and the
+// sequencing engine that runs a plan with health gates between phases.
+//
+// EKS upgrades one minor version at a time, so a multi-minor upgrade expands
+// into sequential "hops" (1.31 → 1.32 → 1.33). Each hop runs control plane →
+// addons (dependency order, versions compatible with the hop target) →
+// nodegroup rolls, with a gate after every phase.
+//
+// The orchestrator is resumable by re-derivation rather than state files:
+// BuildPlan inspects actual cluster state and marks already-satisfied steps
+// completed, so rerunning `refresh cluster upgrade --to X` after a failure
+// (or after success) only executes what remains.
+package upgrade
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// StepType identifies which phase a plan step belongs to.
+type StepType string
+
+const (
+	StepReadiness    StepType = "readiness"
+	StepControlPlane StepType = "control-plane"
+	StepAddon        StepType = "addon"
+	StepNodegroup    StepType = "nodegroup"
+)
+
+// StepStatus is the planned/derived state of a step.
+type StepStatus string
+
+const (
+	// StatusPending means the step still needs to run.
+	StatusPending StepStatus = "pending"
+	// StatusCompleted means live cluster state already satisfies the step,
+	// so the engine skips it (this is what makes reruns resumable/no-ops).
+	StatusCompleted StepStatus = "completed"
+	// StatusBlocked means the step cannot run until the blocker is resolved;
+	// a plan containing blocked steps refuses to execute.
+	StatusBlocked StepStatus = "blocked"
+	// StatusManual means the orchestrator will not perform this step (e.g.
+	// custom-AMI nodegroups); it is surfaced for the operator instead.
+	StatusManual StepStatus = "manual"
+)
+
+// Step is one entry in the ordered upgrade plan.
+type Step struct {
+	Type        StepType   `json:"type" yaml:"type"`
+	Description string     `json:"description" yaml:"description"`
+	Target      string     `json:"target,omitempty" yaml:"target,omitempty"`
+	Version     string     `json:"version,omitempty" yaml:"version,omitempty"`
+	Status      StepStatus `json:"status" yaml:"status"`
+	Reason      string     `json:"reason,omitempty" yaml:"reason,omitempty"`
+}
+
+// Hop is a single minor-version upgrade cycle within the plan.
+type Hop struct {
+	From  string `json:"from" yaml:"from"`
+	To    string `json:"to" yaml:"to"`
+	Steps []Step `json:"steps" yaml:"steps"`
+}
+
+// Plan is the full ordered upgrade plan for a cluster.
+type Plan struct {
+	ClusterName    string   `json:"clusterName" yaml:"clusterName"`
+	CurrentVersion string   `json:"currentVersion" yaml:"currentVersion"`
+	TargetVersion  string   `json:"targetVersion" yaml:"targetVersion"`
+	Hops           []Hop    `json:"hops" yaml:"hops"`
+	Warnings       []string `json:"warnings,omitempty" yaml:"warnings,omitempty"`
+}
+
+// Blockers returns the descriptions of all blocked steps across hops.
+func (p *Plan) Blockers() []string {
+	var out []string
+	for _, hop := range p.Hops {
+		for _, s := range hop.Steps {
+			if s.Status == StatusBlocked {
+				out = append(out, fmt.Sprintf("%s → %s: %s: %s", hop.From, hop.To, s.Description, s.Reason))
+			}
+		}
+	}
+	return out
+}
+
+// Blocked reports whether any step in the plan is blocked.
+func (p *Plan) Blocked() bool { return len(p.Blockers()) > 0 }
+
+// PendingSteps counts mutating steps the engine would actually execute.
+// Readiness steps are checks, not work, so they don't count.
+func (p *Plan) PendingSteps() int {
+	n := 0
+	for _, hop := range p.Hops {
+		for _, s := range hop.Steps {
+			if s.Status == StatusPending && s.Type != StepReadiness {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// kubeletSkew is the supported kubelet version skew: nodes may lag the
+// control plane by at most this many minor versions (Kubernetes >= 1.28).
+const kubeletSkew = 3
+
+// minorVersion parses an EKS Kubernetes version string ("1.31") into its
+// minor component, validating the major is 1.
+func minorVersion(v string) (int, error) {
+	parts := strings.SplitN(strings.TrimSpace(v), ".", 3)
+	if len(parts) < 2 || parts[0] != "1" {
+		return 0, fmt.Errorf("unrecognized Kubernetes version %q (expected \"1.<minor>\")", v)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, fmt.Errorf("unrecognized Kubernetes version %q: %w", v, err)
+	}
+	return minor, nil
+}
+
+// expandHops lists the sequential minor-version targets between from and to,
+// exclusive of from, inclusive of to ("1.31"→"1.33" yields ["1.32","1.33"]).
+// to == from yields zero hops — that's how a rerun of a completed upgrade
+// becomes a no-op rather than an error.
+func expandHops(from, to string) ([]string, error) {
+	fromMinor, err := minorVersion(from)
+	if err != nil {
+		return nil, err
+	}
+	toMinor, err := minorVersion(to)
+	if err != nil {
+		return nil, err
+	}
+	if toMinor < fromMinor {
+		return nil, fmt.Errorf("target version %s is older than current version %s", to, from)
+	}
+	var hops []string
+	for m := fromMinor + 1; m <= toMinor; m++ {
+		hops = append(hops, fmt.Sprintf("1.%d", m))
+	}
+	return hops, nil
+}
+
+// versionAtLeast reports whether version a >= b (minor comparison).
+func versionAtLeast(a, b string) bool {
+	am, err1 := minorVersion(a)
+	bm, err2 := minorVersion(b)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return am >= bm
+}


### PR DESCRIPTION
Implements the **Phase 7 epic REF-81** and its five sub-tasks (REF-98…REF-102). **Stacked on #27** (cli v3 migration) — merge that first; this PR's base is `ref-11-cli-v3-migration` so only orchestrator commits show here.

## What

`refresh cluster upgrade -c <cluster> --to <version>` — `terraform plan` for EKS upgrades: plan → gate → execute → verify, composed from the existing health/addon/nodegroup/monitoring machinery plus a new `internal/services/upgrade` package.

```
$ refresh cluster upgrade -c prod-east --to 1.33 --dry-run
Upgrade plan: prod-east 1.31 → 1.32 → 1.33 (EKS upgrades are sequential minors)

Hop 1.31 → 1.32
   1. [pending] readiness for 1.32 (insights + version skew) — 0 blocking insights; skew OK
   2. [pending] control plane → 1.32
   3. [pending] addon vpc-cni → v1.32.2-eksbuild.1 (compatible with 1.32)
   4. [pending] nodegroup workers-a → 1.32
...
```

## Sub-tasks

- **REF-98 — plan generation**: sequential minor hops; per hop readiness → control plane → addons (dependency order, target-compatible versions) → nodegroup rolls; blockers (kubelet skew, blocking insights, addons with no target-compatible version) render inline and the command exits non-zero without mutating; `-o table|json|yaml|plain`.
- **REF-99 — control-plane step**: `UpdateClusterVersion` with pinned `ClientRequestToken` + `common.WithRetry` + `FormatAWSError`; `DescribeUpdate` polling; attaches to an already-UPDATING cluster instead of failing; permission added to `formatPermissionError`.
- **REF-100 — addon phase**: serial dependency order via exported `addons.SortByDependency`; versions chosen for compatibility with the **target** k8s version via `DescribeAddonVersions(KubernetesVersion=target)`; the addon service's pre/post health checks gate the phase; `--skip` passthrough.
- **REF-101 — nodegroup phase**: `UpdateNodegroupVersion` rolls (same machinery as the AMI refresh) with a pre-flight gate per group; a gate failure halts remaining groups; custom-AMI nodegroups surface as **manual** actions, never API calls; `--skip-nodegroup`, `--force` passthrough.
- **REF-102 — sequencing engine**: phases in order with gates between; confirmation before each mutating phase unless `--yes`; halt produces a precise completed / failed-at / remaining report plus a resume command; **resumable by re-derivation** — rerun re-inspects live cluster state and skips satisfied steps; double-run of a finished upgrade is a no-op; SIGINT prints what continues server-side.

## Tests (all mock-driven, no live AWS)

21 new tests in `internal/services/upgrade` covering every acceptance criterion: two-minors-behind → two-hop plan; lagging-nodegroup blocker exits non-zero; start/monitor/complete with idempotency token asserted; attach-to-in-flight; target-compatible addon version proven against a version catalogue keyed by k8s version; gate failure halts before the nodegroup phase; multi-nodegroup ordered rolls; custom-AMI as manual item; mid-plan failure → rerun skips completed steps; double-run no-op; SIGINT leaves resume guidance.

`task dev:full` (fmt + vet + lint + test + build) and `go test ./... -race` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)