### PR TITLE
fix(cli): output & flag correctness — filters, format validation, global region/profile, yaml keys (REF-1, REF-47, REF-48, REF-49, REF-59)

### DIFF
--- a/internal/commands/addon/actions.go
+++ b/internal/commands/addon/actions.go
@@ -20,6 +20,9 @@ import (
 )
 
 func runList(ctx context.Context, cmd *cli.Command) error {
+	if err := runner.ValidateFormat(cmd.String("format"), runner.FormatsStandard); err != nil {
+		return err
+	}
 	ctx, cancel, cfg, err := runner.SetupAWS(ctx, cmd)
 	if err != nil {
 		return err
@@ -51,6 +54,9 @@ func runList(ctx context.Context, cmd *cli.Command) error {
 }
 
 func runDescribe(ctx context.Context, cmd *cli.Command) error {
+	if err := runner.ValidateFormat(cmd.String("format"), runner.FormatsStandard); err != nil {
+		return err
+	}
 	ctx, cancel, cfg, err := runner.SetupAWS(ctx, cmd)
 	if err != nil {
 		return err
@@ -177,6 +183,9 @@ func runUpdate(ctx context.Context, cmd *cli.Command) error {
 }
 
 func runUpdateAll(ctx context.Context, cmd *cli.Command) error {
+	if err := runner.ValidateFormat(cmd.String("format"), runner.FormatsStandard); err != nil {
+		return err
+	}
 	ctx, cancel, cfg, err := runner.SetupAWSStrict(ctx, cmd)
 	if err != nil {
 		return err

--- a/internal/commands/cluster/actions.go
+++ b/internal/commands/cluster/actions.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -19,7 +20,34 @@ import (
 	"github.com/dantech2000/refresh/internal/ui"
 )
 
+// allowedClusterFilterKeys are the --filter keys cluster list understands.
+// "name" is applied at the list stage; "status"/"version" need the per-cluster
+// summary and are applied afterwards.
+var allowedClusterFilterKeys = map[string]bool{"name": true, "status": true, "version": true}
+
+// validateClusterFilters rejects unsupported --filter keys so a typo like
+// `--filter staus=ACTIVE` errors instead of silently returning everything.
+func validateClusterFilters(filters map[string]string) error {
+	var unknown []string
+	for k := range filters {
+		if !allowedClusterFilterKeys[k] {
+			unknown = append(unknown, k)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return fmt.Errorf("unsupported filter key(s): %s (supported: name, status, version)", strings.Join(unknown, ", "))
+	}
+	return nil
+}
+
 func runList(ctx context.Context, cmd *cli.Command) error {
+	if err := runner.ValidateFormat(cmd.String("format"), runner.FormatsWithTree); err != nil {
+		return err
+	}
+	if err := validateClusterFilters(runner.ParseFilters(cmd.StringSlice("filter"))); err != nil {
+		return err
+	}
 	// Each --watch iteration performs the full setup+fetch+render cycle so a
 	// fresh service (and cache) is used every time.
 	return runner.Watch(cmd, func() error { return listClustersOnce(ctx, cmd) })
@@ -78,6 +106,9 @@ func listClustersOnce(ctx context.Context, cmd *cli.Command) error {
 }
 
 func runDescribe(ctx context.Context, cmd *cli.Command) error {
+	if err := runner.ValidateFormat(cmd.String("format"), runner.FormatsStandard); err != nil {
+		return err
+	}
 	ctx, cancel, awsCfg, err := runner.SetupAWS(ctx, cmd)
 	if err != nil {
 		return err
@@ -114,6 +145,9 @@ func runDescribe(ctx context.Context, cmd *cli.Command) error {
 }
 
 func runDiff(ctx context.Context, cmd *cli.Command) error {
+	if err := runner.ValidateFormat(cmd.String("format"), runner.FormatsStandard); err != nil {
+		return err
+	}
 	ctx, cancel, awsCfg, err := runner.SetupAWSWithTimeout(ctx, cmd, 60*time.Second)
 	if err != nil {
 		return err

--- a/internal/commands/cluster/filter_test.go
+++ b/internal/commands/cluster/filter_test.go
@@ -1,0 +1,34 @@
+package cluster
+
+import (
+	"strings"
+	"testing"
+)
+
+// validateClusterFilters must reject unsupported --filter keys instead of
+// silently ignoring them (REF-1).
+func TestValidateClusterFilters(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		filters map[string]string
+		wantErr bool
+	}{
+		{"empty", nil, false},
+		{"name", map[string]string{"name": "prod"}, false},
+		{"status", map[string]string{"status": "ACTIVE"}, false},
+		{"version", map[string]string{"version": "1.32"}, false},
+		{"all supported", map[string]string{"name": "p", "status": "ACTIVE", "version": "1.32"}, false},
+		{"unknown key", map[string]string{"staus": "ACTIVE"}, true},
+		{"mixed known + unknown", map[string]string{"status": "ACTIVE", "color": "blue"}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateClusterFilters(tc.filters)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateClusterFilters(%v) error = %v, wantErr %v", tc.filters, err, tc.wantErr)
+			}
+			if err != nil && !strings.Contains(err.Error(), "supported:") {
+				t.Errorf("error %q should name the supported keys", err)
+			}
+		})
+	}
+}

--- a/internal/commands/cluster/upgrade.go
+++ b/internal/commands/cluster/upgrade.go
@@ -66,6 +66,9 @@ Examples:
 }
 
 func runUpgrade(ctx context.Context, cmd *cli.Command) error {
+	if err := runner.ValidateFormat(cmd.String("format"), runner.FormatsStandard); err != nil {
+		return err
+	}
 	// Strict credential validation: this command mutates the control plane.
 	ctx, cancel, awsCfg, err := runner.SetupAWSStrict(ctx, cmd)
 	if err != nil {

--- a/internal/commands/cluster/upgradecheck.go
+++ b/internal/commands/cluster/upgradecheck.go
@@ -42,6 +42,9 @@ Examples:
 }
 
 func runUpgradeCheck(ctx context.Context, cmd *cli.Command) error {
+	if err := runner.ValidateFormat(cmd.String("format"), runner.FormatsStandard); err != nil {
+		return err
+	}
 	ctx, cancel, awsCfg, err := runner.SetupAWS(ctx, cmd)
 	if err != nil {
 		return err

--- a/internal/commands/nodegroup/actions.go
+++ b/internal/commands/nodegroup/actions.go
@@ -32,6 +32,9 @@ import (
 )
 
 func runList(ctx context.Context, cmd *cli.Command) error {
+	if err := runner.ValidateFormat(cmd.String("format"), runner.FormatsStandard); err != nil {
+		return err
+	}
 	// Each --watch iteration performs the full setup+fetch+render cycle so a
 	// fresh service (and cache) is used every time.
 	return runner.Watch(cmd, func() error { return listNodegroupsOnce(ctx, cmd) })
@@ -70,10 +73,9 @@ func listNodegroupsOnce(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	format := strings.ToLower(cmd.String("format"))
-	if format == "table" || format == "plain" || format == "" {
-		items = sortNodegroupSummaries(items, cmd.String("sort"), cmd.Bool("desc"))
-	}
+	// Sort before encoding so --sort/--desc apply to every output format, not
+	// just table/plain — matching cluster list and keeping JSON/YAML scriptable. (REF-49)
+	items = sortNodegroupSummaries(items, cmd.String("sort"), cmd.Bool("desc"))
 
 	payload := map[string]any{"cluster": clusterName, "nodegroups": items, "count": len(items)}
 	if handled, err := runner.EncodeStdout(cmd.String("format"), payload); handled {
@@ -83,6 +85,9 @@ func listNodegroupsOnce(ctx context.Context, cmd *cli.Command) error {
 }
 
 func runDescribe(ctx context.Context, cmd *cli.Command) error {
+	if err := runner.ValidateFormat(cmd.String("format"), runner.FormatsStandard); err != nil {
+		return err
+	}
 	ctx, cancel, awsCfg, err := runner.SetupAWS(ctx, cmd)
 	if err != nil {
 		return err
@@ -257,6 +262,9 @@ func (f updateAMIFlags) machineHealthOutput() bool {
 }
 
 func runUpdateAMI(ctx context.Context, cmd *cli.Command) error {
+	if err := runner.ValidateFormat(cmd.String("format"), runner.FormatsTableJSON); err != nil {
+		return err
+	}
 	if cmd.Bool("all-clusters") {
 		return runFleetUpdate(ctx, cmd)
 	}

--- a/internal/commands/runner/runner.go
+++ b/internal/commands/runner/runner.go
@@ -237,10 +237,23 @@ func EncodeStdout(format string, payload any) (handled bool, err error) {
 		enc.SetIndent("", "  ")
 		return true, enc.Encode(payload)
 	case "yaml":
+		// yaml.v3 ignores `json` tags and lowercases Go field names, so a struct
+		// tagged only for JSON would serialize to YAML with keys that diverge
+		// from the documented camelCase (e.g. instancetype vs instanceType).
+		// Round-trip through JSON so the `json` tags drive both encoders and the
+		// -o yaml keys always match -o json. (REF-59)
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return true, err
+		}
+		var generic any
+		if err := json.Unmarshal(data, &generic); err != nil {
+			return true, err
+		}
 		enc := yaml.NewEncoder(os.Stdout)
 		enc.SetIndent(2)
 		defer func() { _ = enc.Close() }()
-		return true, enc.Encode(payload)
+		return true, enc.Encode(generic)
 	case "plain":
 		ui.SetPlainOutput(true)
 		color.NoColor = true
@@ -249,6 +262,37 @@ func EncodeStdout(format string, payload any) (handled bool, err error) {
 	default:
 		return false, nil
 	}
+}
+
+// Output-format presets for ValidateFormat. Commands pass the set they can
+// actually render so an unknown value fails loudly instead of silently
+// falling through to the table renderer.
+var (
+	// FormatsStandard is the common set for list/describe/encode commands.
+	FormatsStandard = []string{"table", "json", "yaml", "plain"}
+	// FormatsWithTree adds the cluster-list-only hierarchical tree renderer.
+	FormatsWithTree = []string{"table", "json", "yaml", "plain", "tree"}
+	// FormatsTableJSON is for commands that only emit a table or a JSON summary
+	// (e.g. nodegroup update's run summary).
+	FormatsTableJSON = []string{"table", "json"}
+)
+
+// ValidateFormat returns an error when format is not one of allowed. Matching
+// is case-insensitive and an empty value is treated as valid (callers default
+// it to "table"). Without this, runner.EncodeStdout returns handled=false for
+// an unrecognized format and every caller falls through to its table renderer,
+// so a typo like `-o jsom` silently prints a human table and exits 0. (REF-48)
+func ValidateFormat(format string, allowed []string) error {
+	f := strings.ToLower(strings.TrimSpace(format))
+	if f == "" {
+		return nil
+	}
+	for _, a := range allowed {
+		if f == a {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid output format %q (valid: %s)", format, strings.Join(allowed, ", "))
 }
 
 // watchIsTerminal reports whether stdout is an interactive terminal.

--- a/internal/commands/runner/runner_test.go
+++ b/internal/commands/runner/runner_test.go
@@ -2,11 +2,16 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/urfave/cli/v3"
+	"gopkg.in/yaml.v3"
 )
 
 // ── setupAWS context propagation ──────────────────────────────────────────────
@@ -230,5 +235,98 @@ func TestParseFilters(t *testing.T) {
 func TestParseFilters_Empty(t *testing.T) {
 	if got := ParseFilters(nil); len(got) != 0 {
 		t.Errorf("ParseFilters(nil) = %v, want empty map", got)
+	}
+}
+
+// ── ValidateFormat (REF-48) ─────────────────────────────────────────────────
+
+func TestValidateFormat(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		format  string
+		allowed []string
+		wantErr bool
+	}{
+		{"empty is valid (caller defaults to table)", "", FormatsStandard, false},
+		{"table valid", "table", FormatsStandard, false},
+		{"json valid", "json", FormatsStandard, false},
+		{"case-insensitive", "JSON", FormatsStandard, false},
+		{"surrounding space tolerated", "  yaml ", FormatsStandard, false},
+		{"tree only valid with tree set", "tree", FormatsWithTree, false},
+		{"tree rejected in standard set", "tree", FormatsStandard, true},
+		{"typo rejected", "jsom", FormatsStandard, true},
+		{"xml rejected", "xml", FormatsStandard, true},
+		{"yaml rejected for table/json-only", "yaml", FormatsTableJSON, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateFormat(tc.format, tc.allowed)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateFormat(%q) error = %v, wantErr %v", tc.format, err, tc.wantErr)
+			}
+			if err != nil && !strings.Contains(err.Error(), "valid:") {
+				t.Errorf("error %q should list valid formats", err)
+			}
+		})
+	}
+}
+
+// ── EncodeStdout YAML key parity (REF-59) ───────────────────────────────────
+
+// captureStdout redirects os.Stdout for the duration of fn and returns what was
+// written.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	return string(out)
+}
+
+// EncodeStdout's YAML output must use the same camelCase keys as its JSON output
+// (driven by the `json` tags), not yaml.v3's lowercased Go field names.
+func TestEncodeStdout_YAMLKeysMatchJSON(t *testing.T) {
+	type item struct {
+		InstanceType string `json:"instanceType"`
+		DesiredSize  int    `json:"desiredSize"`
+		ReadyNodes   int    `json:"readyNodes"`
+	}
+	payload := map[string]any{"nodegroups": []item{{"m5.large", 3, 2}}, "count": 1}
+
+	yamlOut := captureStdout(t, func() {
+		if handled, err := EncodeStdout("yaml", payload); !handled || err != nil {
+			t.Fatalf("EncodeStdout(yaml) handled=%v err=%v", handled, err)
+		}
+	})
+
+	for _, key := range []string{"instanceType:", "desiredSize:", "readyNodes:"} {
+		if !strings.Contains(yamlOut, key) {
+			t.Errorf("YAML output missing camelCase key %q\n%s", key, yamlOut)
+		}
+	}
+	if strings.Contains(yamlOut, "instancetype:") {
+		t.Errorf("YAML output still has lowercased key 'instancetype'\n%s", yamlOut)
+	}
+
+	// And the YAML must round-trip to the same structure as the JSON encoding.
+	var fromYAML, fromJSON any
+	if err := yaml.Unmarshal([]byte(yamlOut), &fromYAML); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	jsonBytes, _ := json.Marshal(payload)
+	if err := json.Unmarshal(jsonBytes, &fromJSON); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	gotJSON, _ := json.Marshal(fromYAML)
+	wantJSON, _ := json.Marshal(fromJSON)
+	if string(gotJSON) != string(wantJSON) {
+		t.Errorf("YAML structure diverges from JSON:\n got=%s\nwant=%s", gotJSON, wantJSON)
 	}
 }

--- a/internal/commands/statuscmd/actions.go
+++ b/internal/commands/statuscmd/actions.go
@@ -20,6 +20,9 @@ import (
 )
 
 func runStatus(ctx context.Context, cmd *cli.Command) error {
+	if err := runner.ValidateFormat(cmd.String("format"), runner.FormatsStandard); err != nil {
+		return err
+	}
 	ctx, cancel, awsCfg, err := runner.SetupAWS(ctx, cmd)
 	if err != nil {
 		return err

--- a/internal/services/cluster/filter_test.go
+++ b/internal/services/cluster/filter_test.go
@@ -1,0 +1,47 @@
+package cluster
+
+import "testing"
+
+// filterSummaries applies the status/version filters that need each cluster's
+// fetched summary (REF-1).
+func TestFilterSummaries(t *testing.T) {
+	summaries := []ClusterSummary{
+		{Name: "prod-a", Status: "ACTIVE", Version: "1.32"},
+		{Name: "prod-b", Status: "CREATING", Version: "1.31"},
+		{Name: "prod-c", Status: "ACTIVE", Version: "1.31"},
+	}
+
+	for _, tc := range []struct {
+		name    string
+		filters map[string]string
+		want    []string
+	}{
+		{"no filters returns all", nil, []string{"prod-a", "prod-b", "prod-c"}},
+		{"name-only is a no-op here", map[string]string{"name": "prod"}, []string{"prod-a", "prod-b", "prod-c"}},
+		{"status filter", map[string]string{"status": "ACTIVE"}, []string{"prod-a", "prod-c"}},
+		{"status case-insensitive", map[string]string{"status": "active"}, []string{"prod-a", "prod-c"}},
+		{"version filter", map[string]string{"version": "1.31"}, []string{"prod-b", "prod-c"}},
+		{"status AND version", map[string]string{"status": "ACTIVE", "version": "1.31"}, []string{"prod-c"}},
+		{"no match", map[string]string{"status": "DELETING"}, []string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterSummaries(summaries, tc.filters)
+			if len(got) != len(tc.want) {
+				t.Fatalf("filterSummaries returned %d (%v), want %d (%v)", len(got), names(got), len(tc.want), tc.want)
+			}
+			for i, n := range tc.want {
+				if got[i].Name != n {
+					t.Errorf("result[%d] = %q, want %q", i, got[i].Name, n)
+				}
+			}
+		})
+	}
+}
+
+func names(s []ClusterSummary) []string {
+	out := make([]string, len(s))
+	for i, c := range s {
+		out[i] = c.Name
+	}
+	return out
+}

--- a/internal/services/cluster/helpers.go
+++ b/internal/services/cluster/helpers.go
@@ -156,13 +156,36 @@ func (s *ServiceImpl) getClusterNodegroups(ctx context.Context, clusterName stri
 }
 
 // shouldSkipCluster applies filters to determine if a cluster should be skipped.
-// Only the "name" filter is supported at the list stage; other filter keys are
-// applied later by callers that have already fetched cluster details.
+// Only the "name" filter is supported at the list stage; "status"/"version" need
+// the per-cluster summary and are applied afterwards by filterSummaries.
 func (s *ServiceImpl) shouldSkipCluster(clusterName string, filters map[string]string) bool {
 	if pattern, ok := filters["name"]; ok && !strings.Contains(clusterName, pattern) {
 		return true
 	}
 	return false
+}
+
+// filterSummaries applies the "status"/"version" filters that can only be
+// evaluated once each cluster's summary (and thus its Status/Version) has been
+// fetched. Matching is case-insensitive and exact. The "name" filter is already
+// applied at the list stage by shouldSkipCluster. (REF-1)
+func filterSummaries(summaries []ClusterSummary, filters map[string]string) []ClusterSummary {
+	status, hasStatus := filters["status"]
+	version, hasVersion := filters["version"]
+	if !hasStatus && !hasVersion {
+		return summaries
+	}
+	out := make([]ClusterSummary, 0, len(summaries))
+	for _, s := range summaries {
+		if hasStatus && !strings.EqualFold(s.Status, status) {
+			continue
+		}
+		if hasVersion && !strings.EqualFold(s.Version, version) {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
 }
 
 // getClusterSummary creates a summary for a single cluster. On describe

--- a/internal/services/cluster/service.go
+++ b/internal/services/cluster/service.go
@@ -265,6 +265,10 @@ func (s *ServiceImpl) List(ctx context.Context, options ListOptions) ([]ClusterS
 		}
 	}
 
+	// Apply status/version filters now that each summary carries those fields
+	// (the name filter was already applied at the list stage).
+	summaries = filterSummaries(summaries, options.Filters)
+
 	// Cache the result
 	s.cache.Set(cacheKey, summaries, defaultCacheTTLList)
 

--- a/main.go
+++ b/main.go
@@ -83,6 +83,21 @@ func newApp() *cli.Command {
 				Usage:   "Disable colored output (NO_COLOR env is also honored)",
 				Sources: cli.EnvVars("NO_COLOR"),
 			},
+			// Global AWS overrides. urfave/cli v3 propagates parent flags to every
+			// subcommand, so awsconfig.Load sees these on all AWS-touching commands
+			// (nodegroup/addon/cluster describe, …), honoring the documented
+			// "flags override the active context for this invocation" precedence.
+			// No -r/-p aliases: -p already means --poll-interval/--parallel and the
+			// list commands keep their own repeatable -r/--region slice, which
+			// shadows this string flag cleanly. (REF-47)
+			&cli.StringFlag{
+				Name:  "profile",
+				Usage: "AWS shared-config profile (overrides the active context for this invocation)",
+			},
+			&cli.StringFlag{
+				Name:  "region",
+				Usage: "AWS region (overrides the active context for this invocation)",
+			},
 		},
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
 			if cmd.Bool("no-color") {

--- a/main_test.go
+++ b/main_test.go
@@ -218,7 +218,8 @@ func TestNewAppAndRun(t *testing.T) {
 	if app.Name != "refresh" {
 		t.Fatalf("app name = %q", app.Name)
 	}
-	if len(app.Commands) == 0 || len(app.Flags) != 3 {
+	// Global flags: --timeout, --max-concurrency, --no-color, --profile, --region.
+	if len(app.Commands) == 0 || len(app.Flags) != 5 {
 		t.Fatalf("unexpected app shape: commands=%d flags=%d", len(app.Commands), len(app.Flags))
 	}
 	if !app.EnableShellCompletion {
@@ -246,6 +247,42 @@ func TestNewAppAndRun(t *testing.T) {
 	if err := run(context.Background(), []string{"refresh", "--timeout", "not-a-duration", "version"}, &out, &errOut); err == nil {
 		t.Fatal("expected invalid flag error")
 	}
+}
+
+// REF-47: --profile/--region are global flags, so they're accepted on every
+// AWS-touching subcommand (previously "flag provided but not defined"). Use
+// --help so the action short-circuits before any AWS call.
+func TestGlobalProfileRegionFlagsPropagate(t *testing.T) {
+	app := newApp()
+	var names []string
+	for _, f := range app.Flags {
+		names = append(names, f.Names()...)
+	}
+	for _, want := range []string{"profile", "region"} {
+		if !containsString(names, want) {
+			t.Fatalf("global flag %q not registered (have %v)", want, names)
+		}
+	}
+
+	for _, argv := range [][]string{
+		{"refresh", "nodegroup", "describe", "--region", "us-west-2", "--help"},
+		{"refresh", "addon", "list", "--profile", "prod", "--help"},
+		{"refresh", "cluster", "describe", "--profile", "prod", "--region", "eu-west-1", "--help"},
+	} {
+		var out, errOut bytes.Buffer
+		if err := run(context.Background(), argv, &out, &errOut); err != nil {
+			t.Errorf("run %v = %v, want nil (global flags should be accepted)", argv[1:], err)
+		}
+	}
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
 }
 
 func TestMainErrorPath(t *testing.T) {


### PR DESCRIPTION
**Batch A** of the Sonnet 4.6 backlog — five independent CLI-correctness fixes, all in one PR since they share the command/runner/output surface.

## Fixes

| Issue | Fix |
|---|---|
| **REF-1** (High) | `cluster list --filter status=ACTIVE` / `version=1.32` now actually filter (applied after each cluster summary is built, in both single- and multi-region paths). Unsupported filter keys (e.g. `--filter color=blue`) now error instead of silently returning everything. |
| **REF-47** | `--region`/`--profile` are now **global** flags. urfave/cli v3 propagates parent flags to every subcommand, so `awsconfig.Load` sees them on all AWS-touching commands (`nodegroup *`, `addon *`, `cluster describe`, …) — previously rejected with "flag provided but not defined". No `-r`/`-p` aliases (avoids clashing with `-p`=poll-interval/parallel; the list commands keep their repeatable `-r`/`--region` slice, which shadows the global string flag cleanly). |
| **REF-48** | `runner.ValidateFormat` rejects unknown `-o`/`--format` values up front with a message listing the valid set, instead of silently rendering a table and exiting 0 (data corruption for scripts expecting JSON). Wired into cluster/nodegroup/addon/status list+describe, `cluster upgrade(-check)`, and `nodegroup update`. |
| **REF-49** | `nodegroup list` sorts before `EncodeStdout` so `--sort`/`--desc` apply to JSON/YAML too, matching `cluster list`. |
| **REF-59** (High) | `EncodeStdout`'s YAML branch round-trips through JSON so the `json` tags drive both encoders. `-o yaml` keys now match `-o json` (camelCase like `instanceType`) instead of yaml.v3's lowercased `instancetype`. |

## Verification

```
$ refresh cluster list -o jsom
Error: invalid output format "jsom" (valid: table, json, yaml, plain, tree)   # exit 1
$ refresh cluster list --filter color=blue
Error: unsupported filter key(s): color (supported: name, status, version)    # exit 1
$ refresh nodegroup describe --profile foo --region us-west-2 --help           # exit 0 (accepted)
```

Tests added: `ValidateFormat` table, YAML↔JSON key parity, `filterSummaries`, `validateClusterFilters`, global-flag propagation. Full gate green: `go build`, `go test -race ./...`, `go vet`, `golangci-lint` (0 issues), `gofmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)