### PR TITLE
fix(ui): output/formatting data-integrity — TSV escaping, zero-time, display-cell widths (REF-62, 65, 66, 67)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/aws/smithy-go v1.23.0
 	github.com/fatih/color v1.18.0
 	github.com/mattn/go-isatty v0.0.20
+	github.com/mattn/go-runewidth v0.0.16
 	github.com/pterm/pterm v0.12.81
 	github.com/urfave/cli-docs/v3 v3.1.0
 	github.com/urfave/cli/v3 v3.9.1
@@ -58,7 +59,6 @@ require (
 	github.com/lithammer/fuzzysearch v1.1.8 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/internal/commands/clusterview/clusterview_test.go
+++ b/internal/commands/clusterview/clusterview_test.go
@@ -107,6 +107,29 @@ func TestSortClusterSummaries_UnknownKeyFallsBackToName(t *testing.T) {
 
 // ── formatStatus ─────────────────────────────────────────────────────────────
 
+// REF-66: formatAge must read sensibly for sub-minute and clamp negatives
+// (clock skew) instead of printing "0 minutes" / "-N minutes".
+func TestFormatAge(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{"days", 50 * time.Hour, "2 days"},
+		{"hours", 3 * time.Hour, "3 hours"},
+		{"minutes", 5 * time.Minute, "5 minutes"},
+		{"sub-minute", 30 * time.Second, "just now"},
+		{"zero", 0, "just now"},
+		{"negative clock-skew", -3 * time.Minute, "just now"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatAge(tc.d); got != tc.want {
+				t.Errorf("formatAge(%v) = %q, want %q", tc.d, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestFormatStatus(t *testing.T) {
 	cases := map[string]string{
 		"ACTIVE":   "Active",

--- a/internal/commands/clusterview/color.go
+++ b/internal/commands/clusterview/color.go
@@ -170,11 +170,19 @@ func truncateEndpoint(endpoint string) string {
 }
 
 func formatAge(d time.Duration) string {
+	// Clamp negatives (clock skew / a future timestamp) so we never render a
+	// nonsensical "-3 minutes".
+	if d < 0 {
+		d = 0
+	}
 	if days := int(d.Hours() / 24); days > 0 {
 		return fmt.Sprintf("%d days", days)
 	}
 	if hours := int(d.Hours()); hours > 0 {
 		return fmt.Sprintf("%d hours", hours)
 	}
-	return fmt.Sprintf("%d minutes", int(d.Minutes()))
+	if mins := int(d.Minutes()); mins > 0 {
+		return fmt.Sprintf("%d minutes", mins)
+	}
+	return "just now"
 }

--- a/internal/commands/clusterview/detail.go
+++ b/internal/commands/clusterview/detail.go
@@ -64,8 +64,13 @@ func OutputClusterDetailsTable(details *clustersvc.ClusterDetails, elapsed time.
 	}
 	tbl.Add("Encryption", encStatus)
 	tbl.AddBool("Deletion Protection", details.Security.DeletionProtection)
-	tbl.Add("Created", details.CreatedAt.Format("2006-01-02 15:04:05 UTC"))
-	tbl.Add("Age", formatAge(time.Since(details.CreatedAt)))
+	if details.CreatedAt.IsZero() {
+		tbl.Add("Created", "unknown")
+		tbl.Add("Age", "unknown")
+	} else {
+		tbl.Add("Created", details.CreatedAt.Format("2006-01-02 15:04:05 UTC"))
+		tbl.Add("Age", formatAge(time.Since(details.CreatedAt)))
+	}
 	tbl.Render()
 
 	if len(details.Addons) > 0 {

--- a/internal/ui/ansi.go
+++ b/internal/ui/ansi.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/mattn/go-runewidth"
 )
 
 // This file is the single home for ANSI-aware string measurement, padding,
@@ -28,8 +29,12 @@ type Column struct {
 	Align Alignment
 }
 
-// VisibleWidth returns the printable width of a string, excluding ANSI escape
-// codes. Hardened against malformed sequences with a bounded escape length.
+// VisibleWidth returns the printable terminal width of a string, excluding ANSI
+// escape codes. Width is measured in display cells, not runes, so CJK
+// ideographs and emoji (2 columns) and zero-width/combining marks are counted
+// correctly — otherwise PadANSI/TruncateANSI and the table column math drift on
+// non-ASCII cells. Hardened against malformed sequences with a bounded escape
+// length.
 func VisibleWidth(s string) int {
 	count := 0
 	inEscape := false
@@ -57,7 +62,7 @@ func VisibleWidth(s string) int {
 			}
 			continue
 		}
-		count++
+		count += runewidth.RuneWidth(r)
 	}
 	return count
 }
@@ -124,12 +129,12 @@ func TruncateANSI(s string, width int) string {
 			}
 			continue
 		}
-		if visibleCount < target {
-			out.WriteRune(r)
-			visibleCount++
-		} else {
+		w := runewidth.RuneWidth(r)
+		if visibleCount+w > target {
 			break
 		}
+		out.WriteRune(r)
+		visibleCount += w
 	}
 	if sawEscape {
 		// The cut may have dropped the original trailing reset.
@@ -171,6 +176,19 @@ func StripANSI(s string) string {
 		out.WriteRune(r)
 	}
 	return out.String()
+}
+
+// PlainCell prepares a value for tab-separated `-o plain` output: it strips
+// ANSI codes and replaces any embedded tab/newline/carriage-return with a
+// single space. Without this, a cell containing a literal tab or newline (AWS
+// tags, multi-line status/error strings) would split one logical row across
+// columns or physical lines, breaking `awk -F'\t'` / `cut`. (REF-65)
+func PlainCell(s string) string {
+	s = StripANSI(s)
+	if strings.ContainsAny(s, "\t\n\r") {
+		s = strings.NewReplacer("\t", " ", "\n", " ", "\r", " ").Replace(s)
+	}
+	return s
 }
 
 // plainOutput, when enabled, makes table renderers emit uncolored,

--- a/internal/ui/ansi_test.go
+++ b/internal/ui/ansi_test.go
@@ -16,6 +16,51 @@ func TestVisibleWidthAndPadANSI(t *testing.T) {
 	}
 }
 
+// REF-67: width must be measured in display cells, not runes — CJK ideographs
+// and emoji occupy 2 columns.
+func TestVisibleWidthWideRunes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		s    string
+		want int
+	}{
+		{"ascii", "abc", 3},
+		{"cjk", "世界", 4},
+		{"emoji", "🚀", 2},
+		{"mixed", "a世b", 4},
+		{"colored cjk", "\x1b[32m世\x1b[0m", 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := VisibleWidth(tc.s); got != tc.want {
+				t.Errorf("VisibleWidth(%q) = %d, want %d", tc.s, got, tc.want)
+			}
+		})
+	}
+	if got := VisibleWidth(PadANSI("世", 6, AlignLeft)); got != 6 {
+		t.Errorf("PadANSI wide cell: visible width = %d, want 6", got)
+	}
+}
+
+// REF-65: PlainCell must strip ANSI and neutralize embedded tab/newline/CR so a
+// single logical cell stays a single TSV field.
+func TestPlainCell(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"plain", "plain"},
+		{"\x1b[32mPASS\x1b[0m", "PASS"},
+		{"a\tb", "a b"},
+		{"line1\nline2", "line1 line2"},
+		{"a\r\nb", "a  b"},
+		{"k=v\tx=y", "k=v x=y"},
+	} {
+		if got := PlainCell(tc.in); got != tc.want {
+			t.Errorf("PlainCell(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+		if strings.ContainsAny(PlainCell(tc.in), "\t\n\r") {
+			t.Errorf("PlainCell(%q) still contains a TSV-breaking char", tc.in)
+		}
+	}
+}
+
 func TestVisibleWidthMalformedEscape(t *testing.T) {
 	// A runaway escape sequence must not swallow the rest of the string.
 	malformed := "\x1b[" + strings.Repeat("9", 40) + "hello"

--- a/internal/ui/dynamic_table.go
+++ b/internal/ui/dynamic_table.go
@@ -68,7 +68,7 @@ func (dt *DynamicTable) Render() {
 
 	if plainOutput {
 		for _, row := range dt.rows {
-			Outf("%s\t%s\n", StripANSI(row.Key), StripANSI(row.Value))
+			Outf("%s\t%s\n", PlainCell(row.Key), PlainCell(row.Value))
 		}
 		return
 	}

--- a/internal/ui/ptable.go
+++ b/internal/ui/ptable.go
@@ -120,7 +120,7 @@ func (t *PTable) renderPlain() {
 	for _, row := range t.rows {
 		cells := make([]string, len(row))
 		for i, cell := range row {
-			cells[i] = StripANSI(cell)
+			cells[i] = PlainCell(cell)
 		}
 		Outln(strings.Join(cells, "\t"))
 	}


### PR DESCRIPTION
**Batch D** of the Sonnet 4.6 backlog — epic **REF-62** (output/formatting data-integrity). Three independent correctness fixes in `internal/ui` + `clusterview`.

| Issue | Fix |
|---|---|
| **REF-65** | `-o plain` (TSV) now neutralizes embedded tab/newline/CR per cell via a new `ui.PlainCell` helper (after `StripANSI`), so a value containing whitespace (AWS tags, multi-line status/error strings) stays **one** well-formed TSV row for `awk -F'\t'` / `cut`. Applied in both plain renderers. |
| **REF-66** | `clusterview` detail guards `CreatedAt.IsZero()` → renders `unknown` instead of `0001-01-01` / a ~739000-day age; `formatAge` gains a sub-minute (`just now`) branch and clamps negative (clock-skew) durations. |
| **REF-67** | `VisibleWidth` (and `TruncateANSI`'s cut) measure **display cells** via `github.com/mattn/go-runewidth` instead of counting runes, so CJK/emoji (2 columns) and combining marks no longer drift table borders / right-aligned columns. `runewidth` promoted to a direct dependency. |

## Tests
`VisibleWidth` wide-rune cases (CJK/emoji/mixed/colored), `PlainCell` escaping, `formatAge` sub-minute/negative. Full gate green: `go build`, `gofmt`, `go vet`, `go test -race ./...`, `golangci-lint` (0 issues).

Branched off post-trim `main` — no conflicts with the merged A/B/C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)