### PR TITLE
fix(health): scoring accuracy — skip exclusion, peak CPU, proxy honesty, std-dev relabel (REF-63)

### DIFF
--- a/internal/health/balance.go
+++ b/internal/health/balance.go
@@ -35,19 +35,20 @@ func (hc *HealthChecker) checkResourceBalanceWith(ctx context.Context, snap *cpu
 	analysis := hc.analyzeResourceDistribution(nodeMetrics)
 
 	result.Details = append(result.Details, fmt.Sprintf("Analyzed %d nodes", len(nodeMetrics)))
-	result.Details = append(result.Details, fmt.Sprintf("CPU variance: %.1f%%", analysis.CPUVariance))
-	result.Details = append(result.Details, "Memory variance: Not available (requires CloudWatch agent)")
+	result.Details = append(result.Details, fmt.Sprintf("CPU spread (std dev): %.1f pts", analysis.CPUStdDev))
+	result.Details = append(result.Details, "Memory spread: Not available (requires CloudWatch agent)")
 	result.Details = append(result.Details, fmt.Sprintf("Max CPU utilization: %.1f%%", analysis.MaxCPU))
 	result.Details = append(result.Details, "Max Memory utilization: Not available (requires CloudWatch agent)")
 
-	// Determine status based on CPU balance and utilization only
-	maxVariance := analysis.CPUVariance
+	// Determine status based on CPU balance and utilization only. Thresholds
+	// below are expressed in std-dev of per-node CPU, in percentage points.
+	cpuSpread := analysis.CPUStdDev
 	maxUtilization := analysis.MaxCPU
 
-	// Score based on both balance and peak utilization
+	// Score based on both balance (CPU std dev) and peak utilization.
 	balanceScore := 100.0
-	if maxVariance > 30 {
-		balanceScore -= (maxVariance - 30) * 2 // Penalize high variance
+	if cpuSpread > 30 {
+		balanceScore -= (cpuSpread - 30) * 2 // Penalize a wide CPU spread
 	}
 
 	utilizationScore := 100.0
@@ -64,11 +65,11 @@ func (hc *HealthChecker) checkResourceBalanceWith(ctx context.Context, snap *cpu
 		result.Status = StatusWarn
 		result.Message = fmt.Sprintf("High CPU utilization detected (max: %.1f%%)", maxUtilization)
 		result.Details = append(result.Details, "Consider scaling before update")
-	} else if maxVariance > 40 {
+	} else if cpuSpread > 40 {
 		result.Status = StatusWarn
-		result.Message = fmt.Sprintf("Uneven CPU distribution (variance: %.1f%%)", maxVariance)
+		result.Message = fmt.Sprintf("Uneven CPU distribution (std dev: %.1f pts)", cpuSpread)
 		result.Details = append(result.Details, "Workload distribution may cause issues during rolling update")
-	} else if maxUtilization > 80 || maxVariance > 25 {
+	} else if maxUtilization > 80 || cpuSpread > 25 {
 		result.Status = StatusWarn
 		result.Message = "Moderate CPU utilization detected"
 		result.Details = append(result.Details, "Monitor closely during update")
@@ -88,14 +89,17 @@ type NodeMetrics struct {
 	MemoryPercent float64
 }
 
-// ResourceAnalysis contains analysis of resource distribution
+// ResourceAnalysis contains analysis of resource distribution.
+// CPUStdDev/MemoryStdDev are the population standard deviation of per-node
+// utilization, in percentage points (a spread measure, not statistical
+// variance).
 type ResourceAnalysis struct {
-	CPUVariance    float64
-	MemoryVariance float64
-	MaxCPU         float64
-	MaxMemory      float64
-	MinCPU         float64
-	MinMemory      float64
+	CPUStdDev    float64
+	MemoryStdDev float64
+	MaxCPU       float64
+	MaxMemory    float64
+	MinCPU       float64
+	MinMemory    float64
 }
 
 // nodeMetricsFromSnapshot converts the snapshot's per-instance averages into
@@ -163,19 +167,20 @@ func (hc *HealthChecker) analyzeResourceDistribution(metrics []NodeMetrics) Reso
 	cpuAvg := cpuSum / float64(len(metrics))
 	memoryAvg := memorySum / float64(len(metrics))
 
-	// Calculate variance
-	cpuVarianceSum := 0.0
-	memoryVarianceSum := 0.0
+	// Calculate the population standard deviation (sqrt of mean squared
+	// deviation) of per-node CPU/memory — a spread measure in percentage points.
+	cpuSquaredDevSum := 0.0
+	memorySquaredDevSum := 0.0
 
 	for _, metric := range metrics {
 		cpuDiff := metric.CPUPercent - cpuAvg
 		memoryDiff := metric.MemoryPercent - memoryAvg
-		cpuVarianceSum += cpuDiff * cpuDiff
-		memoryVarianceSum += memoryDiff * memoryDiff
+		cpuSquaredDevSum += cpuDiff * cpuDiff
+		memorySquaredDevSum += memoryDiff * memoryDiff
 	}
 
-	analysis.CPUVariance = math.Sqrt(cpuVarianceSum / float64(len(metrics)))
-	analysis.MemoryVariance = math.Sqrt(memoryVarianceSum / float64(len(metrics)))
+	analysis.CPUStdDev = math.Sqrt(cpuSquaredDevSum / float64(len(metrics)))
+	analysis.MemoryStdDev = math.Sqrt(memorySquaredDevSum / float64(len(metrics)))
 
 	return analysis
 }

--- a/internal/health/capacity.go
+++ b/internal/health/capacity.go
@@ -23,6 +23,16 @@ const (
 	minWarnCPUHeadroomPercent = 15.0
 )
 
+// Per-node peak-CPU thresholds. The cluster mean can hide a single saturated
+// node (one busy large instance averaged with idle small ones), so the peak
+// node degrades — never upgrades — the mean-based verdict: a node at or above
+// peakFailCPUPercent fails the check, and one at or above peakWarnCPUPercent
+// downgrades a pass to a warning.
+const (
+	peakWarnCPUPercent = 85.0
+	peakFailCPUPercent = 95.0
+)
+
 // CheckClusterCapacity validates that the cluster has sufficient capacity for rolling updates
 func (hc *HealthChecker) CheckClusterCapacity(ctx context.Context, clusterName string) HealthResult {
 	return hc.checkClusterCapacityWith(ctx, hc.newCPUSnapshot(clusterName))
@@ -51,32 +61,50 @@ func (hc *HealthChecker) checkClusterCapacityWith(ctx context.Context, snap *cpu
 	result.Details = append(result.Details, "Using default EC2 metrics (CPU only)")
 	result.Details = append(result.Details, "Memory metrics require Container Insights setup")
 
-	// Calculate average CPU utilization
+	// Calculate average and peak CPU utilization
 	cpuMetrics := make([]float64, 0, len(cpuByInstance))
 	for _, v := range cpuByInstance {
 		cpuMetrics = append(cpuMetrics, v)
 	}
 	avgCPU := calculateAverage(cpuMetrics)
+	maxCPU := maxFloat(cpuMetrics)
 
-	result.Details = append(result.Details, fmt.Sprintf("Average CPU utilization: %.1f%%", avgCPU))
+	result.Details = append(result.Details, fmt.Sprintf("Average CPU utilization: %.1f%% (peak node %.1f%%)", avgCPU, maxCPU))
 	result.Details = append(result.Details, "Memory utilization: Not available (requires Container Insights)")
 
-	// Calculate score based on CPU headroom only
+	// Mean-based verdict from cluster-wide CPU headroom.
 	headroom := 100 - avgCPU
-	if headroom >= minSafeCPUHeadroomPercent {
+	switch {
+	case headroom >= minSafeCPUHeadroomPercent:
 		result.Status = StatusPass
 		result.Score = 100
-		result.Message = fmt.Sprintf("Sufficient CPU capacity (%.1f%% utilization)", avgCPU)
-	} else if headroom >= minWarnCPUHeadroomPercent {
+		result.Message = fmt.Sprintf("Sufficient CPU capacity (avg %.1f%%, peak %.1f%%)", avgCPU, maxCPU)
+	case headroom >= minWarnCPUHeadroomPercent:
 		result.Status = StatusWarn
 		result.Score = 70
-		result.Message = fmt.Sprintf("Limited CPU capacity (%.1f%% utilization)", avgCPU)
+		result.Message = fmt.Sprintf("Limited CPU capacity (avg %.1f%%, peak %.1f%%)", avgCPU, maxCPU)
 		result.Details = append(result.Details, "Consider scaling up nodes before update")
-	} else {
+	default:
 		result.Status = StatusFail
 		result.Score = 30
-		result.Message = fmt.Sprintf("Insufficient CPU capacity (%.1f%% utilization)", avgCPU)
+		result.Message = fmt.Sprintf("Insufficient CPU capacity (avg %.1f%%, peak %.1f%%)", avgCPU, maxCPU)
 		result.Details = append(result.Details, "Insufficient CPU headroom for safe rolling update")
+	}
+
+	// Peak-node guard: a single near-saturated node is a real bottleneck for a
+	// rolling update even when the cluster mean looks healthy. Only ever
+	// degrade the mean-based verdict, never improve it.
+	switch {
+	case maxCPU >= peakFailCPUPercent && result.Status != StatusFail:
+		result.Status = StatusFail
+		result.Score = 30
+		result.Message = fmt.Sprintf("A node is near CPU saturation (peak %.1f%%, avg %.1f%%)", maxCPU, avgCPU)
+		result.Details = append(result.Details, fmt.Sprintf("At least one node at/above %.0f%% CPU — rolling it could overload its peers", peakFailCPUPercent))
+	case maxCPU >= peakWarnCPUPercent && result.Status == StatusPass:
+		result.Status = StatusWarn
+		result.Score = 70
+		result.Message = fmt.Sprintf("Uneven CPU capacity (peak %.1f%%, avg %.1f%%)", maxCPU, avgCPU)
+		result.Details = append(result.Details, fmt.Sprintf("At least one node at/above %.0f%% CPU despite a low cluster average", peakWarnCPUPercent))
 	}
 
 	return result
@@ -204,6 +232,20 @@ func calculateAverage(values []float64) float64 {
 		sum += value
 	}
 	return sum / float64(len(values))
+}
+
+// maxFloat returns the largest value in the slice, or 0 for an empty slice.
+func maxFloat(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	m := values[0]
+	for _, v := range values[1:] {
+		if v > m {
+			m = v
+		}
+	}
+	return m
 }
 
 // getClusterInstanceIDs retrieves all EC2 instance IDs for the cluster

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -36,6 +36,10 @@ type HealthResult struct {
 	Message    string       `json:"message"`
 	Details    []string     `json:"details,omitempty"`
 	IsBlocking bool         `json:"isBlocking"`
+	// Skipped marks a check that could not be evaluated (e.g. no Kubernetes
+	// client) rather than measured. Skipped checks are excluded from the
+	// OverallScore so a missing prerequisite doesn't silently drag the score.
+	Skipped bool `json:"skipped,omitempty"`
 }
 
 // HealthSummary represents the overall health check results
@@ -69,9 +73,6 @@ func NewChecker(eksClient *eks.Client, k8sClient kubernetes.Interface, cwClient 
 // are independent, so they run concurrently; capacity and balance share one
 // instance-discovery + CloudWatch fetch via a lazy snapshot.
 func (hc *HealthChecker) RunAllChecks(ctx context.Context, clusterName string) HealthSummary {
-	var warnings []string
-	var errors []string
-
 	snap := hc.newCPUSnapshot(clusterName)
 	checks := []func() HealthResult{
 		func() HealthResult { return hc.CheckNodeHealth(ctx, clusterName) },
@@ -92,28 +93,45 @@ func (hc *HealthChecker) RunAllChecks(ctx context.Context, clusterName string) H
 	}
 	wg.Wait()
 
-	// Calculate overall score and decision
+	return aggregateResults(results)
+}
+
+// aggregateResults folds the individual check results into a HealthSummary:
+// the OverallScore is the mean of the *measured* checks (skipped checks are
+// excluded so a missing prerequisite doesn't penalize the score), and the
+// Decision is driven solely by blocking/warning flags.
+func aggregateResults(results []HealthResult) HealthSummary {
+	var warnings, errors []string
 	totalScore := 0
+	measuredCount := 0
 	hasBlocking := false
 	hasWarnings := false
 
 	for _, result := range results {
-		totalScore += result.Score
+		if !result.Skipped {
+			totalScore += result.Score
+			measuredCount++
+		}
 
-		if result.Status == StatusFail && result.IsBlocking {
+		switch {
+		case result.Status == StatusFail && result.IsBlocking:
 			hasBlocking = true
 			errors = append(errors, result.Message)
-		} else if result.Status == StatusWarn {
+		case result.Status == StatusWarn:
 			hasWarnings = true
 			warnings = append(warnings, result.Message)
-		} else if result.Status == StatusFail {
+		case result.Status == StatusFail:
 			errors = append(errors, result.Message)
+			hasWarnings = true
 		}
 	}
 
-	overallScore := totalScore / len(results)
-	decision := DecisionProceed
+	overallScore := 0
+	if measuredCount > 0 {
+		overallScore = totalScore / measuredCount
+	}
 
+	decision := DecisionProceed
 	if hasBlocking {
 		decision = DecisionBlock
 	} else if hasWarnings || len(errors) > 0 {

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -72,41 +72,34 @@ func TestDecision_BlockingBeatsWarn(t *testing.T) {
 	}
 }
 
-// aggregateResults mirrors the logic in RunAllChecks so we can unit-test it
-// without touching AWS. Keep it in sync if RunAllChecks logic changes.
-func aggregateResults(results []HealthResult) HealthSummary {
-	var warnings, errors []string
-	totalScore := 0
-	hasBlocking := false
-	hasWarnings := false
+// aggregateResults is the real aggregation used by RunAllChecks (defined in
+// checker.go); these tests exercise it directly so they don't touch AWS.
 
-	for _, r := range results {
-		totalScore += r.Score
-		if r.Status == StatusFail && r.IsBlocking {
-			hasBlocking = true
-			errors = append(errors, r.Message)
-		} else if r.Status == StatusWarn {
-			hasWarnings = true
-			warnings = append(warnings, r.Message)
-		} else if r.Status == StatusFail {
-			errors = append(errors, r.Message)
-			hasWarnings = true
-		}
+func TestAggregate_SkippedCheckExcludedFromScore(t *testing.T) {
+	// A perfect measured cluster with one skipped check (no kube client →
+	// fixed 70) must not be dragged down: score reflects only measured checks.
+	results := []HealthResult{
+		{Status: StatusPass, Score: 100, IsBlocking: false},
+		{Status: StatusPass, Score: 100, IsBlocking: false},
+		{Status: StatusWarn, Score: 70, IsBlocking: false, Skipped: true, Message: "k8s unavailable"},
 	}
-
-	decision := DecisionProceed
-	if hasBlocking {
-		decision = DecisionBlock
-	} else if hasWarnings || len(errors) > 0 {
-		decision = DecisionWarn
+	summary := aggregateResults(results)
+	if summary.OverallScore != 100 {
+		t.Errorf("skipped check should be excluded: score = %d, want 100", summary.OverallScore)
 	}
+	// A skipped WARN still surfaces as a warning in the decision.
+	if summary.Decision != DecisionWarn {
+		t.Errorf("decision = %s, want WARN", summary.Decision)
+	}
+}
 
-	return HealthSummary{
-		Results:      results,
-		OverallScore: totalScore / len(results),
-		Decision:     decision,
-		Warnings:     warnings,
-		Errors:       errors,
+func TestAggregate_AllSkippedNoPanic(t *testing.T) {
+	results := []HealthResult{
+		{Status: StatusWarn, Score: 70, Skipped: true},
+	}
+	summary := aggregateResults(results)
+	if summary.OverallScore != 0 {
+		t.Errorf("all-skipped score = %d, want 0", summary.OverallScore)
 	}
 }
 

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -51,7 +51,7 @@ func TestCalculateAverage_FloatPrecision(t *testing.T) {
 func TestAnalyzeResourceDistribution_EmptyMetrics(t *testing.T) {
 	hc := &HealthChecker{}
 	analysis := hc.analyzeResourceDistribution(nil)
-	if analysis.MaxCPU != 0 || analysis.MinCPU != 0 || analysis.CPUVariance != 0 {
+	if analysis.MaxCPU != 0 || analysis.MinCPU != 0 || analysis.CPUStdDev != 0 {
 		t.Errorf("empty metrics should yield zero analysis, got %+v", analysis)
 	}
 }
@@ -63,8 +63,8 @@ func TestAnalyzeResourceDistribution_SingleNode(t *testing.T) {
 	if analysis.MaxCPU != 50.0 || analysis.MinCPU != 50.0 {
 		t.Errorf("single node: MaxCPU=%f MinCPU=%f, both want 50.0", analysis.MaxCPU, analysis.MinCPU)
 	}
-	if analysis.CPUVariance != 0 {
-		t.Errorf("single node variance should be 0, got %f", analysis.CPUVariance)
+	if analysis.CPUStdDev != 0 {
+		t.Errorf("single node std dev should be 0, got %f", analysis.CPUStdDev)
 	}
 }
 
@@ -79,10 +79,10 @@ func TestAnalyzeResourceDistribution_MultipleNodes(t *testing.T) {
 	if analysis.MinCPU != 10 || analysis.MaxCPU != 30 {
 		t.Errorf("min=%f max=%f, want 10/30", analysis.MinCPU, analysis.MaxCPU)
 	}
-	// Variance = sqrt(((10-20)^2 + (20-20)^2 + (30-20)^2) / 3) = sqrt(200/3) ≈ 8.165
-	wantVariance := math.Sqrt(200.0 / 3.0)
-	if math.Abs(analysis.CPUVariance-wantVariance) > 0.001 {
-		t.Errorf("CPUVariance=%f, want ~%f", analysis.CPUVariance, wantVariance)
+	// Std dev = sqrt(((10-20)^2 + (20-20)^2 + (30-20)^2) / 3) = sqrt(200/3) ≈ 8.165
+	wantStdDev := math.Sqrt(200.0 / 3.0)
+	if math.Abs(analysis.CPUStdDev-wantStdDev) > 0.001 {
+		t.Errorf("CPUStdDev=%f, want ~%f", analysis.CPUStdDev, wantStdDev)
 	}
 }
 
@@ -93,8 +93,8 @@ func TestAnalyzeResourceDistribution_HighVarianceDetected(t *testing.T) {
 		{CPUPercent: 95},
 	}
 	analysis := hc.analyzeResourceDistribution(metrics)
-	if analysis.CPUVariance <= 40 {
-		t.Errorf("expected high variance for 5/95 split, got %f", analysis.CPUVariance)
+	if analysis.CPUStdDev <= 40 {
+		t.Errorf("expected high std dev for 5/95 split, got %f", analysis.CPUStdDev)
 	}
 }
 
@@ -340,8 +340,8 @@ func TestAnalyzeResourceDistribution_MemoryTracked(t *testing.T) {
 	if analysis.MinMemory != 20 || analysis.MaxMemory != 80 {
 		t.Errorf("memory: MinMemory=%f MaxMemory=%f, want 20/80", analysis.MinMemory, analysis.MaxMemory)
 	}
-	if analysis.MemoryVariance <= 0 {
-		t.Errorf("expected positive memory variance for 20/80 split, got %f", analysis.MemoryVariance)
+	if analysis.MemoryStdDev <= 0 {
+		t.Errorf("expected positive memory std dev for 20/80 split, got %f", analysis.MemoryStdDev)
 	}
 }
 

--- a/internal/health/nodes.go
+++ b/internal/health/nodes.go
@@ -43,6 +43,7 @@ func (hc *HealthChecker) CheckNodeHealth(ctx context.Context, clusterName string
 	totalNodes := 0
 	readyNodes := 0
 	var problemNodes []string
+	var inProgress []string
 
 	// Prefer real node readiness from the Kubernetes API when available;
 	// DesiredSize is only a proxy (an ACTIVE nodegroup can still have
@@ -67,16 +68,18 @@ func (hc *HealthChecker) CheckNodeHealth(ctx context.Context, clusterName string
 			totalNodes += int(*nodegroup.ScalingConfig.DesiredSize)
 		}
 
-		// Check nodegroup status
+		// Classify by nodegroup status. CREATING/UPDATING are benign,
+		// in-progress states (scaling, rolling) — they are tracked separately
+		// and must not be reported as readiness failures.
 		switch nodegroup.Status {
 		case types.NodegroupStatusActive:
 			if nodegroup.ScalingConfig != nil && nodegroup.ScalingConfig.DesiredSize != nil {
 				readyNodes += int(*nodegroup.ScalingConfig.DesiredSize)
 			}
+		case types.NodegroupStatusCreating, types.NodegroupStatusUpdating:
+			inProgress = append(inProgress, fmt.Sprintf("%s (%s)", ngName, string(nodegroup.Status)))
 		case types.NodegroupStatusDegraded:
 			problemNodes = append(problemNodes, fmt.Sprintf("%s (DEGRADED)", ngName))
-		case types.NodegroupStatusCreating, types.NodegroupStatusUpdating:
-			problemNodes = append(problemNodes, fmt.Sprintf("%s (%s)", ngName, string(nodegroup.Status)))
 		default:
 			problemNodes = append(problemNodes, fmt.Sprintf("%s (%s)", ngName, string(nodegroup.Status)))
 		}
@@ -93,6 +96,10 @@ func (hc *HealthChecker) CheckNodeHealth(ctx context.Context, clusterName string
 		}
 	}
 
+	if len(inProgress) > 0 {
+		result.Details = append(result.Details, fmt.Sprintf("Nodegroups scaling/updating (not a failure): %v", inProgress))
+	}
+
 	// Calculate score and status
 	if totalNodes == 0 {
 		result.Status = StatusFail
@@ -102,21 +109,48 @@ func (hc *HealthChecker) CheckNodeHealth(ctx context.Context, clusterName string
 	}
 
 	scorePercentage := (readyNodes * 100) / totalNodes
+
+	// Without real Kubernetes counts the score is an estimate derived from
+	// nodegroup desired capacity: an ACTIVE nodegroup can still hold
+	// NotReady/cordoned nodes, so a "100%" here is not a confident measurement.
+	// Cap it below 100 and label it estimated.
+	estimated := !haveRealCounts
+	if estimated {
+		result.Details = append(result.Details, "Node readiness estimated from nodegroup desired capacity (no Kubernetes API access)")
+		if scorePercentage > maxEstimatedNodeHealthScore {
+			scorePercentage = maxEstimatedNodeHealthScore
+		}
+	}
 	result.Score = scorePercentage
 
-	if len(problemNodes) == 0 {
-		result.Status = StatusPass
-		result.Message = fmt.Sprintf("%d/%d nodes ready", readyNodes, totalNodes)
-	} else if readyNodes > 0 {
+	estimatedSuffix := ""
+	if estimated {
+		estimatedSuffix = " (estimated)"
+	}
+
+	switch {
+	case len(problemNodes) == 0 && readyNodes == 0 && len(inProgress) > 0:
+		// Everything is mid-scale and nothing is wrong — warn, don't fail.
 		result.Status = StatusWarn
-		result.Message = fmt.Sprintf("%d/%d nodes ready, issues: %v", readyNodes, totalNodes, problemNodes)
-	} else {
+		result.Message = fmt.Sprintf("Nodegroups still scaling: %v", inProgress)
+	case len(problemNodes) == 0:
+		result.Status = StatusPass
+		result.Message = fmt.Sprintf("%d/%d nodes ready%s", readyNodes, totalNodes, estimatedSuffix)
+	case readyNodes > 0:
+		result.Status = StatusWarn
+		result.Message = fmt.Sprintf("%d/%d nodes ready%s, issues: %v", readyNodes, totalNodes, estimatedSuffix, problemNodes)
+	default:
 		result.Status = StatusFail
 		result.Message = fmt.Sprintf("No ready nodes, issues: %v", problemNodes)
 	}
 
 	return result
 }
+
+// maxEstimatedNodeHealthScore caps the Node Health score when it is derived
+// from the nodegroup DesiredSize proxy rather than real Kubernetes node counts,
+// so an estimate never reads as a confident perfect 100.
+const maxEstimatedNodeHealthScore = 90
 
 // kubernetesNodeCounts returns real node readiness from the Kubernetes API:
 // total node count, ready count, and names of NotReady nodes. ok is false when

--- a/internal/health/pdbs.go
+++ b/internal/health/pdbs.go
@@ -19,6 +19,7 @@ func (hc *HealthChecker) CheckPodDisruptionBudgets(ctx context.Context) HealthRe
 	if hc.k8sClient == nil {
 		result.Status = StatusWarn
 		result.Score = 70
+		result.Skipped = true // excluded from OverallScore — not measured
 		result.Message = "Kubernetes client not available, skipping PDB check"
 		result.Details = append(result.Details, "Install kubectl and configure cluster access to enable this check")
 		return result

--- a/internal/health/workloads.go
+++ b/internal/health/workloads.go
@@ -24,6 +24,7 @@ func (hc *HealthChecker) CheckCriticalWorkloads(ctx context.Context) HealthResul
 		result.Status = StatusWarn
 		result.Score = 70
 		result.IsBlocking = false // unavailable client is a skip, not a hard block
+		result.Skipped = true     // excluded from OverallScore — not measured
 		result.Message = "Kubernetes client not available, skipping workload check"
 		result.Details = append(result.Details, "Install kubectl and configure cluster access to enable this check")
 		return result


### PR DESCRIPTION
## What & why

Batch A of the Opus-4.8 roadmap — the **REF-63 health-check scoring accuracy** epic. These are the four verified findings from the 2026-06-10 scan about the *numeric scores* feeding the verdict and the exported `OverallScore`. The binary `Decision` (proceed/warn/block) was already sound and is unchanged. All changes live in `internal/health/*`; no AWS/kube API surface changes, no v3-migration dependency.

## Changes

| Issue | Fix |
|-------|-----|
| **REF-68** | `OverallScore` averaged a *skipped* check (no kube client → fixed 70) as if measured, dragging a perfect cluster down. Added a `Skipped` flag (set in the workloads/PDB nil-client paths) and excluded skipped checks from the denominator. Extracted the shared `aggregateResults` so `RunAllChecks` and the tests use one implementation instead of a drifting copy. |
| **REF-69** | Capacity (the *blocking* check) judged headroom from an unweighted CPU mean, hiding one saturated node behind idle ones. Now factors per-node **peak** CPU to degrade (never upgrade) the mean-based verdict — peak ≥95% fails, ≥85% downgrades a pass to warn. |
| **REF-70** | The `DesiredSize` node-health proxy scored an ACTIVE nodegroup a confident **100%** with no real counts, and flagged benign CREATING/UPDATING nodegroups as problems. Now caps the proxy score at 90 / marks it *estimated*, and treats in-progress nodegroups as informational, not failures. |
| **REF-71** | `balance.go`'s `CPUVariance` is actually **standard deviation**. Renamed to `CPUStdDev`/`MemoryStdDev`, relabeled display to "CPU spread (std dev)", documented thresholds as std-dev in CPU percentage points. |

## Testing

- `go build ./...`, `go test ./...`, `go test ./internal/health/... -race` — all pass
- `go vet ./...`, `golangci-lint run ./...` — 0 issues
- Added `aggregateResults` skip-exclusion + all-skipped tests; updated balance tests for the rename.

Closes REF-68, REF-69, REF-70, REF-71 (epic REF-63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)