### PR TITLE
feat(status): refresh status — fleet patch posture across clusters/regions (REF-79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ refresh/
 
 -   **Pre-flight Health Checks**: Validate cluster readiness before AMI updates using default EC2 metrics (no additional setup required)
 -   **Real-time Monitoring**: Live progress tracking with professional spinner displays and clean completion summaries
+-   **Fleet Status**: `refresh status -A` shows patch posture (version, EKS support window + extended-support cost, stale AMIs, addons behind) across all clusters/regions, with CI-friendly exit codes
 -   **Cluster Management**: List clusters and nodegroups with status and versions
 -   **Smart Updates**: Update AMI for all or specific nodegroups with rolling updates and optional force mode
 -   **Nodegroup Intelligence**: Fast list/describe with optional utilization and cost, and safe scaling with health checks
@@ -242,6 +243,7 @@ go install github.com/dantech2000/refresh@latest
 
 ```text
 refresh
+├── status                 # Fleet patch posture across clusters/regions (front door)
 ├── cluster
 │   ├── list (lc)          # List clusters across regions
 │   ├── describe / get     # Describe comprehensive cluster info
@@ -260,6 +262,51 @@ refresh
 ├── context (ctx)          # Manage saved contexts (list, add, remove)
 └── version                # Show version information
 ```
+
+### Fleet status (`refresh status`)
+
+The Monday-morning command: one table showing, per cluster, the Kubernetes
+version, EKS support window, nodegroup AMI staleness, and addons behind latest —
+across every region.
+
+```bash
+refresh status                 # clusters in the current region
+refresh status -A              # all EKS-supported regions
+refresh status -r us-east-1 -r us-west-2   # specific regions
+refresh status prod            # only clusters whose name contains "prod"
+refresh status -A -o json      # machine-readable for scripts/CI
+refresh status -A --sort stale --desc      # most-stale clusters first
+```
+
+Example:
+
+```text
+CLUSTER     REGION     VERSION  SUPPORT                      COMPUTE         STALE AMI        ADDONS BEHIND
+prod-east   us-east-1  1.31     standard until 2025-11-26    4 nodegroups    2/4 (oldest 94d) 1 (coredns)
+prod-west   us-west-2  1.29     ⚠ EXTENDED until 2026-03-23 (~$0.50/hr)  3 nodegroups  3/3 (oldest 210d) 2 (coredns,vpc-cni)
+legacy      us-east-1  1.33     standard until 2026-07-23    🤖 Auto Mode    n/a              0
+
+3 clusters · 5 stale nodegroups · 3 addons behind · 1 extended/unsupported
+```
+
+Support dates come from `eks:DescribeClusterVersions`; if that call is
+unavailable a compiled-in calendar is used and the row is marked with `*`.
+Extended support is roughly `$0.60/hr` vs `$0.10/hr` standard (~$4,400/yr per
+lingering cluster), so the premium is surfaced inline.
+
+**Exit codes** (for CI/cron):
+
+| Code | Meaning |
+| ---- | ------- |
+| `0`  | everything current and in standard support |
+| `2`  | something stale (nodegroup AMI or addon behind latest) |
+| `3`  | a cluster is on extended support or unsupported |
+
+`-o table|json|yaml|plain` is supported (`plain` is uncolored TSV); `--no-color`
+and `NO_COLOR` are honored. Required IAM: `eks:ListClusters`,
+`eks:DescribeCluster`, `eks:DescribeClusterVersions`, `eks:ListNodegroups`,
+`eks:DescribeNodegroup`, `eks:ListAddons`, `eks:DescribeAddon`,
+`eks:DescribeAddonVersions`, `ec2:DescribeImages`, `ec2:DescribeInstances`.
 
 ### Contexts (kubectx-style)
 

--- a/internal/aws/errors.go
+++ b/internal/aws/errors.go
@@ -255,8 +255,10 @@ Required permissions for refresh tool:
 - eks:UpdateNodegroupVersion
 - eks:UpdateClusterVersion (for cluster upgrade)
 - eks:DescribeUpdate (for cluster upgrade)
-- eks:DescribeClusterVersions (for cluster upgrade)
+- eks:DescribeClusterVersions (for cluster upgrade and status support calendar)
 - eks:ListInsights (for cluster upgrade readiness)
+- eks:ListAddons / eks:DescribeAddon / eks:DescribeAddonVersions (for addon status)
+- ec2:DescribeImages / ec2:DescribeInstances (for AMI staleness and compute detection)
 - cloudwatch:GetMetricStatistics (for health checks)
 
 Current error: %w`, operation, err)

--- a/internal/commands/statuscmd/actions.go
+++ b/internal/commands/statuscmd/actions.go
@@ -1,0 +1,219 @@
+package statuscmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/fatih/color"
+	"github.com/urfave/cli/v3"
+
+	"github.com/dantech2000/refresh/internal/commands/runner"
+	"github.com/dantech2000/refresh/internal/commands/statusview"
+	appconfig "github.com/dantech2000/refresh/internal/config"
+	statussvc "github.com/dantech2000/refresh/internal/services/status"
+)
+
+func runStatus(ctx context.Context, cmd *cli.Command) error {
+	ctx, cancel, awsCfg, err := runner.SetupAWS(ctx, cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	regions := resolveRegions(cmd, awsCfg)
+	maxConc := cmd.Int("max-concurrency")
+	opts := statussvc.ListOptions{
+		NamePattern:    strings.TrimSpace(cmd.Args().First()),
+		MaxConcurrency: maxConc,
+	}
+
+	start := time.Now()
+	var (
+		statuses   []statussvc.ClusterStatus
+		regionErrs []error
+	)
+	gather := func() error {
+		statuses, regionErrs = gatherFleet(ctx, awsCfg, regions, opts, maxConc)
+		// Only a total failure (no data from any region) is fatal.
+		if len(statuses) == 0 && len(regionErrs) > 0 {
+			return regionErrs[0]
+		}
+		return nil
+	}
+	if err := runner.WithSpinner("status", "Fleet status gathered!", gather); err != nil {
+		return err
+	}
+	elapsed := time.Since(start)
+
+	for _, e := range regionErrs {
+		fmt.Fprintln(os.Stderr, color.YellowString("warning: %v", e))
+	}
+
+	sortStatuses(statuses, cmd.String("sort"), cmd.Bool("desc"))
+
+	if handled, err := runner.EncodeStdout(cmd.String("format"), statussvc.FleetStatus{Clusters: statuses}); handled {
+		if err != nil {
+			return err
+		}
+		return exitForStatuses(statuses)
+	}
+	if err := statusview.OutputFleetTable(statuses, elapsed); err != nil {
+		return err
+	}
+	return exitForStatuses(statuses)
+}
+
+// resolveRegions picks the region set: explicit --region wins, then
+// --all-regions (partition sweep / REFRESH_EKS_REGIONS), else the config region.
+func resolveRegions(cmd *cli.Command, awsCfg aws.Config) []string {
+	if r := cmd.StringSlice("region"); len(r) > 0 {
+		return r
+	}
+	if cmd.Bool("all-regions") {
+		if env := appconfig.RegionsFromEnv(); len(env) > 0 {
+			return env
+		}
+		return appconfig.GetRegionsForPartition(awsCfg.Region)
+	}
+	if awsCfg.Region != "" {
+		return []string{awsCfg.Region}
+	}
+	return appconfig.GetRegionsForPartition(awsCfg.Region)
+}
+
+// gatherFleet fans out across regions with bounded concurrency, returning the
+// merged cluster statuses and any per-region errors.
+func gatherFleet(ctx context.Context, baseCfg aws.Config, regions []string, opts statussvc.ListOptions, maxConc int) ([]statussvc.ClusterStatus, []error) {
+	if maxConc <= 0 {
+		maxConc = appconfig.DefaultMaxConcurrency
+	}
+	var (
+		mu   sync.Mutex
+		all  []statussvc.ClusterStatus
+		errs []error
+		wg   sync.WaitGroup
+		sem  = make(chan struct{}, maxConc)
+	)
+	for _, region := range regions {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(r string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			cfg := baseCfg.Copy()
+			cfg.Region = r
+			svc := statussvc.NewService(cfg, nil)
+			statuses, err := svc.ListClusterStatuses(ctx, opts)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				errs = append(errs, fmt.Errorf("region %s: %w", r, err))
+				return
+			}
+			all = append(all, statuses...)
+		}(region)
+	}
+	wg.Wait()
+	return all, errs
+}
+
+// exitForStatuses maps the fleet posture to the documented exit-code contract:
+// 3 when any cluster is on extended/unsupported EKS, 2 when something is stale,
+// 0 otherwise.
+func exitForStatuses(statuses []statussvc.ClusterStatus) error {
+	supportRisk, stale := false, false
+	for _, c := range statuses {
+		if c.SupportRisk() {
+			supportRisk = true
+		}
+		if c.NeedsAttention() {
+			stale = true
+		}
+	}
+	switch {
+	case supportRisk:
+		return cli.Exit("", 3)
+	case stale:
+		return cli.Exit("", 2)
+	default:
+		return nil
+	}
+}
+
+func sortStatuses(statuses []statussvc.ClusterStatus, key string, desc bool) {
+	less := lessFunc(strings.ToLower(strings.TrimSpace(key)))
+	sort.SliceStable(statuses, func(i, j int) bool {
+		if desc {
+			return less(statuses[j], statuses[i])
+		}
+		return less(statuses[i], statuses[j])
+	})
+}
+
+func lessFunc(key string) func(a, b statussvc.ClusterStatus) bool {
+	byName := func(a, b statussvc.ClusterStatus) bool {
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		return a.Region < b.Region
+	}
+	switch key {
+	case "region":
+		return func(a, b statussvc.ClusterStatus) bool {
+			if a.Region != b.Region {
+				return a.Region < b.Region
+			}
+			return byName(a, b)
+		}
+	case "version":
+		return func(a, b statussvc.ClusterStatus) bool {
+			if a.Version != b.Version {
+				return a.Version < b.Version
+			}
+			return byName(a, b)
+		}
+	case "support":
+		return func(a, b statussvc.ClusterStatus) bool {
+			ra, rb := supportSeverity(a.Support.Tier), supportSeverity(b.Support.Tier)
+			if ra != rb {
+				return ra < rb
+			}
+			return byName(a, b)
+		}
+	case "stale":
+		return func(a, b statussvc.ClusterStatus) bool {
+			sa, sb := a.StaleAMI.Behind+a.AddonsBehind.Behind, b.StaleAMI.Behind+b.AddonsBehind.Behind
+			if sa != sb {
+				return sa < sb
+			}
+			return byName(a, b)
+		}
+	default: // cluster
+		return byName
+	}
+}
+
+// supportSeverity orders tiers from healthiest to most urgent so descending
+// sort surfaces the clusters that need attention first.
+func supportSeverity(t statussvc.SupportTier) int {
+	switch t {
+	case statussvc.SupportStandard:
+		return 0
+	case statussvc.SupportUnknown:
+		return 1
+	case statussvc.SupportExtended:
+		return 2
+	case statussvc.SupportUnsupported:
+		return 3
+	default:
+		return 1
+	}
+}

--- a/internal/commands/statuscmd/actions_test.go
+++ b/internal/commands/statuscmd/actions_test.go
@@ -1,0 +1,83 @@
+package statuscmd
+
+import (
+	"testing"
+
+	"github.com/urfave/cli/v3"
+
+	statussvc "github.com/dantech2000/refresh/internal/services/status"
+)
+
+func exitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if ec, ok := err.(cli.ExitCoder); ok {
+		return ec.ExitCode()
+	}
+	return -1
+}
+
+func TestExitForStatuses(t *testing.T) {
+	cases := []struct {
+		name     string
+		statuses []statussvc.ClusterStatus
+		want     int
+	}{
+		{
+			name:     "all current",
+			statuses: []statussvc.ClusterStatus{{Support: statussvc.SupportPosture{Tier: statussvc.SupportStandard}}},
+			want:     0,
+		},
+		{
+			name: "stale only → 2",
+			statuses: []statussvc.ClusterStatus{{
+				Support:  statussvc.SupportPosture{Tier: statussvc.SupportStandard},
+				StaleAMI: statussvc.StaleAMISummary{Behind: 1, Total: 3},
+			}},
+			want: 2,
+		},
+		{
+			name: "extended support → 3 (beats stale)",
+			statuses: []statussvc.ClusterStatus{{
+				Support:  statussvc.SupportPosture{Tier: statussvc.SupportExtended},
+				StaleAMI: statussvc.StaleAMISummary{Behind: 1},
+			}},
+			want: 3,
+		},
+		{
+			name: "unsupported → 3",
+			statuses: []statussvc.ClusterStatus{{
+				Support: statussvc.SupportPosture{Tier: statussvc.SupportUnsupported},
+			}},
+			want: 3,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := exitCode(exitForStatuses(tc.statuses)); got != tc.want {
+				t.Errorf("exit code = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSortStatuses_ByStaleDescending(t *testing.T) {
+	statuses := []statussvc.ClusterStatus{
+		{Name: "a", StaleAMI: statussvc.StaleAMISummary{Behind: 0}},
+		{Name: "b", StaleAMI: statussvc.StaleAMISummary{Behind: 5}},
+		{Name: "c", StaleAMI: statussvc.StaleAMISummary{Behind: 2}},
+	}
+	sortStatuses(statuses, "stale", true)
+	if statuses[0].Name != "b" || statuses[1].Name != "c" || statuses[2].Name != "a" {
+		t.Errorf("stale desc order = %s,%s,%s, want b,c,a", statuses[0].Name, statuses[1].Name, statuses[2].Name)
+	}
+}
+
+func TestSortStatuses_ByClusterName(t *testing.T) {
+	statuses := []statussvc.ClusterStatus{{Name: "c"}, {Name: "a"}, {Name: "b"}}
+	sortStatuses(statuses, "cluster", false)
+	if statuses[0].Name != "a" || statuses[2].Name != "c" {
+		t.Errorf("name order = %s..%s, want a..c", statuses[0].Name, statuses[2].Name)
+	}
+}

--- a/internal/commands/statuscmd/command.go
+++ b/internal/commands/statuscmd/command.go
@@ -1,0 +1,39 @@
+// Package statuscmd wires the top-level `refresh status` command — the fleet
+// patch-posture "front door".
+package statuscmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/urfave/cli/v3"
+
+	appconfig "github.com/dantech2000/refresh/internal/config"
+)
+
+// Command returns the `refresh status` top-level command.
+func Command() *cli.Command {
+	return &cli.Command{
+		Name:      "status",
+		Usage:     "Fleet patch posture across clusters and regions (the front door)",
+		ArgsUsage: "[name-pattern]",
+		Description: `One command, all clusters, all regions, one table: Kubernetes version,
+EKS support window (with extended-support cost callout), nodegroup AMI
+staleness, and addons behind latest.
+
+Exit codes (for CI/cron):
+  0  everything current and in standard support
+  2  something stale (nodegroup AMI or addon behind latest)
+  3  a cluster is on extended support or unsupported`,
+		Flags: []cli.Flag{
+			&cli.DurationFlag{Name: "timeout", Aliases: []string{"t"}, Usage: "Operation timeout (e.g. 60s, 2m)", Value: 2 * time.Minute, Sources: cli.EnvVars("REFRESH_TIMEOUT")},
+			&cli.BoolFlag{Name: "all-regions", Aliases: []string{"A"}, Usage: "Query all EKS-supported regions"},
+			&cli.StringSliceFlag{Name: "region", Aliases: []string{"r"}, Usage: "Specific region(s) to query (repeatable)"},
+			&cli.IntFlag{Name: "max-concurrency", Aliases: []string{"C"}, Usage: "Max concurrent region/cluster requests", Value: appconfig.DefaultMaxConcurrency, Sources: cli.EnvVars("REFRESH_MAX_CONCURRENCY")},
+			&cli.StringFlag{Name: "format", Aliases: []string{"o"}, Usage: "Output format (table, json, yaml, plain)", Value: "table"},
+			&cli.StringFlag{Name: "sort", Usage: "Sort by field: cluster,region,version,support,stale", Value: "cluster"},
+			&cli.BoolFlag{Name: "desc", Usage: "Sort descending"},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error { return runStatus(ctx, cmd) },
+	}
+}

--- a/internal/commands/statusview/status.go
+++ b/internal/commands/statusview/status.go
@@ -1,0 +1,152 @@
+// Package statusview renders fleet patch-posture output for `refresh status`.
+package statusview
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+
+	statussvc "github.com/dantech2000/refresh/internal/services/status"
+	"github.com/dantech2000/refresh/internal/ui"
+)
+
+const dateLayout = "2006-01-02"
+
+// OutputFleetTable renders the fleet status as a table (or plain TSV when plain
+// output is active) followed by a one-line summary footer.
+func OutputFleetTable(statuses []statussvc.ClusterStatus, elapsed time.Duration) error {
+	columns := []ui.Column{
+		{Title: "CLUSTER", Min: 8},
+		{Title: "REGION", Min: 9},
+		{Title: "VERSION", Min: 7},
+		{Title: "SUPPORT", Min: 24, Max: 40},
+		{Title: "COMPUTE", Min: 10, Max: 28},
+		{Title: "STALE AMI", Min: 9},
+		{Title: "ADDONS BEHIND", Min: 13, Max: 30},
+	}
+	table := ui.NewPTable(columns, ui.CyanHeaders())
+	for _, c := range statuses {
+		table.AddRow(
+			c.Name,
+			c.Region,
+			versionCell(c),
+			supportCell(c.Support),
+			computeCell(c),
+			staleAMICell(c),
+			addonsCell(c.AddonsBehind),
+		)
+	}
+	table.Render()
+
+	fmt.Println()
+	fmt.Println(summaryFooter(statuses, elapsed))
+	return nil
+}
+
+func versionCell(c statussvc.ClusterStatus) string {
+	if c.Version == "" {
+		return "unknown"
+	}
+	return c.Version
+}
+
+func supportCell(s statussvc.SupportPosture) string {
+	star := ""
+	if s.Fallback {
+		star = "*"
+	}
+	switch s.Tier {
+	case statussvc.SupportStandard:
+		txt := "standard"
+		if s.StandardUntil != nil {
+			txt += " until " + s.StandardUntil.Format(dateLayout)
+		}
+		if s.DaysRemaining != nil {
+			txt += fmt.Sprintf(" (%dd)", *s.DaysRemaining)
+		}
+		return txt + star
+	case statussvc.SupportExtended:
+		txt := "⚠ EXTENDED"
+		if s.ExtendedUntil != nil {
+			txt += " until " + s.ExtendedUntil.Format(dateLayout)
+		}
+		if s.ExtraCostUSDPerHour > 0 {
+			txt += fmt.Sprintf(" (~$%.2f/hr)", s.ExtraCostUSDPerHour)
+		}
+		return color.YellowString(txt + star)
+	case statussvc.SupportUnsupported:
+		return color.RedString("✖ UNSUPPORTED" + star)
+	default:
+		return "unknown"
+	}
+}
+
+func computeCell(c statussvc.ClusterStatus) string {
+	switch c.Compute {
+	case statussvc.ComputeManaged:
+		return fmt.Sprintf("%d nodegroups", c.NodegroupCount)
+	case statussvc.ComputeAutoMode:
+		return color.CyanString("🤖 Auto Mode")
+	case statussvc.ComputeKarpenter:
+		return color.CyanString("Karpenter-managed")
+	default:
+		return "no managed nodegroups"
+	}
+}
+
+func staleAMICell(c statussvc.ClusterStatus) string {
+	// AMI staleness only applies to managed nodegroups; AWS owns AMIs for Auto
+	// Mode and Karpenter manages them out-of-band.
+	if c.Compute != statussvc.ComputeManaged {
+		return "n/a"
+	}
+	if c.StaleAMI.Behind == 0 {
+		return "0"
+	}
+	txt := fmt.Sprintf("%d/%d", c.StaleAMI.Behind, c.StaleAMI.Total)
+	if c.StaleAMI.OldestDays != nil {
+		txt += fmt.Sprintf(" (oldest %dd)", *c.StaleAMI.OldestDays)
+	}
+	return color.YellowString(txt)
+}
+
+func addonsCell(a statussvc.AddonsBehindSummary) string {
+	if a.Behind == 0 {
+		return "0"
+	}
+	names := a.Names
+	const maxNames = 2
+	suffix := ""
+	if len(names) > maxNames {
+		suffix = fmt.Sprintf(" +%d", len(names)-maxNames)
+		names = names[:maxNames]
+	}
+	return color.YellowString(fmt.Sprintf("%d (%s%s)", a.Behind, strings.Join(names, ","), suffix))
+}
+
+func summaryFooter(statuses []statussvc.ClusterStatus, elapsed time.Duration) string {
+	staleNodegroups, addonsBehind, supportRisk := 0, 0, 0
+	for _, c := range statuses {
+		staleNodegroups += c.StaleAMI.Behind
+		addonsBehind += c.AddonsBehind.Behind
+		if c.SupportRisk() {
+			supportRisk++
+		}
+	}
+	parts := []string{
+		fmt.Sprintf("%d clusters", len(statuses)),
+		fmt.Sprintf("%d stale nodegroups", staleNodegroups),
+		fmt.Sprintf("%d addons behind", addonsBehind),
+		fmt.Sprintf("%d extended/unsupported", supportRisk),
+	}
+	line := strings.Join(parts, " · ")
+	if elapsed > 0 {
+		line += fmt.Sprintf("  (%s)", elapsed.Round(time.Millisecond))
+	}
+	if supportRisk > 0 || staleNodegroups > 0 || addonsBehind > 0 {
+		return line
+	}
+	return color.GreenString(line)
+}

--- a/internal/services/status/service.go
+++ b/internal/services/status/service.go
@@ -1,0 +1,308 @@
+package status
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	"github.com/dantech2000/refresh/internal/services/addons"
+	"github.com/dantech2000/refresh/internal/services/common"
+	"github.com/dantech2000/refresh/internal/services/nodegroup"
+	"github.com/dantech2000/refresh/internal/types"
+)
+
+// ClusterAPI is the subset of the EKS API the status service calls directly.
+type ClusterAPI interface {
+	ListClusters(ctx context.Context, in *eks.ListClustersInput, optFns ...func(*eks.Options)) (*eks.ListClustersOutput, error)
+	DescribeCluster(ctx context.Context, in *eks.DescribeClusterInput, optFns ...func(*eks.Options)) (*eks.DescribeClusterOutput, error)
+	DescribeClusterVersions(ctx context.Context, in *eks.DescribeClusterVersionsInput, optFns ...func(*eks.Options)) (*eks.DescribeClusterVersionsOutput, error)
+}
+
+// NodegroupLister provides per-cluster nodegroup summaries (with AMI status).
+// Satisfied by *nodegroup.ServiceImpl.
+type NodegroupLister interface {
+	List(ctx context.Context, clusterName string, options nodegroup.ListOptions) ([]nodegroup.NodegroupSummary, error)
+}
+
+// AddonAnalyzer provides installed addons and their available versions.
+// Satisfied by *addons.ServiceImpl.
+type AddonAnalyzer interface {
+	List(ctx context.Context, clusterName string, options addons.ListOptions) ([]addons.AddonSummary, error)
+	GetAvailableVersions(ctx context.Context, addonName, k8sVersion string) ([]addons.AddonVersionInfo, error)
+}
+
+// EC2API is the optional EC2 subset used for AMI age and Karpenter detection.
+type EC2API interface {
+	DescribeImages(ctx context.Context, in *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error)
+	DescribeInstances(ctx context.Context, in *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+}
+
+// Service aggregates fleet patch posture for a single region.
+type Service struct {
+	region     string
+	clusterAPI ClusterAPI
+	nodegroups NodegroupLister
+	addons     AddonAnalyzer
+	ec2        EC2API // optional; nil disables AMI-age and Karpenter probes
+	logger     *slog.Logger
+
+	// now is injectable for tests; nil means time.Now.
+	now func() time.Time
+
+	supportMu    sync.Mutex
+	supportCache map[string]SupportPosture
+}
+
+// ListOptions controls cluster selection for a single-region status sweep.
+type ListOptions struct {
+	NamePattern    string
+	MaxConcurrency int
+}
+
+// NewService builds a region-scoped status service from an AWS config, wiring
+// the concrete cluster/nodegroup/addons/ec2 clients.
+func NewService(awsCfg aws.Config, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	eksClient := eks.NewFromConfig(awsCfg)
+	return &Service{
+		region:     awsCfg.Region,
+		clusterAPI: eksClient,
+		nodegroups: nodegroup.NewService(awsCfg, nil, logger),
+		addons:     addons.NewService(eksClient, logger),
+		ec2:        ec2.NewFromConfig(awsCfg),
+		logger:     logger,
+	}
+}
+
+func (s *Service) clock() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
+
+// ListClusterStatuses returns the patch posture of every cluster in the
+// service's region (optionally filtered by NamePattern). Per-cluster failures
+// are recorded on the row rather than failing the whole sweep.
+func (s *Service) ListClusterStatuses(ctx context.Context, opts ListOptions) ([]ClusterStatus, error) {
+	names, err := s.listClusterNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if p := strings.TrimSpace(opts.NamePattern); p != "" {
+		filtered := names[:0]
+		for _, n := range names {
+			if strings.Contains(strings.ToLower(n), strings.ToLower(p)) {
+				filtered = append(filtered, n)
+			}
+		}
+		names = filtered
+	}
+
+	conc := opts.MaxConcurrency
+	if conc <= 0 {
+		conc = common.DefaultItemConcurrency
+	}
+	results := common.ForEachParallel(ctx, names, conc,
+		func(fctx context.Context, name string) ClusterStatus {
+			return s.assembleCluster(fctx, name)
+		})
+	return results, nil
+}
+
+func (s *Service) listClusterNames(ctx context.Context) ([]string, error) {
+	var names []string
+	var token *string
+	for {
+		out, err := common.WithRetry(ctx, common.DefaultRetryConfig, func(rc context.Context) (*eks.ListClustersOutput, error) {
+			return s.clusterAPI.ListClusters(rc, &eks.ListClustersInput{NextToken: token})
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing clusters in %s: %w", s.region, err)
+		}
+		names = append(names, out.Clusters...)
+		if out.NextToken == nil {
+			break
+		}
+		token = out.NextToken
+	}
+	return names, nil
+}
+
+// assembleCluster builds one cluster's status row. Each data source is
+// best-effort: a failure appends to Errors and leaves that field zero-valued.
+func (s *Service) assembleCluster(ctx context.Context, name string) ClusterStatus {
+	cs := ClusterStatus{Name: name, Region: s.region}
+
+	desc, err := common.WithRetry(ctx, common.DefaultRetryConfig, func(rc context.Context) (*eks.DescribeClusterOutput, error) {
+		return s.clusterAPI.DescribeCluster(rc, &eks.DescribeClusterInput{Name: aws.String(name)})
+	})
+	if err != nil || desc == nil || desc.Cluster == nil {
+		cs.Errors = append(cs.Errors, fmt.Sprintf("describe cluster: %v", err))
+		cs.Support = SupportPosture{Tier: SupportUnknown}
+		cs.Compute = ComputeNone
+		return cs
+	}
+	cluster := desc.Cluster
+	cs.Version = aws.ToString(cluster.Version)
+	cs.Support = s.resolveSupport(ctx, cs.Version)
+
+	ngs, ngErr := s.nodegroups.List(ctx, name, nodegroup.ListOptions{})
+	if ngErr != nil {
+		cs.Errors = append(cs.Errors, fmt.Sprintf("list nodegroups: %v", ngErr))
+	} else {
+		cs.NodegroupCount = len(ngs)
+		cs.StaleAMI = s.staleAMISummary(ctx, ngs)
+	}
+
+	cs.Compute = s.detectCompute(ctx, cluster, cs.NodegroupCount)
+
+	behind, addErr := s.addonsBehind(ctx, name, cs.Version)
+	if addErr != nil {
+		cs.Errors = append(cs.Errors, fmt.Sprintf("analyze addons: %v", addErr))
+	}
+	cs.AddonsBehind = behind
+
+	return cs
+}
+
+// staleAMISummary counts outdated nodegroup AMIs and, best-effort, the age of
+// the oldest stale AMI.
+func (s *Service) staleAMISummary(ctx context.Context, ngs []nodegroup.NodegroupSummary) StaleAMISummary {
+	summary := StaleAMISummary{Total: len(ngs)}
+	var staleIDs []string
+	for _, ng := range ngs {
+		if ng.AMIStatus == types.AMIOutdated {
+			summary.Behind++
+			if ng.CurrentAMI != "" {
+				staleIDs = append(staleIDs, ng.CurrentAMI)
+			}
+		}
+	}
+	if summary.Behind > 0 && len(staleIDs) > 0 {
+		if days := s.amiOldestDays(ctx, staleIDs); days != nil {
+			summary.OldestDays = days
+		}
+	}
+	return summary
+}
+
+// amiOldestDays resolves the age in days of the oldest AMI among the given IDs
+// via DescribeImages. Returns nil when EC2 is unavailable or the call fails.
+func (s *Service) amiOldestDays(ctx context.Context, amiIDs []string) *int {
+	if s.ec2 == nil {
+		return nil
+	}
+	out, err := s.ec2.DescribeImages(ctx, &ec2.DescribeImagesInput{ImageIds: dedupe(amiIDs)})
+	if err != nil || out == nil || len(out.Images) == 0 {
+		return nil
+	}
+	var oldest time.Time
+	for _, img := range out.Images {
+		created := aws.ToString(img.CreationDate)
+		if created == "" {
+			continue
+		}
+		t, perr := time.Parse(time.RFC3339, created)
+		if perr != nil {
+			continue
+		}
+		if oldest.IsZero() || t.Before(oldest) {
+			oldest = t
+		}
+	}
+	if oldest.IsZero() {
+		return nil
+	}
+	return daysBetween(oldest, s.clock())
+}
+
+// addonsBehind counts cluster addons whose installed version trails the latest
+// version compatible with the cluster's Kubernetes version.
+func (s *Service) addonsBehind(ctx context.Context, cluster, k8sVersion string) (AddonsBehindSummary, error) {
+	installed, err := s.addons.List(ctx, cluster, addons.ListOptions{})
+	if err != nil {
+		return AddonsBehindSummary{}, err
+	}
+	summary := AddonsBehindSummary{Total: len(installed)}
+	for _, a := range installed {
+		avail, verr := s.addons.GetAvailableVersions(ctx, a.Name, k8sVersion)
+		if verr != nil || len(avail) == 0 {
+			continue // can't determine latest — don't guess
+		}
+		latest := avail[0].Version
+		if addons.CompareVersions(a.Version, latest) < 0 {
+			summary.Behind++
+			summary.Names = append(summary.Names, a.Name)
+		}
+	}
+	return summary, nil
+}
+
+// karpenterTagKeys are the EC2 instance tags Karpenter sets on the nodes it
+// provisions (current and legacy).
+var karpenterTagKeys = []string{"karpenter.sh/nodepool", "karpenter.sh/provisioner-name"}
+
+// detectCompute classifies how a cluster runs compute so a nodegroup-less
+// cluster never renders as an empty "nothing to do" row.
+func (s *Service) detectCompute(ctx context.Context, cluster *ekstypes.Cluster, ngCount int) ComputeType {
+	if cluster != nil && cluster.ComputeConfig != nil && aws.ToBool(cluster.ComputeConfig.Enabled) {
+		return ComputeAutoMode
+	}
+	if ngCount > 0 {
+		return ComputeManaged
+	}
+	if s.hasKarpenterInstances(ctx) {
+		return ComputeKarpenter
+	}
+	return ComputeNone
+}
+
+// hasKarpenterInstances is a best-effort probe for Karpenter-provisioned EC2
+// instances in the region. Any error (including missing permission) is treated
+// as "no signal".
+func (s *Service) hasKarpenterInstances(ctx context.Context) bool {
+	if s.ec2 == nil {
+		return false
+	}
+	out, err := s.ec2.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		MaxResults: aws.Int32(5),
+		Filters: []ec2types.Filter{
+			{Name: aws.String("tag-key"), Values: karpenterTagKeys},
+			{Name: aws.String("instance-state-name"), Values: []string{"pending", "running"}},
+		},
+	})
+	if err != nil || out == nil {
+		return false
+	}
+	for _, r := range out.Reservations {
+		if len(r.Instances) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func dedupe(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := in[:0]
+	for _, v := range in {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}

--- a/internal/services/status/service_test.go
+++ b/internal/services/status/service_test.go
@@ -1,0 +1,172 @@
+package status
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	"github.com/dantech2000/refresh/internal/services/addons"
+	"github.com/dantech2000/refresh/internal/services/nodegroup"
+	"github.com/dantech2000/refresh/internal/types"
+)
+
+// fakeNodegroups implements NodegroupLister.
+type fakeNodegroups struct {
+	byCluster map[string][]nodegroup.NodegroupSummary
+}
+
+func (f *fakeNodegroups) List(_ context.Context, cluster string, _ nodegroup.ListOptions) ([]nodegroup.NodegroupSummary, error) {
+	return f.byCluster[cluster], nil
+}
+
+// fakeAddons implements AddonAnalyzer.
+type fakeAddons struct {
+	installed map[string][]addons.AddonSummary
+	available map[string][]addons.AddonVersionInfo
+}
+
+func (f *fakeAddons) List(_ context.Context, cluster string, _ addons.ListOptions) ([]addons.AddonSummary, error) {
+	return f.installed[cluster], nil
+}
+
+func (f *fakeAddons) GetAvailableVersions(_ context.Context, addonName, _ string) ([]addons.AddonVersionInfo, error) {
+	return f.available[addonName], nil
+}
+
+func newTestService(api *fakeClusterAPI, ng *fakeNodegroups, ad *fakeAddons) *Service {
+	return &Service{
+		region:     "us-east-1",
+		clusterAPI: api,
+		nodegroups: ng,
+		addons:     ad,
+		now:        func() time.Time { return date(2026, 6, 11) },
+	}
+}
+
+func TestListClusterStatuses_Fleet(t *testing.T) {
+	api := &fakeClusterAPI{
+		clusters: []string{"prod", "auto"},
+		describe: map[string]*ekstypes.Cluster{
+			"prod": {Name: aws.String("prod"), Version: aws.String("1.32")},
+			"auto": {
+				Name:          aws.String("auto"),
+				Version:       aws.String("1.32"),
+				ComputeConfig: &ekstypes.ComputeConfigResponse{Enabled: aws.Bool(true)},
+			},
+		},
+		versions: map[string]ekstypes.ClusterVersionInformation{
+			"1.32": {
+				ClusterVersion:           aws.String("1.32"),
+				EndOfStandardSupportDate: timePtr(date(2027, 3, 23)),
+				EndOfExtendedSupportDate: timePtr(date(2028, 3, 23)),
+			},
+		},
+	}
+	ng := &fakeNodegroups{byCluster: map[string][]nodegroup.NodegroupSummary{
+		"prod": {
+			{Name: "ng-a", AMIStatus: types.AMILatest, CurrentAMI: "ami-1"},
+			{Name: "ng-b", AMIStatus: types.AMIOutdated, CurrentAMI: "ami-2"},
+		},
+		// "auto" has no managed nodegroups.
+	}}
+	ad := &fakeAddons{
+		installed: map[string][]addons.AddonSummary{
+			"prod": {{Name: "vpc-cni", Version: "v1.10.0"}, {Name: "coredns", Version: "v1.11.4"}},
+		},
+		available: map[string][]addons.AddonVersionInfo{
+			"vpc-cni": {{Version: "v1.18.1"}, {Version: "v1.10.0"}}, // behind
+			"coredns": {{Version: "v1.11.4"}},                       // current
+		},
+	}
+
+	svc := newTestService(api, ng, ad)
+	statuses, err := svc.ListClusterStatuses(context.Background(), ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(statuses) != 2 {
+		t.Fatalf("got %d statuses, want 2", len(statuses))
+	}
+
+	byName := map[string]ClusterStatus{}
+	for _, c := range statuses {
+		byName[c.Name] = c
+	}
+
+	prod := byName["prod"]
+	if prod.Compute != ComputeManaged {
+		t.Errorf("prod compute = %s, want managed-nodegroups", prod.Compute)
+	}
+	if prod.StaleAMI.Behind != 1 || prod.StaleAMI.Total != 2 {
+		t.Errorf("prod stale AMI = %d/%d, want 1/2", prod.StaleAMI.Behind, prod.StaleAMI.Total)
+	}
+	if prod.AddonsBehind.Behind != 1 {
+		t.Errorf("prod addons behind = %d, want 1", prod.AddonsBehind.Behind)
+	}
+	if len(prod.AddonsBehind.Names) != 1 || prod.AddonsBehind.Names[0] != "vpc-cni" {
+		t.Errorf("prod addons behind names = %v, want [vpc-cni]", prod.AddonsBehind.Names)
+	}
+	if prod.Support.Tier != SupportStandard {
+		t.Errorf("prod support = %s, want standard", prod.Support.Tier)
+	}
+	if !prod.NeedsAttention() {
+		t.Error("prod should need attention (stale AMI + addon behind)")
+	}
+
+	auto := byName["auto"]
+	if auto.Compute != ComputeAutoMode {
+		t.Errorf("auto compute = %s, want auto-mode", auto.Compute)
+	}
+	if auto.NodegroupCount != 0 {
+		t.Errorf("auto nodegroup count = %d, want 0", auto.NodegroupCount)
+	}
+	if auto.NeedsAttention() {
+		t.Error("auto (no managed nodegroups) should not need AMI attention")
+	}
+}
+
+func TestAssembleCluster_DescribeErrorIsNonFatal(t *testing.T) {
+	api := &fakeClusterAPI{
+		clusters: []string{"ghost"},
+		describe: map[string]*ekstypes.Cluster{}, // describe will error
+	}
+	svc := newTestService(api, &fakeNodegroups{}, &fakeAddons{})
+	statuses, err := svc.ListClusterStatuses(context.Background(), ListOptions{})
+	if err != nil {
+		t.Fatalf("sweep should not fail on a single bad cluster: %v", err)
+	}
+	if len(statuses) != 1 {
+		t.Fatalf("got %d, want 1 partial row", len(statuses))
+	}
+	if len(statuses[0].Errors) == 0 {
+		t.Error("expected the describe failure recorded on the row")
+	}
+	if statuses[0].Support.Tier != SupportUnknown {
+		t.Errorf("support = %s, want unknown for undescribable cluster", statuses[0].Support.Tier)
+	}
+}
+
+func TestListClusterStatuses_NameFilter(t *testing.T) {
+	api := &fakeClusterAPI{
+		clusters: []string{"prod-east", "staging", "prod-west"},
+		describe: map[string]*ekstypes.Cluster{
+			"prod-east": {Name: aws.String("prod-east"), Version: aws.String("1.32")},
+			"prod-west": {Name: aws.String("prod-west"), Version: aws.String("1.32")},
+			"staging":   {Name: aws.String("staging"), Version: aws.String("1.32")},
+		},
+		versions: map[string]ekstypes.ClusterVersionInformation{
+			"1.32": {ClusterVersion: aws.String("1.32"), EndOfStandardSupportDate: timePtr(date(2027, 3, 23))},
+		},
+	}
+	svc := newTestService(api, &fakeNodegroups{}, &fakeAddons{})
+	statuses, err := svc.ListClusterStatuses(context.Background(), ListOptions{NamePattern: "prod"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(statuses) != 2 {
+		t.Fatalf("name filter returned %d, want 2", len(statuses))
+	}
+}

--- a/internal/services/status/support.go
+++ b/internal/services/status/support.go
@@ -1,0 +1,138 @@
+package status
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+)
+
+// Extended support roughly doubles the control-plane price: ~$0.60/hr vs the
+// standard ~$0.10/hr, i.e. a ~$0.50/hr premium per cluster (~$4,380/yr). The
+// premium is what we surface — it's the number that makes a lingering cluster
+// worth upgrading.
+const extendedSupportPremiumUSDPerHour = 0.50
+
+// fallbackCalendar maps a Kubernetes minor version to its published EKS support
+// window, used when DescribeClusterVersions is unavailable (missing permission,
+// older API). Dates are AWS's published end-of-support calendar; rows derived
+// from this table are flagged Fallback.
+var fallbackCalendar = map[string]struct {
+	standardEnd time.Time
+	extendedEnd time.Time
+}{
+	"1.28": {date(2024, 11, 26), date(2025, 11, 26)},
+	"1.29": {date(2025, 3, 23), date(2026, 3, 23)},
+	"1.30": {date(2025, 7, 23), date(2026, 7, 23)},
+	"1.31": {date(2025, 11, 26), date(2026, 11, 26)},
+	"1.32": {date(2026, 3, 23), date(2027, 3, 23)},
+	"1.33": {date(2026, 7, 23), date(2027, 7, 23)},
+}
+
+func date(y int, m time.Month, d int) time.Time {
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+}
+
+// resolveSupport returns the support posture for a Kubernetes version, caching
+// per version so `status -A` resolves each version at most once. It prefers
+// DescribeClusterVersions and falls back to the compiled-in calendar.
+func (s *Service) resolveSupport(ctx context.Context, version string) SupportPosture {
+	if version == "" {
+		return SupportPosture{Tier: SupportUnknown}
+	}
+
+	s.supportMu.Lock()
+	if s.supportCache == nil {
+		s.supportCache = make(map[string]SupportPosture)
+	}
+	if cached, ok := s.supportCache[version]; ok {
+		s.supportMu.Unlock()
+		return cached
+	}
+	s.supportMu.Unlock()
+
+	posture := s.lookupSupport(ctx, version)
+
+	s.supportMu.Lock()
+	s.supportCache[version] = posture
+	s.supportMu.Unlock()
+	return posture
+}
+
+func (s *Service) lookupSupport(ctx context.Context, version string) SupportPosture {
+	std, ext, ok := s.supportDatesFromAPI(ctx, version)
+	fallback := false
+	if !ok {
+		cal, found := fallbackCalendar[version]
+		if !found {
+			return SupportPosture{Tier: SupportUnknown}
+		}
+		std, ext = cal.standardEnd, cal.extendedEnd
+		fallback = true
+	}
+	return classifySupport(std, ext, s.clock(), fallback)
+}
+
+// supportDatesFromAPI fetches the standard/extended end dates for a version via
+// DescribeClusterVersions. ok is false when the API errors or the dates are
+// absent, so the caller falls back to the compiled-in calendar.
+func (s *Service) supportDatesFromAPI(ctx context.Context, version string) (std, ext time.Time, ok bool) {
+	if s.clusterAPI == nil {
+		return time.Time{}, time.Time{}, false
+	}
+	out, err := s.clusterAPI.DescribeClusterVersions(ctx, &eks.DescribeClusterVersionsInput{
+		ClusterVersions: []string{version},
+	})
+	if err != nil || out == nil {
+		return time.Time{}, time.Time{}, false
+	}
+	for _, cv := range out.ClusterVersions {
+		if aws.ToString(cv.ClusterVersion) != version {
+			continue
+		}
+		if cv.EndOfStandardSupportDate == nil {
+			return time.Time{}, time.Time{}, false
+		}
+		std = *cv.EndOfStandardSupportDate
+		if cv.EndOfExtendedSupportDate != nil {
+			ext = *cv.EndOfExtendedSupportDate
+		}
+		return std, ext, true
+	}
+	return time.Time{}, time.Time{}, false
+}
+
+// classifySupport derives the tier, days-remaining, and extended-cost callout
+// from the standard/extended end dates relative to now.
+func classifySupport(standardEnd, extendedEnd, now time.Time, fallback bool) SupportPosture {
+	posture := SupportPosture{Fallback: fallback}
+	if !standardEnd.IsZero() {
+		su := standardEnd
+		posture.StandardUntil = &su
+	}
+	if !extendedEnd.IsZero() {
+		eu := extendedEnd
+		posture.ExtendedUntil = &eu
+	}
+
+	switch {
+	case !standardEnd.IsZero() && now.Before(standardEnd):
+		posture.Tier = SupportStandard
+		posture.DaysRemaining = daysBetween(now, standardEnd)
+	case !extendedEnd.IsZero() && now.Before(extendedEnd):
+		posture.Tier = SupportExtended
+		posture.DaysRemaining = daysBetween(now, extendedEnd)
+		posture.ExtraCostUSDPerHour = extendedSupportPremiumUSDPerHour
+	case !standardEnd.IsZero() || !extendedEnd.IsZero():
+		posture.Tier = SupportUnsupported
+	default:
+		posture.Tier = SupportUnknown
+	}
+	return posture
+}
+
+func daysBetween(from, to time.Time) *int {
+	d := int(to.Sub(from).Hours() / 24)
+	return &d
+}

--- a/internal/services/status/support_test.go
+++ b/internal/services/status/support_test.go
@@ -1,0 +1,135 @@
+package status
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+)
+
+func TestClassifySupport(t *testing.T) {
+	now := date(2026, 6, 11)
+	std := date(2026, 11, 26) // standard ends in the future
+	ext := date(2027, 11, 26)
+
+	t.Run("standard", func(t *testing.T) {
+		p := classifySupport(std, ext, now, false)
+		if p.Tier != SupportStandard {
+			t.Fatalf("tier = %s, want standard", p.Tier)
+		}
+		if p.DaysRemaining == nil || *p.DaysRemaining <= 0 {
+			t.Errorf("expected positive days remaining, got %v", p.DaysRemaining)
+		}
+		if p.ExtraCostUSDPerHour != 0 {
+			t.Errorf("standard should have no extra cost, got %v", p.ExtraCostUSDPerHour)
+		}
+	})
+
+	t.Run("extended", func(t *testing.T) {
+		p := classifySupport(date(2026, 3, 23), date(2027, 3, 23), now, false)
+		if p.Tier != SupportExtended {
+			t.Fatalf("tier = %s, want extended", p.Tier)
+		}
+		if p.ExtraCostUSDPerHour != extendedSupportPremiumUSDPerHour {
+			t.Errorf("extra cost = %v, want %v", p.ExtraCostUSDPerHour, extendedSupportPremiumUSDPerHour)
+		}
+	})
+
+	t.Run("unsupported", func(t *testing.T) {
+		p := classifySupport(date(2024, 11, 26), date(2025, 11, 26), now, false)
+		if p.Tier != SupportUnsupported {
+			t.Fatalf("tier = %s, want unsupported", p.Tier)
+		}
+	})
+
+	t.Run("unknown when no dates", func(t *testing.T) {
+		p := classifySupport(time.Time{}, time.Time{}, now, false)
+		if p.Tier != SupportUnknown {
+			t.Fatalf("tier = %s, want unknown", p.Tier)
+		}
+	})
+}
+
+func TestResolveSupport_FallbackCalendar(t *testing.T) {
+	// API errors → resolver falls back to the compiled-in calendar and flags it.
+	svc := &Service{
+		clusterAPI: &fakeClusterAPI{versionsErr: errors.New("access denied")},
+		now:        func() time.Time { return date(2026, 6, 11) },
+	}
+	p := svc.resolveSupport(context.Background(), "1.31")
+	if !p.Fallback {
+		t.Error("expected Fallback=true when API unavailable")
+	}
+	// 1.31 standard ended 2025-11-26 and extended ends 2026-11-26, so as of
+	// 2026-06-11 the cluster is in extended support.
+	if p.Tier != SupportExtended {
+		t.Errorf("tier = %s, want extended (1.31 as of 2026-06-11)", p.Tier)
+	}
+}
+
+func TestResolveSupport_FromAPI(t *testing.T) {
+	api := &fakeClusterAPI{
+		versions: map[string]ekstypes.ClusterVersionInformation{
+			"1.32": {
+				ClusterVersion:           aws.String("1.32"),
+				EndOfStandardSupportDate: timePtr(date(2027, 3, 23)),
+				EndOfExtendedSupportDate: timePtr(date(2028, 3, 23)),
+			},
+		},
+	}
+	svc := &Service{clusterAPI: api, now: func() time.Time { return date(2026, 6, 11) }}
+	p := svc.resolveSupport(context.Background(), "1.32")
+	if p.Fallback {
+		t.Error("expected API-derived posture, not fallback")
+	}
+	if p.Tier != SupportStandard {
+		t.Errorf("tier = %s, want standard", p.Tier)
+	}
+
+	// Second call must hit the cache (no extra API calls).
+	_ = svc.resolveSupport(context.Background(), "1.32")
+	if api.versionCalls != 1 {
+		t.Errorf("DescribeClusterVersions called %d times, want 1 (cached)", api.versionCalls)
+	}
+}
+
+func timePtr(t time.Time) *time.Time { return &t }
+
+// fakeClusterAPI implements ClusterAPI for tests.
+type fakeClusterAPI struct {
+	clusters     []string
+	describe     map[string]*ekstypes.Cluster
+	versions     map[string]ekstypes.ClusterVersionInformation
+	versionsErr  error
+	versionCalls int
+}
+
+func (f *fakeClusterAPI) ListClusters(_ context.Context, _ *eks.ListClustersInput, _ ...func(*eks.Options)) (*eks.ListClustersOutput, error) {
+	return &eks.ListClustersOutput{Clusters: f.clusters}, nil
+}
+
+func (f *fakeClusterAPI) DescribeCluster(_ context.Context, in *eks.DescribeClusterInput, _ ...func(*eks.Options)) (*eks.DescribeClusterOutput, error) {
+	c, ok := f.describe[aws.ToString(in.Name)]
+	if !ok {
+		return nil, errors.New("cluster not found")
+	}
+	return &eks.DescribeClusterOutput{Cluster: c}, nil
+}
+
+func (f *fakeClusterAPI) DescribeClusterVersions(_ context.Context, in *eks.DescribeClusterVersionsInput, _ ...func(*eks.Options)) (*eks.DescribeClusterVersionsOutput, error) {
+	f.versionCalls++
+	if f.versionsErr != nil {
+		return nil, f.versionsErr
+	}
+	out := &eks.DescribeClusterVersionsOutput{}
+	for _, v := range in.ClusterVersions {
+		if cv, ok := f.versions[v]; ok {
+			out.ClusterVersions = append(out.ClusterVersions, cv)
+		}
+	}
+	return out, nil
+}

--- a/internal/services/status/support_test.go
+++ b/internal/services/status/support_test.go
@@ -3,6 +3,7 @@ package status
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -92,8 +93,8 @@ func TestResolveSupport_FromAPI(t *testing.T) {
 
 	// Second call must hit the cache (no extra API calls).
 	_ = svc.resolveSupport(context.Background(), "1.32")
-	if api.versionCalls != 1 {
-		t.Errorf("DescribeClusterVersions called %d times, want 1 (cached)", api.versionCalls)
+	if got := api.versionCalls.Load(); got != 1 {
+		t.Errorf("DescribeClusterVersions called %d times, want 1 (cached)", got)
 	}
 }
 
@@ -101,11 +102,14 @@ func timePtr(t time.Time) *time.Time { return &t }
 
 // fakeClusterAPI implements ClusterAPI for tests.
 type fakeClusterAPI struct {
-	clusters     []string
-	describe     map[string]*ekstypes.Cluster
-	versions     map[string]ekstypes.ClusterVersionInformation
-	versionsErr  error
-	versionCalls int
+	clusters    []string
+	describe    map[string]*ekstypes.Cluster
+	versions    map[string]ekstypes.ClusterVersionInformation
+	versionsErr error
+	// versionCalls is atomic: a fleet sweep resolves support from multiple
+	// assembleCluster goroutines concurrently (concurrent cache misses for the
+	// same version each hit the API once).
+	versionCalls atomic.Int64
 }
 
 func (f *fakeClusterAPI) ListClusters(_ context.Context, _ *eks.ListClustersInput, _ ...func(*eks.Options)) (*eks.ListClustersOutput, error) {
@@ -121,7 +125,7 @@ func (f *fakeClusterAPI) DescribeCluster(_ context.Context, in *eks.DescribeClus
 }
 
 func (f *fakeClusterAPI) DescribeClusterVersions(_ context.Context, in *eks.DescribeClusterVersionsInput, _ ...func(*eks.Options)) (*eks.DescribeClusterVersionsOutput, error) {
-	f.versionCalls++
+	f.versionCalls.Add(1)
 	if f.versionsErr != nil {
 		return nil, f.versionsErr
 	}

--- a/internal/services/status/types.go
+++ b/internal/services/status/types.go
@@ -1,0 +1,97 @@
+// Package status aggregates fleet-wide EKS patch posture — Kubernetes version,
+// support window, nodegroup AMI staleness, and addons-behind-latest — for the
+// `refresh status` command. It reuses the cluster/nodegroup/addons services and
+// is single-region; multi-region fan-out lives in the command layer.
+package status
+
+import "time"
+
+// ComputeType describes how a cluster provisions its worker nodes. It exists so
+// `refresh status` never renders a nodegroup-less cluster as an empty row.
+type ComputeType string
+
+const (
+	// ComputeManaged is the normal case: one or more managed nodegroups.
+	ComputeManaged ComputeType = "managed-nodegroups"
+	// ComputeAutoMode is EKS Auto Mode (AWS manages compute and AMIs).
+	ComputeAutoMode ComputeType = "auto-mode"
+	// ComputeKarpenter is a nodegroup-less cluster with Karpenter signals.
+	ComputeKarpenter ComputeType = "karpenter"
+	// ComputeNone is a cluster with no managed nodegroups and no detected
+	// alternative compute provider.
+	ComputeNone ComputeType = "none"
+)
+
+// SupportTier is the EKS support posture for a cluster's Kubernetes version.
+type SupportTier string
+
+const (
+	SupportStandard    SupportTier = "standard"
+	SupportExtended    SupportTier = "extended"
+	SupportUnsupported SupportTier = "unsupported"
+	SupportUnknown     SupportTier = "unknown"
+)
+
+// SupportPosture is the resolved support window for a cluster's version.
+type SupportPosture struct {
+	Tier          SupportTier `json:"tier" yaml:"tier"`
+	StandardUntil *time.Time  `json:"standardUntil,omitempty" yaml:"standardUntil,omitempty"`
+	ExtendedUntil *time.Time  `json:"extendedUntil,omitempty" yaml:"extendedUntil,omitempty"`
+	// DaysRemaining counts down to the end of the current tier (standard or
+	// extended). Negative once the window has closed.
+	DaysRemaining *int `json:"daysRemaining,omitempty" yaml:"daysRemaining,omitempty"`
+	// ExtraCostUSDPerHour is the per-cluster premium of the current tier over
+	// standard support (0 unless extended).
+	ExtraCostUSDPerHour float64 `json:"extraCostUsdPerHour,omitempty" yaml:"extraCostUsdPerHour,omitempty"`
+	// Fallback is true when the posture came from the compiled-in calendar
+	// because DescribeClusterVersions was unavailable.
+	Fallback bool `json:"fallback,omitempty" yaml:"fallback,omitempty"`
+}
+
+// StaleAMISummary summarizes nodegroup AMI posture for a cluster.
+type StaleAMISummary struct {
+	Total  int `json:"total" yaml:"total"`
+	Behind int `json:"behind" yaml:"behind"`
+	// OldestDays is the age of the oldest stale AMI in days, when resolvable.
+	OldestDays *int `json:"oldestDays,omitempty" yaml:"oldestDays,omitempty"`
+}
+
+// AddonsBehindSummary summarizes addon version posture for a cluster.
+type AddonsBehindSummary struct {
+	Total  int      `json:"total" yaml:"total"`
+	Behind int      `json:"behind" yaml:"behind"`
+	Names  []string `json:"names,omitempty" yaml:"names,omitempty"`
+}
+
+// ClusterStatus is the fleet-status row for a single cluster.
+type ClusterStatus struct {
+	Name           string              `json:"name" yaml:"name"`
+	Region         string              `json:"region" yaml:"region"`
+	Version        string              `json:"version" yaml:"version"`
+	Support        SupportPosture      `json:"support" yaml:"support"`
+	Compute        ComputeType         `json:"compute" yaml:"compute"`
+	NodegroupCount int                 `json:"nodegroupCount" yaml:"nodegroupCount"`
+	StaleAMI       StaleAMISummary     `json:"staleAmi" yaml:"staleAmi"`
+	AddonsBehind   AddonsBehindSummary `json:"addonsBehind" yaml:"addonsBehind"`
+	// Errors holds non-fatal, per-cluster failures so a partial row still
+	// renders instead of dropping the cluster entirely.
+	Errors []string `json:"errors,omitempty" yaml:"errors,omitempty"`
+}
+
+// NeedsAttention reports whether the cluster has any stale AMIs or addons
+// behind latest (drives the exit-code "something stale" signal).
+func (c ClusterStatus) NeedsAttention() bool {
+	return c.StaleAMI.Behind > 0 || c.AddonsBehind.Behind > 0
+}
+
+// SupportRisk reports whether the cluster is on extended or unsupported EKS
+// (drives the exit-code "support risk" signal).
+func (c ClusterStatus) SupportRisk() bool {
+	return c.Support.Tier == SupportExtended || c.Support.Tier == SupportUnsupported
+}
+
+// FleetStatus is the aggregate posture across clusters and regions — the
+// payload serialized for json/yaml output.
+type FleetStatus struct {
+	Clusters []ClusterStatus `json:"clusters" yaml:"clusters"`
+}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	clustercmd "github.com/dantech2000/refresh/internal/commands/cluster"
 	ctxcmd "github.com/dantech2000/refresh/internal/commands/ctxcmd"
 	nodegroupcmd "github.com/dantech2000/refresh/internal/commands/nodegroup"
+	statuscmd "github.com/dantech2000/refresh/internal/commands/statuscmd"
 	workloadcmd "github.com/dantech2000/refresh/internal/commands/workload"
 	appconfig "github.com/dantech2000/refresh/internal/config"
 )
@@ -91,6 +92,8 @@ func newApp() *cli.Command {
 			return ctx, nil
 		},
 		Commands: []*cli.Command{
+			// Fleet front door
+			statuscmd.Command(),
 			// Resource-first groups
 			clustercmd.Command(),
 			nodegroupcmd.Command(),


### PR DESCRIPTION
## What & why

Batch B of the Opus-4.8 roadmap — the **REF-79 `refresh status`** epic: the fleet "front door". One command surfaces, per cluster across all regions, what's out of date and what it's costing you.

```text
CLUSTER     REGION     VERSION  SUPPORT                      COMPUTE         STALE AMI        ADDONS BEHIND
prod-east   us-east-1  1.31     standard until 2025-11-26    4 nodegroups    2/4 (oldest 94d) 1 (coredns)
prod-west   us-west-2  1.29     ⚠ EXTENDED until 2026-03-23 (~$0.50/hr)  3 nodegroups  3/3 (oldest 210d) 2
legacy      us-east-1  1.33     standard until 2026-07-23    🤖 Auto Mode    n/a              0

3 clusters · 5 stale nodegroups · 3 addons behind · 1 extended/unsupported
```

Built on the v3 base (PR #27). Depends on nothing else outstanding.

## Sub-issues

| Issue | What |
|-------|------|
| **REF-87** | Support-calendar resolver via `eks:DescribeClusterVersions` (cached per version) + compiled-in fallback calendar (rows marked `*`); standard/extended/unsupported with days-remaining and the ~$0.50/hr extended-support premium surfaced inline |
| **REF-88** | Fleet stale-AMI summary reusing nodegroup AMI-status resolution (behind/total + best-effort oldest-AMI age via `ec2:DescribeImages`) |
| **REF-89** | Addons-behind detection via the addons version analyzer (`CompareVersions` vs latest compatible) |
| **REF-91** | Compute-type detection so nodegroup-less clusters aren't empty rows — EKS Auto Mode (definitive, `computeConfig.enabled`) + best-effort Karpenter EC2-tag heuristic |
| **REF-90** | Command wiring (`-A`/`-r`/`--max-concurrency`/`-o`/`--sort`/`--desc` + name pattern), multi-region fan-out (bounded concurrency), table/json/yaml/plain + footer, and the **0/2/3 exit-code contract** |

## Design

- The `status` service is **single-region and testable** via injected interfaces (`ClusterAPI`, `NodegroupLister`, `AddonAnalyzer`, optional `EC2API`) — the real `eks`/`nodegroup`/`addons`/`ec2` clients satisfy them. Multi-region fan-out lives in the command layer, mirroring `cluster list`'s `forRegion` pattern.
- Per-cluster failures are recorded on the row (`Errors`) rather than failing the whole sweep — `status -A` degrades gracefully.
- No SDK bump needed: `eks@v1.73.1` already has `DescribeClusterVersions`, the support-date fields, and `Cluster.ComputeConfig`.

## Testing

- `go build ./...`, `go test ./...` (incl. `-race` on the new packages), `go vet`, `golangci-lint` — **all green, 0 issues**
- Unit tests: support mapping (standard/extended/unsupported/unknown, fallback, per-version cache), fleet aggregation (stale AMI, addons-behind, Auto Mode, partial-failure non-fatal, name filter), exit codes, and sorting
- Manual smoke: `refresh status --help` and command registration verified
- README + IAM permissions documented

Closes REF-87, REF-88, REF-89, REF-90, REF-91 (epic REF-79).

🤖 Generated with [Claude Code](https://claude.com/claude-code)