### PR TITLE
test: coverage on health/command layers, offline benchmarks, integration scaffold (REF-5, 6, 7)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -83,6 +83,16 @@ tasks:
       - go tool cover -html=coverage.out -o coverage.html
       - echo "Coverage report generated at coverage.html"
 
+  test:integration:
+    desc: Run opt-in integration tests (needs REFRESH_INTEGRATION=1 + AWS creds)
+    cmds:
+      - go test -tags integration -run Integration ./internal/integration/... -v
+
+  bench:
+    desc: Run service-layer benchmarks (offline, mock-driven)
+    cmds:
+      - go test -bench=. -benchmem -run=^$ ./internal/services/...
+
   # Dependency management
   deps:
     desc: Download and tidy dependencies

--- a/internal/commands/addon/formatters_detail_test.go
+++ b/internal/commands/addon/formatters_detail_test.go
@@ -1,0 +1,97 @@
+package addon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dantech2000/refresh/internal/services/addons"
+)
+
+func TestOutputAddonDetailsTable_FullDetails(t *testing.T) {
+	d := &addons.AddonDetails{
+		Name:               "vpc-cni",
+		Version:            "v1.18.3",
+		Status:             "ACTIVE",
+		Health:             "PASS",
+		ARN:                "arn:aws:eks:us-east-1:123:addon/x",
+		ServiceAccountRole: "arn:aws:iam::123:role/cni",
+		Issues: []addons.AddonIssue{
+			{Code: "AccessDenied", Message: "missing permission"},
+		},
+		Configuration: map[string]any{"env": map[string]any{"ENABLE_PREFIX_DELEGATION": "true"}},
+	}
+	out, err := captureStdout(t, func() error { return outputAddonDetailsTable("prod", d) })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"vpc-cni", "v1.18.3", "arn:aws:eks", "Service Account Role", "Issues:", "AccessDenied", "Configuration:", "ENABLE_PREFIX_DELEGATION"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("details output missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestOutputAddonDetailsTable_Minimal(t *testing.T) {
+	d := &addons.AddonDetails{Name: "coredns", Version: "v1.10", Status: "ACTIVE"}
+	out, err := captureStdout(t, func() error { return outputAddonDetailsTable("prod", d) })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "coredns") {
+		t.Errorf("expected addon name, got: %q", out)
+	}
+	// No optional sections should appear.
+	if strings.Contains(out, "Issues:") || strings.Contains(out, "Configuration:") {
+		t.Errorf("minimal details should omit empty sections, got:\n%s", out)
+	}
+}
+
+func TestOutputUpdateAllResults_Empty(t *testing.T) {
+	// The "No addons to update" notice goes via color.Yellow (color.Output),
+	// which this helper doesn't capture; assert on the header (ui.Outf → stdout)
+	// and that the call returns cleanly.
+	out, err := captureStdout(t, func() error { return outputUpdateAllResults("prod", nil, false) })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Addon Updates for cluster: prod") {
+		t.Errorf("expected the cluster header, got: %q", out)
+	}
+}
+
+func TestOutputUpdateAllResults_DryRunMode(t *testing.T) {
+	results := []addons.AddonUpdateResult{
+		{AddonName: "vpc-cni", PreviousVersion: "v1", NewVersion: "v2", Status: "DRY_RUN"},
+	}
+	out, err := captureStdout(t, func() error { return outputUpdateAllResults("prod", results, true) })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "DRY RUN") {
+		t.Errorf("dry-run header expected, got: %q", out)
+	}
+	// Dry run suppresses the success/fail summary line.
+	if strings.Contains(out, "Summary:") {
+		t.Errorf("dry run should not print a Summary line, got: %q", out)
+	}
+}
+
+func TestOutputUpdateAllResults_SummaryCounts(t *testing.T) {
+	results := []addons.AddonUpdateResult{
+		{AddonName: "a", PreviousVersion: "v1", NewVersion: "v2", Status: "COMPLETED"},
+		{AddonName: "b", PreviousVersion: "v1", NewVersion: "v1", Status: "UPDATE_FAILED"},
+		{AddonName: "c", PreviousVersion: "v1", NewVersion: "v2", Status: "COMPLETED_WITH_ISSUES"},
+	}
+	out, err := captureStdout(t, func() error { return outputUpdateAllResults("prod", results, false) })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Summary:") {
+		t.Errorf("expected a summary line, got: %q", out)
+	}
+	for _, want := range []string{"successful", "with issues", "failed"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summary missing %q; got: %q", want, out)
+		}
+	}
+}

--- a/internal/commands/cluster/render_test.go
+++ b/internal/commands/cluster/render_test.go
@@ -1,0 +1,158 @@
+package cluster
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/fatih/color"
+
+	"github.com/dantech2000/refresh/internal/services/upgrade"
+)
+
+// captureStdout redirects both os.Stdout and color.Output so colorized
+// renderer output is captured.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	originalStdout := os.Stdout
+	originalColor := color.Output
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	color.Output = w
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+		color.Output = originalColor
+	})
+	fn()
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
+}
+
+// ── Command structure ──────────────────────────────────────────────────────
+
+func TestClusterCommand_HasUpgradeSubcommands(t *testing.T) {
+	cmd := Command()
+	has := func(name string) bool {
+		for _, sc := range cmd.Commands {
+			if sc.Name == name {
+				return true
+			}
+			for _, a := range sc.Aliases {
+				if a == name {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	for _, name := range []string{"upgrade", "upgrade-check"} {
+		if !has(name) {
+			t.Errorf("cluster: missing subcommand %q", name)
+		}
+	}
+}
+
+func TestClusterListCommand_HasFormatFlag(t *testing.T) {
+	lc := listCommand()
+	if lc.Name != "list" {
+		t.Fatalf("expected name 'list', got %q", lc.Name)
+	}
+	found := false
+	for _, f := range lc.Flags {
+		for _, n := range f.Names() {
+			if n == "format" || n == "o" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("list command should expose a -o/--format flag")
+	}
+}
+
+// ── stepMarkerAndNote ──────────────────────────────────────────────────────
+
+func TestStepMarkerAndNote(t *testing.T) {
+	cases := []struct {
+		status     upgrade.StepStatus
+		wantMarker string
+	}{
+		{upgrade.StatusCompleted, "done"},
+		{upgrade.StatusBlocked, "BLOCKED"},
+		{upgrade.StatusManual, "manual"},
+		{upgrade.StatusPending, "pending"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.status), func(t *testing.T) {
+			marker, note := stepMarkerAndNote(upgrade.Step{Status: tc.status, Reason: "because"})
+			if !strings.Contains(marker, tc.wantMarker) {
+				t.Errorf("marker = %q, want it to contain %q", marker, tc.wantMarker)
+			}
+			if note != "because" {
+				t.Errorf("note = %q, want the step Reason", note)
+			}
+		})
+	}
+}
+
+// ── renderPlan ─────────────────────────────────────────────────────────────
+
+func TestRenderPlan_ShowsPathHopsAndWarnings(t *testing.T) {
+	plan := &upgrade.Plan{
+		ClusterName:    "prod",
+		CurrentVersion: "1.30",
+		TargetVersion:  "1.32",
+		Warnings:       []string{"custom AMI nodegroups will be skipped"},
+		Hops: []upgrade.Hop{
+			{
+				From: "1.30", To: "1.31",
+				Steps: []upgrade.Step{
+					{Type: upgrade.StepReadiness, Description: "readiness check", Status: upgrade.StatusBlocked, Reason: "2 blocking insights"},
+					{Type: upgrade.StepControlPlane, Description: "control plane → 1.31", Status: upgrade.StatusPending},
+				},
+			},
+			{
+				From: "1.31", To: "1.32",
+				Steps: []upgrade.Step{
+					{Type: upgrade.StepControlPlane, Description: "control plane → 1.32", Status: upgrade.StatusPending},
+				},
+			},
+		},
+	}
+	out := captureStdout(t, func() { renderPlan(plan) })
+	for _, want := range []string{"prod", "1.30 → 1.31 → 1.32", "warning", "Hop 1.30 → 1.31", "control plane → 1.31", "2 blocking insights"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("renderPlan output missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// ── renderReport ───────────────────────────────────────────────────────────
+
+func TestRenderReport_Nil(t *testing.T) {
+	out := captureStdout(t, func() { renderReport(nil) })
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("nil report should print nothing, got: %q", out)
+	}
+}
+
+func TestRenderReport_CompletedFailedRemaining(t *testing.T) {
+	report := &upgrade.Report{
+		Completed: []string{"control plane → 1.31"},
+		FailedAt:  "addon coredns update",
+		Remaining: []string{"nodegroup workers"},
+	}
+	out := captureStdout(t, func() { renderReport(report) })
+	for _, want := range []string{"completed:", "control plane → 1.31", "failed at:", "addon coredns update", "remaining:", "nodegroup workers"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("renderReport output missing %q; got:\n%s", want, out)
+		}
+	}
+}

--- a/internal/commands/nodegroup/output_test.go
+++ b/internal/commands/nodegroup/output_test.go
@@ -1,0 +1,250 @@
+package nodegroup
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/dantech2000/refresh/internal/health"
+	nodegroupsvc "github.com/dantech2000/refresh/internal/services/nodegroup"
+	"github.com/dantech2000/refresh/internal/types"
+)
+
+// captureStdout is defined in health_decision_test.go (redirects both
+// os.Stdout and color.Output).
+
+// ──────────────────────────────────────────────────────────────────────────────
+// outputNodegroupsTable
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestOutputNodegroupsTable_Empty(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := outputNodegroupsTable("my-cluster", nil, time.Second); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "No nodegroups found") {
+		t.Errorf("empty output should note no nodegroups, got: %q", out)
+	}
+}
+
+func TestOutputNodegroupsTable_WithRows(t *testing.T) {
+	items := []nodegroupsvc.NodegroupSummary{
+		{Name: "workers", Status: "ACTIVE", InstanceType: "m5.large", AMIStatus: types.AMILatest, ReadyNodes: 3, DesiredSize: 3},
+		{Name: "spot", Status: "UPDATING", InstanceType: "t3.medium", AMIStatus: types.AMIOutdated, ReadyNodes: 1, DesiredSize: 2},
+	}
+	// pterm renders the table body to its own (TTY-detecting) writer, which a
+	// captured pipe suppresses; assert on the reliably-captured intro line and
+	// that the call itself succeeds for a non-empty set.
+	out := captureStdout(t, func() {
+		if err := outputNodegroupsTable("my-cluster", items, 2*time.Second); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "Nodegroups for cluster: my-cluster") {
+		t.Errorf("table output missing cluster header; got:\n%s", out)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// outputNodegroupDetailsTable
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestOutputNodegroupDetailsTable(t *testing.T) {
+	details := &nodegroupsvc.NodegroupDetails{
+		Name:         "workers",
+		Status:       "ACTIVE",
+		InstanceType: "m5.large",
+		AmiType:      "AL2_x86_64",
+		CapacityType: "ON_DEMAND",
+		CurrentAMI:   "ami-aaa",
+		LatestAMI:    "ami-bbb",
+		AMIStatus:    types.AMIOutdated,
+		Scaling:      nodegroupsvc.ScalingConfig{DesiredSize: 3, MinSize: 1, MaxSize: 5},
+		Workloads:    nodegroupsvc.WorkloadInfo{TotalPods: 10, CriticalPods: 2, PodDisruption: "2 PDBs"},
+	}
+	out := captureStdout(t, func() {
+		if err := outputNodegroupDetailsTable(details, time.Second); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+	for _, want := range []string{"workers", "m5.large", "ami-aaa", "ami-bbb", "Workloads", "2 PDBs"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("details output missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// printScaleDownPDBImpact
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestPrintScaleDownPDBImpact_None(t *testing.T) {
+	out := captureStdout(t, func() { printScaleDownPDBImpact(nil) })
+	if !strings.Contains(out, "none found") {
+		t.Errorf("expected a 'none found' message, got: %q", out)
+	}
+}
+
+func TestPrintScaleDownPDBImpact_AllHealthy(t *testing.T) {
+	pdbs := []health.PDBInfo{
+		{Namespace: "app", Name: "web", DisruptionsAllowed: 2},
+		{Namespace: "app", Name: "api", DisruptionsAllowed: 1},
+	}
+	out := captureStdout(t, func() { printScaleDownPDBImpact(pdbs) })
+	if !strings.Contains(out, "none should block") {
+		t.Errorf("all-healthy PDBs should report nothing blocks, got: %q", out)
+	}
+}
+
+func TestPrintScaleDownPDBImpact_AtRisk(t *testing.T) {
+	pdbs := []health.PDBInfo{
+		{Namespace: "app", Name: "web", DisruptionsAllowed: 0, CurrentHealthy: 1, DesiredHealthy: 1},
+		{Namespace: "app", Name: "api", DisruptionsAllowed: 3},
+	}
+	out := captureStdout(t, func() { printScaleDownPDBImpact(pdbs) })
+	if !strings.Contains(out, "at risk") {
+		t.Errorf("at-risk PDBs should be flagged, got: %q", out)
+	}
+	if !strings.Contains(out, "app/web") {
+		t.Errorf("the at-risk PDB should be named, got: %q", out)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// printVerification + PostRollVerification.OK
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestPostRollVerification_OK(t *testing.T) {
+	if !(PostRollVerification{Checks: []string{"ok"}}).OK() {
+		t.Error("no issues should be OK")
+	}
+	if (PostRollVerification{Issues: []string{"boom"}}).OK() {
+		t.Error("issues present should not be OK")
+	}
+}
+
+func TestPrintVerification_Passed(t *testing.T) {
+	v := PostRollVerification{Checks: []string{"nodegroup workers is ACTIVE", "no new Pending pods"}}
+	out := captureStdout(t, func() { printVerification(v) })
+	if !strings.Contains(out, "passed") {
+		t.Errorf("expected a passed banner, got: %q", out)
+	}
+	if !strings.Contains(out, "no new Pending pods") {
+		t.Errorf("expected checks listed, got: %q", out)
+	}
+}
+
+func TestPrintVerification_Issues(t *testing.T) {
+	v := PostRollVerification{
+		Checks: []string{"nodegroup workers is ACTIVE"},
+		Issues: []string{"2 pod(s) newly Pending after roll"},
+	}
+	out := captureStdout(t, func() { printVerification(v) })
+	if !strings.Contains(out, "found issues") {
+		t.Errorf("expected an issues banner, got: %q", out)
+	}
+	if !strings.Contains(out, "newly Pending") {
+		t.Errorf("expected the issue listed, got: %q", out)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// printChangelog + orDash
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestOrDash(t *testing.T) {
+	cases := map[string]string{"": "-", "   ": "-", "v1": "v1"}
+	for in, want := range cases {
+		if got := orDash(in); got != want {
+			t.Errorf("orDash(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestPrintChangelog_Degraded(t *testing.T) {
+	cl := amiChangelog{Current: "ami-1", Target: "ami-2", Degraded: true, Reason: "could not parse release dates"}
+	out := captureStdout(t, func() { printChangelog(cl, false) })
+	if !strings.Contains(out, "release notes unavailable") {
+		t.Errorf("degraded changelog should say notes unavailable, got: %q", out)
+	}
+}
+
+func TestPrintChangelog_TruncatesWithoutFull(t *testing.T) {
+	cl := amiChangelog{
+		Current: "ami-1",
+		Target:  "ami-9",
+		Behind:  4,
+		Notes: []releaseNote{
+			{Tag: "v1", Highlights: []string{"a"}},
+			{Tag: "v2"},
+			{Tag: "v3"},
+			{Tag: "v4"},
+		},
+	}
+	out := captureStdout(t, func() { printChangelog(cl, false) })
+	if !strings.Contains(out, "release(s) behind") {
+		t.Errorf("expected behind count, got: %q", out)
+	}
+	if !strings.Contains(out, "more release(s)") {
+		t.Errorf("non-full changelog with >3 notes should truncate, got: %q", out)
+	}
+}
+
+func TestPrintChangelog_FullShowsAll(t *testing.T) {
+	cl := amiChangelog{
+		Current: "ami-1",
+		Target:  "ami-9",
+		Notes: []releaseNote{
+			{Tag: "v1"}, {Tag: "v2"}, {Tag: "v3"}, {Tag: "v4"},
+		},
+	}
+	out := captureStdout(t, func() { printChangelog(cl, true) })
+	if strings.Contains(out, "more release(s)") {
+		t.Errorf("full changelog should not truncate, got: %q", out)
+	}
+	if !strings.Contains(out, "v4") {
+		t.Errorf("full changelog should list every release, got: %q", out)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// int32PtrIfSet
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestInt32PtrIfSet(t *testing.T) {
+	var got *int32
+	cmd := &cli.Command{
+		Name:  "test",
+		Flags: []cli.Flag{&cli.IntFlag{Name: "desired"}},
+		Action: func(_ context.Context, c *cli.Command) error {
+			got = int32PtrIfSet(c, "desired")
+			return nil
+		},
+	}
+	if err := cmd.Run(context.Background(), []string{"test", "--desired", "7"}); err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || *got != 7 {
+		t.Errorf("set flag: got %v, want 7", got)
+	}
+
+	got = nil
+	cmd2 := &cli.Command{
+		Name:  "test",
+		Flags: []cli.Flag{&cli.IntFlag{Name: "desired"}},
+		Action: func(_ context.Context, c *cli.Command) error {
+			got = int32PtrIfSet(c, "desired")
+			return nil
+		},
+	}
+	if err := cmd2.Run(context.Background(), []string{"test"}); err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("unset flag: got %v, want nil", got)
+	}
+}

--- a/internal/health/coverage_test.go
+++ b/internal/health/coverage_test.go
@@ -1,0 +1,359 @@
+package health
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// maxFloat
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestMaxFloat(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []float64
+		want float64
+	}{
+		{"empty", nil, 0},
+		{"single", []float64{42}, 42},
+		{"ascending", []float64{1, 2, 3}, 3},
+		{"descending", []float64{9, 4, 1}, 9},
+		{"max in middle", []float64{1, 88, 3}, 88},
+		{"negatives", []float64{-5, -2, -9}, -2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := maxFloat(tc.in); got != tc.want {
+				t.Errorf("maxFloat(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// kubernetesNodeCounts (fake k8s client)
+// ──────────────────────────────────────────────────────────────────────────────
+
+func readyNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+		},
+	}
+}
+
+func notReadyNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionFalse}},
+		},
+	}
+}
+
+func TestKubernetesNodeCounts_NilClient(t *testing.T) {
+	hc := NewChecker(nil, nil, nil, nil)
+	total, ready, notReady, ok := hc.kubernetesNodeCounts(context.Background())
+	if ok {
+		t.Error("nil client should report ok=false")
+	}
+	if total != 0 || ready != 0 || notReady != nil {
+		t.Errorf("nil client should return zero values, got total=%d ready=%d notReady=%v", total, ready, notReady)
+	}
+}
+
+func TestKubernetesNodeCounts_AllReady(t *testing.T) {
+	client := fakek8s.NewSimpleClientset(readyNode("n1"), readyNode("n2"), readyNode("n3"))
+	hc := NewChecker(nil, client, nil, nil)
+	total, ready, notReady, ok := hc.kubernetesNodeCounts(context.Background())
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if total != 3 || ready != 3 {
+		t.Errorf("total=%d ready=%d, want 3/3", total, ready)
+	}
+	if len(notReady) != 0 {
+		t.Errorf("expected no NotReady nodes, got %v", notReady)
+	}
+}
+
+func TestKubernetesNodeCounts_MixedReadiness(t *testing.T) {
+	client := fakek8s.NewSimpleClientset(readyNode("n1"), notReadyNode("n2"), readyNode("n3"))
+	hc := NewChecker(nil, client, nil, nil)
+	total, ready, notReady, ok := hc.kubernetesNodeCounts(context.Background())
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if total != 3 || ready != 2 {
+		t.Errorf("total=%d ready=%d, want 3/2", total, ready)
+	}
+	if len(notReady) != 1 || notReady[0] != "n2" {
+		t.Errorf("notReady = %v, want [n2]", notReady)
+	}
+}
+
+func TestKubernetesNodeCounts_NoNodes(t *testing.T) {
+	client := fakek8s.NewSimpleClientset()
+	hc := NewChecker(nil, client, nil, nil)
+	total, ready, _, ok := hc.kubernetesNodeCounts(context.Background())
+	if !ok {
+		t.Fatal("an empty-but-reachable cluster should still report ok=true")
+	}
+	if total != 0 || ready != 0 {
+		t.Errorf("total=%d ready=%d, want 0/0", total, ready)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CheckClusterCapacity / CheckResourceBalance — no CloudWatch client
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestCheckClusterCapacity_NilCloudWatchWarns(t *testing.T) {
+	// No cwClient → clusterCPUByInstance errors → capacity check degrades to a
+	// non-fatal WARN with a default score rather than panicking.
+	hc := NewChecker(nil, nil, nil, nil)
+	result := hc.CheckClusterCapacity(context.Background(), "my-cluster")
+	if result.Status != StatusWarn {
+		t.Errorf("no CloudWatch: status = %s, want WARN", result.Status)
+	}
+	if result.Score != 70 {
+		t.Errorf("no CloudWatch: score = %d, want default 70", result.Score)
+	}
+	if !result.IsBlocking {
+		t.Error("capacity check is declared blocking")
+	}
+}
+
+func TestCheckResourceBalance_NilCloudWatchWarns(t *testing.T) {
+	hc := NewChecker(nil, nil, nil, nil)
+	result := hc.CheckResourceBalance(context.Background(), "my-cluster")
+	if result.Status != StatusWarn {
+		t.Errorf("no CloudWatch: status = %s, want WARN", result.Status)
+	}
+	if result.IsBlocking {
+		t.Error("resource balance is warning-level, not blocking")
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// ListPodDisruptionBudgets
+// ──────────────────────────────────────────────────────────────────────────────
+
+func pdbWithStatus(namespace, name string, allowed, healthy, desired, expected int32) *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Status: policyv1.PodDisruptionBudgetStatus{
+			DisruptionsAllowed: allowed,
+			CurrentHealthy:     healthy,
+			DesiredHealthy:     desired,
+			ExpectedPods:       expected,
+		},
+	}
+}
+
+func TestListPodDisruptionBudgets_NilClient(t *testing.T) {
+	hc := NewChecker(nil, nil, nil, nil)
+	pdbs, err := hc.ListPodDisruptionBudgets(context.Background())
+	if err != nil {
+		t.Fatalf("nil client should degrade gracefully, got err: %v", err)
+	}
+	if pdbs != nil {
+		t.Errorf("nil client should return nil slice, got %v", pdbs)
+	}
+}
+
+func TestListPodDisruptionBudgets_SkipsSystemNamespaces(t *testing.T) {
+	client := fakek8s.NewSimpleClientset(
+		pdbWithStatus("my-app", "frontend", 2, 5, 4, 5),
+		pdbWithStatus("kube-system", "coredns", 1, 2, 1, 2),
+		pdbWithStatus("kube-public", "x", 0, 0, 0, 0),
+		pdbWithStatus("kube-node-lease", "y", 0, 0, 0, 0),
+	)
+	hc := NewChecker(nil, client, nil, nil)
+	pdbs, err := hc.ListPodDisruptionBudgets(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pdbs) != 1 {
+		t.Fatalf("expected 1 user-namespace PDB, got %d: %+v", len(pdbs), pdbs)
+	}
+	got := pdbs[0]
+	if got.Namespace != "my-app" || got.Name != "frontend" {
+		t.Errorf("got %s/%s, want my-app/frontend", got.Namespace, got.Name)
+	}
+	if got.DisruptionsAllowed != 2 || got.CurrentHealthy != 5 || got.DesiredHealthy != 4 || got.ExpectedPods != 5 {
+		t.Errorf("status fields not copied through: %+v", got)
+	}
+}
+
+func TestListPodDisruptionBudgets_EmptyWhenNoUserPDBs(t *testing.T) {
+	client := fakek8s.NewSimpleClientset(pdbWithStatus("kube-system", "coredns", 1, 2, 1, 2))
+	hc := NewChecker(nil, client, nil, nil)
+	pdbs, err := hc.ListPodDisruptionBudgets(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pdbs) != 0 {
+		t.Errorf("expected 0 user PDBs, got %d", len(pdbs))
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// instanceIDsForASGs
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestInstanceIDsForASGs_EmptyNames(t *testing.T) {
+	hc := NewChecker(nil, nil, nil, nil)
+	ids, err := hc.instanceIDsForASGs(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("empty ASG names should be a no-op, got err: %v", err)
+	}
+	if ids != nil {
+		t.Errorf("expected nil ids, got %v", ids)
+	}
+}
+
+func TestInstanceIDsForASGs_NilClientErrors(t *testing.T) {
+	hc := NewChecker(nil, nil, nil, nil)
+	_, err := hc.instanceIDsForASGs(context.Background(), []string{"asg-1"})
+	if err == nil {
+		t.Fatal("expected an error when the Auto Scaling client is unavailable")
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// checkClusterCapacityWith / checkResourceBalanceWith — scoring branches driven
+// from a pre-seeded snapshot (no CloudWatch).
+// ──────────────────────────────────────────────────────────────────────────────
+
+// seededSnapshot returns a cpuSnapshot whose CPU-by-instance map is already
+// populated, with its sync.Once consumed so get() never touches AWS.
+func seededSnapshot(byInstance map[string]float64) *cpuSnapshot {
+	s := &cpuSnapshot{byInstance: byInstance}
+	s.once.Do(func() {}) // consume Once so the (nil) fetch closure never runs
+	return s
+}
+
+func TestCheckCapacity_HealthyHeadroomPasses(t *testing.T) {
+	hc := NewChecker(nil, nil, nil, nil)
+	snap := seededSnapshot(map[string]float64{"i-1": 20, "i-2": 30}) // avg 25, peak 30 → ~75% headroom
+	result := hc.checkClusterCapacityWith(context.Background(), snap)
+	if result.Status != StatusPass {
+		t.Errorf("low utilization: status = %s, want PASS (msg: %s)", result.Status, result.Message)
+	}
+	if result.Score != 100 {
+		t.Errorf("score = %d, want 100", result.Score)
+	}
+}
+
+func TestCheckCapacity_LimitedHeadroomWarns(t *testing.T) {
+	hc := NewChecker(nil, nil, nil, nil)
+	snap := seededSnapshot(map[string]float64{"i-1": 80, "i-2": 80}) // avg 80 → 20% headroom (warn band)
+	result := hc.checkClusterCapacityWith(context.Background(), snap)
+	if result.Status != StatusWarn {
+		t.Errorf("limited headroom: status = %s, want WARN", result.Status)
+	}
+}
+
+func TestCheckCapacity_InsufficientHeadroomFails(t *testing.T) {
+	hc := NewChecker(nil, nil, nil, nil)
+	snap := seededSnapshot(map[string]float64{"i-1": 90, "i-2": 95}) // avg ~92 → <15% headroom, peak ≥95
+	result := hc.checkClusterCapacityWith(context.Background(), snap)
+	if result.Status != StatusFail {
+		t.Errorf("insufficient headroom: status = %s, want FAIL", result.Status)
+	}
+}
+
+func TestCheckCapacity_PeakNodeDowngradesPass(t *testing.T) {
+	hc := NewChecker(nil, nil, nil, nil)
+	// Cluster mean is low (lots of idle nodes) but one node is near saturation:
+	// the peak-node guard must downgrade the otherwise-PASS verdict to WARN.
+	snap := seededSnapshot(map[string]float64{"i-1": 5, "i-2": 5, "i-3": 5, "i-hot": 88})
+	result := hc.checkClusterCapacityWith(context.Background(), snap)
+	if result.Status != StatusWarn {
+		t.Errorf("peak-node guard: status = %s, want WARN", result.Status)
+	}
+}
+
+func TestCheckResourceBalance_EvenDistributionPasses(t *testing.T) {
+	hc := NewChecker(nil, nil, nil, nil)
+	snap := seededSnapshot(map[string]float64{"i-1": 40, "i-2": 42, "i-3": 41})
+	result := hc.checkResourceBalanceWith(context.Background(), snap)
+	if result.Status != StatusPass {
+		t.Errorf("even, moderate CPU: status = %s, want PASS (msg: %s)", result.Status, result.Message)
+	}
+}
+
+func TestCheckResourceBalance_HighUtilizationWarns(t *testing.T) {
+	hc := NewChecker(nil, nil, nil, nil)
+	snap := seededSnapshot(map[string]float64{"i-1": 95, "i-2": 95})
+	result := hc.checkResourceBalanceWith(context.Background(), snap)
+	if result.Status != StatusWarn {
+		t.Errorf("high utilization: status = %s, want WARN", result.Status)
+	}
+}
+
+func TestCheckResourceBalance_UnevenDistributionWarns(t *testing.T) {
+	hc := NewChecker(nil, nil, nil, nil)
+	// Wide spread (std dev > 40 pts) but no single node above the utilization
+	// thresholds → uneven-distribution warning branch.
+	snap := seededSnapshot(map[string]float64{"i-1": 5, "i-2": 75})
+	result := hc.checkResourceBalanceWith(context.Background(), snap)
+	if result.Status != StatusWarn {
+		t.Errorf("uneven distribution: status = %s, want WARN", result.Status)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// nodeMetricsFromSnapshot
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestNodeMetricsFromSnapshot_MapsInstances(t *testing.T) {
+	hc := NewChecker(nil, nil, nil, nil)
+	snap := seededSnapshot(map[string]float64{"i-1": 10, "i-2": 20})
+	metrics, err := hc.nodeMetricsFromSnapshot(context.Background(), snap)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(metrics) != 2 {
+		t.Fatalf("expected 2 node metrics, got %d", len(metrics))
+	}
+}
+
+func TestNodeMetricsFromSnapshot_EmptyErrors(t *testing.T) {
+	hc := NewChecker(nil, nil, nil, nil)
+	snap := seededSnapshot(map[string]float64{})
+	_, err := hc.nodeMetricsFromSnapshot(context.Background(), snap)
+	if err == nil {
+		t.Fatal("expected an error when no CPU metrics are available")
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PDBInfo.AtRisk
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestPDBInfo_AtRisk(t *testing.T) {
+	cases := []struct {
+		allowed int32
+		want    bool
+	}{
+		{-1, true},
+		{0, true},
+		{1, false},
+		{5, false},
+	}
+	for _, tc := range cases {
+		p := PDBInfo{DisruptionsAllowed: tc.allowed}
+		if got := p.AtRisk(); got != tc.want {
+			t.Errorf("AtRisk(allowed=%d) = %v, want %v", tc.allowed, got, tc.want)
+		}
+	}
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1,0 +1,159 @@
+//go:build integration
+
+// Package integration holds opt-in, end-to-end tests that talk to a real AWS
+// account. They are excluded from the default `go test ./...` by the
+// `integration` build tag above and are additionally gated at runtime on the
+// REFRESH_INTEGRATION env var, so even `go test -tags integration ./...` is a
+// no-op unless you explicitly opt in.
+//
+// Prerequisites to actually exercise these tests:
+//
+//   - An AWS account reachable via the standard credential chain
+//     (env vars, shared config/credentials, SSO, or an instance/role profile).
+//   - A disposable EKS test cluster you don't mind issuing read-only calls
+//     against. Set its name via REFRESH_TEST_CLUSTER (the cluster-bound tests
+//     skip when it is unset).
+//   - REFRESH_INTEGRATION=1 in the environment.
+//
+// Run with:
+//
+//	REFRESH_INTEGRATION=1 \
+//	REFRESH_TEST_CLUSTER=my-disposable-cluster \
+//	task test:integration
+//
+// These tests are intentionally read-only / dry-run: they assert basic
+// invariants of the live AWS surface and must never mutate cluster state.
+package integration
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/dantech2000/refresh/internal/awsconfig"
+	"github.com/dantech2000/refresh/internal/commands/factory"
+	addonsvc "github.com/dantech2000/refresh/internal/services/addons"
+	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
+	nodegroupsvc "github.com/dantech2000/refresh/internal/services/nodegroup"
+)
+
+// requireIntegration skips the test unless REFRESH_INTEGRATION=1. Call it at
+// the top of every test so the suite is a no-op without an explicit opt-in.
+func requireIntegration(t *testing.T) {
+	t.Helper()
+	if os.Getenv("REFRESH_INTEGRATION") != "1" {
+		t.Skip("set REFRESH_INTEGRATION=1 and AWS creds to run")
+	}
+}
+
+// loadConfig loads real AWS config through the same path the application uses.
+// A nil *cli.Command is valid: awsconfig.Load falls back to env vars, the
+// active refresh context, and SDK defaults.
+func loadConfig(t *testing.T) aws.Config {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cfg, err := awsconfig.Load(ctx, nil)
+	if err != nil {
+		t.Fatalf("loading AWS config: %v", err)
+	}
+	return cfg
+}
+
+// testCluster returns REFRESH_TEST_CLUSTER or skips when it is unset, so
+// cluster-scoped tests don't fail on accounts without a designated test cluster.
+func testCluster(t *testing.T) string {
+	t.Helper()
+	name := os.Getenv("REFRESH_TEST_CLUSTER")
+	if name == "" {
+		t.Skip("set REFRESH_TEST_CLUSTER to a disposable cluster to run this test")
+	}
+	return name
+}
+
+// TestIntegrationClusterListAllRegions exercises multi-region cluster discovery
+// (the `cluster list -A` path) against the live account and asserts the
+// summaries come back coherent.
+func TestIntegrationClusterListAllRegions(t *testing.T) {
+	requireIntegration(t)
+	cfg := loadConfig(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	svc := clustersvc.NewService(cfg, nil, nil)
+	summaries, regions, err := svc.ListAllRegionsWithMeta(ctx, clustersvc.ListOptions{AllRegions: true})
+	if err != nil {
+		t.Fatalf("ListAllRegionsWithMeta: %v", err)
+	}
+	if regions <= 0 {
+		t.Fatalf("expected at least one region queried, got %d", regions)
+	}
+	for _, s := range summaries {
+		if s.Name == "" {
+			t.Errorf("cluster summary missing a name: %+v", s)
+		}
+		if s.Region == "" {
+			t.Errorf("cluster %q missing a region after multi-region relabel", s.Name)
+		}
+	}
+}
+
+// TestIntegrationAddonListDescribe lists addons for the test cluster and, for
+// the first one found, describes it, asserting the describe round-trips the
+// addon name.
+func TestIntegrationAddonListDescribe(t *testing.T) {
+	requireIntegration(t)
+	cluster := testCluster(t)
+	cfg := loadConfig(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	svc := factory.NewAddonService(cfg, nil)
+	addons, err := svc.List(ctx, cluster, addonsvc.ListOptions{})
+	if err != nil {
+		t.Fatalf("addon List: %v", err)
+	}
+	if len(addons) == 0 {
+		t.Skipf("cluster %q has no addons to describe", cluster)
+	}
+
+	first := addons[0].Name
+	details, err := svc.Describe(ctx, cluster, first, addonsvc.DescribeOptions{})
+	if err != nil {
+		t.Fatalf("addon Describe(%q): %v", first, err)
+	}
+	if details.Name != first {
+		t.Errorf("Describe returned name %q, want %q", details.Name, first)
+	}
+}
+
+// TestIntegrationNodegroupScaleDryRun verifies the scale dry-run path is a true
+// no-op against the live account: it lists nodegroups, then issues a dry-run
+// scale that must return without error and without mutating anything.
+func TestIntegrationNodegroupScaleDryRun(t *testing.T) {
+	requireIntegration(t)
+	cluster := testCluster(t)
+	cfg := loadConfig(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	svc := nodegroupsvc.NewService(cfg, nil, nil)
+	groups, err := svc.List(ctx, cluster, nodegroupsvc.ListOptions{})
+	if err != nil {
+		t.Fatalf("nodegroup List: %v", err)
+	}
+	if len(groups) == 0 {
+		t.Skipf("cluster %q has no nodegroups to dry-run scale", cluster)
+	}
+
+	target := groups[0].Name
+	desired := groups[0].DesiredSize // scale to the current size — a true no-op even if --dry-run regressed
+	if err := svc.Scale(ctx, cluster, target, aws.Int32(desired), nil, nil, nodegroupsvc.ScaleOptions{DryRun: true}); err != nil {
+		t.Fatalf("dry-run Scale(%q): %v", target, err)
+	}
+}

--- a/internal/services/cluster/bench_test.go
+++ b/internal/services/cluster/bench_test.go
@@ -1,0 +1,128 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/dantech2000/refresh/internal/mocks"
+)
+
+// benchService builds a ServiceImpl wired to an in-memory EKS mock, the same
+// way the *_test.go files do. No live AWS is touched.
+func benchService(b *testing.B, api *mocks.EKSAPI) *ServiceImpl {
+	b.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	return &ServiceImpl{
+		eksClient: api,
+		cache:     NewCache(1 * time.Minute),
+		logger:    logger,
+	}
+}
+
+// manyClustersMock returns a mock that lists n clusters, each backed by a
+// single small nodegroup. Used to exercise the bounded-concurrency fan-out in
+// List under load without any network calls.
+func manyClustersMock(n int) *mocks.EKSAPI {
+	names := make([]string, 0, n)
+	for i := range n {
+		names = append(names, fmt.Sprintf("cluster-%d", i))
+	}
+	return &mocks.EKSAPI{
+		ListClustersFn: func(_ context.Context, _ *eks.ListClustersInput, _ ...func(*eks.Options)) (*eks.ListClustersOutput, error) {
+			return &eks.ListClustersOutput{Clusters: names}, nil
+		},
+		DescribeClusterFn: func(_ context.Context, in *eks.DescribeClusterInput, _ ...func(*eks.Options)) (*eks.DescribeClusterOutput, error) {
+			return &eks.DescribeClusterOutput{Cluster: &ekstypes.Cluster{
+				Name:    in.Name,
+				Version: aws.String("1.29"),
+				Status:  ekstypes.ClusterStatusActive,
+			}}, nil
+		},
+		ListNodegroupsFn: func(_ context.Context, in *eks.ListNodegroupsInput, _ ...func(*eks.Options)) (*eks.ListNodegroupsOutput, error) {
+			return &eks.ListNodegroupsOutput{Nodegroups: []string{aws.ToString(in.ClusterName) + "-ng"}}, nil
+		},
+		DescribeNodegroupFn: func(_ context.Context, in *eks.DescribeNodegroupInput, _ ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error) {
+			desired := int32(3)
+			return &eks.DescribeNodegroupOutput{Nodegroup: &ekstypes.Nodegroup{
+				NodegroupName: in.NodegroupName,
+				Status:        ekstypes.NodegroupStatusActive,
+				ScalingConfig: &ekstypes.NodegroupScalingConfig{DesiredSize: &desired},
+				InstanceTypes: []string{"m5.large"},
+			}}, nil
+		},
+	}
+}
+
+// BenchmarkClusterList measures the List read path over a fleet of mock
+// clusters, including the per-cluster DescribeCluster + nodegroup fan-out.
+func BenchmarkClusterList(b *testing.B) {
+	svc := benchService(b, manyClustersMock(50))
+	ctx := context.Background()
+	opts := ListOptions{}
+
+	b.ResetTimer()
+	for range b.N {
+		// Use a fresh option set each iteration but reuse the service. The
+		// cache is keyed on options; clearing it keeps every iteration doing
+		// real work rather than serving the first run's cached slice.
+		svc.cache = NewCache(1 * time.Minute)
+		if _, err := svc.List(ctx, opts); err != nil {
+			b.Fatalf("List: %v", err)
+		}
+	}
+}
+
+// BenchmarkClusterDescribe measures the Describe read path for a single
+// cluster (DescribeCluster + nodegroup + addon enrichment).
+func BenchmarkClusterDescribe(b *testing.B) {
+	api := mocks.NewEKSAPI().
+		WithCluster("prod", "1.29").
+		WithNodegroup("ng-a", "1.29", ekstypes.AMITypesAl2X8664).
+		WithNodegroup("ng-b", "1.29", ekstypes.AMITypesAl2X8664).
+		WithAddon("coredns", "v1.10", ekstypes.AddonStatusActive).
+		Build()
+	svc := benchService(b, api)
+	ctx := context.Background()
+	opts := DescribeOptions{IncludeAddons: true}
+
+	b.ResetTimer()
+	for range b.N {
+		svc.cache = NewCache(1 * time.Minute)
+		if _, err := svc.Describe(ctx, "prod", opts); err != nil {
+			b.Fatalf("Describe: %v", err)
+		}
+	}
+}
+
+// BenchmarkClusterListAllRegions exercises the bounded-concurrency multi-region
+// fan-out's offline-drivable seam.
+//
+// ListAllRegionsWithMeta itself cannot run offline: forRegion → NewService
+// builds real eks/ec2/iam/sts clients via *.NewFromConfig and the per-region
+// List would hit the live EKS API. So this benchmark measures the pure
+// per-region option/cache-key derivation (regionOptionsFor + buildListCacheKey)
+// that the fan-out performs for every region, which is the part REF-7 can
+// assert is deterministic and offline. The List-with-many-clusters path above
+// covers the bounded fan-out behaviour itself.
+func BenchmarkClusterListAllRegions(b *testing.B) {
+	parent := ListOptions{
+		Regions:    []string{"us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1"},
+		ShowHealth: true,
+		Filters:    map[string]string{"name": "prod"},
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		for _, r := range parent.Regions {
+			opts := regionOptionsFor(parent, r)
+			_ = buildListCacheKey(opts)
+		}
+	}
+}

--- a/internal/services/nodegroup/bench_test.go
+++ b/internal/services/nodegroup/bench_test.go
@@ -1,0 +1,66 @@
+package nodegroup
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/dantech2000/refresh/internal/mocks"
+)
+
+// manyNodegroupsMock returns an EKS mock that lists n nodegroups, each a custom
+// AMI nodegroup (so List/Describe avoid any EC2/ASG/SSM client calls — see
+// stubNodegroup). No live AWS is touched.
+func manyNodegroupsMock(n int) *mocks.EKSAPI {
+	names := make([]string, 0, n)
+	for i := range n {
+		names = append(names, fmt.Sprintf("ng-%d", i))
+	}
+	return &mocks.EKSAPI{
+		DescribeClusterFn: clusterFn("1.29"),
+		ListNodegroupsFn: func(_ context.Context, _ *eks.ListNodegroupsInput, _ ...func(*eks.Options)) (*eks.ListNodegroupsOutput, error) {
+			return &eks.ListNodegroupsOutput{Nodegroups: names}, nil
+		},
+		DescribeNodegroupFn: func(_ context.Context, in *eks.DescribeNodegroupInput, _ ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error) {
+			return &eks.DescribeNodegroupOutput{Nodegroup: stubNodegroup(aws.ToString(in.NodegroupName), ekstypes.NodegroupStatusActive)}, nil
+		},
+	}
+}
+
+// BenchmarkNodegroupList measures the List read path over a cluster with many
+// nodegroups, including the per-nodegroup DescribeNodegroup fan-out.
+func BenchmarkNodegroupList(b *testing.B) {
+	svc := newTestService(manyNodegroupsMock(50))
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for range b.N {
+		if _, err := svc.List(ctx, "my-cluster", ListOptions{}); err != nil {
+			b.Fatalf("List: %v", err)
+		}
+	}
+}
+
+// BenchmarkNodegroupDescribe measures the Describe read path for a single
+// nodegroup.
+func BenchmarkNodegroupDescribe(b *testing.B) {
+	ng := stubNodegroup("workers", ekstypes.NodegroupStatusActive)
+	mock := &mocks.EKSAPI{
+		DescribeClusterFn: clusterFn("1.29"),
+		DescribeNodegroupFn: func(_ context.Context, _ *eks.DescribeNodegroupInput, _ ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error) {
+			return &eks.DescribeNodegroupOutput{Nodegroup: ng}, nil
+		},
+	}
+	svc := newTestService(mock)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for range b.N {
+		if _, err := svc.Describe(ctx, "my-cluster", "workers", DescribeOptions{}); err != nil {
+			b.Fatalf("Describe: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
**Batch G** of the Sonnet 4.6 backlog — Phase 9 tests. Test-only changes + two Taskfile targets; **no production code touched**.

| Issue | Change |
|---|---|
| **REF-5** | Raised coverage via the in-memory mocks + client-go fakes: `internal/health` **36% → 60%**, `commands/addon` **14% → 40%**, `commands/nodegroup` **23% → 33%**, `commands/cluster` **6.5% → 21%**. |
| **REF-7** | Offline, mock-driven benchmarks — `BenchmarkClusterList/Describe/ListAllRegions`, `BenchmarkNodegroupList/Describe`; `task bench`. |
| **REF-6** | Opt-in integration scaffold under `//go:build integration`, gated on `REFRESH_INTEGRATION=1` (+`REFRESH_TEST_CLUSTER`), excluded from default `go test ./...`; read-only/dry-run skeletons; `task test:integration`. |

## Honest note on REF-5 scope
The three command packages rose materially but stay **under the suggested 60%**: most of their remaining surface is `runner.SetupAWS`-bound action handlers (and pterm table rows a captured pipe suppresses) that need a production AWS seam to unit-test — a refactor out of scope for a test-only PR. Every genuinely testable pure helper / renderer / exit-code path is now covered, and `health` (the most logic-heavy target) hit 60%.

## Gate
`go build`, `gofmt`, `go vet`, `go test -race ./...`, `golangci-lint` (0 issues). Benchmarks run with no live AWS; integration compiles under `-tags integration` and is a no-op without the env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)