### PR TITLE
docs: Material for MkDocs site + hardened Pages deploy (REF-106, REF-107)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,4 +49,24 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
-      - "github-actions" 
+      - "github-actions"
+
+  # Docs site Python deps (Material for MkDocs) — keep the hash-locked tree
+  # reviewed rather than silently floating. (REF-107)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "dantech2000"
+    assignees:
+      - "dantech2000"
+    commit-message:
+      prefix: "deps(docs)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "documentation"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,86 @@
+name: Docs
+
+# Build the Material for MkDocs site and deploy it to GitHub Pages.
+#
+# Supply-chain posture (REF-107):
+#   - The BUILD job runs third-party code (Python deps from the hash-locked
+#     uv.lock) with `contents: read` only — NO id-token, NO pages, NO secrets.
+#     A poisoned dependency therefore cannot mint an OIDC token or read secrets.
+#   - A separate DEPLOY job holds `pages: write` + `id-token: write` and runs
+#     ONLY first-party actions (actions/deploy-pages).
+#   - Every action is pinned to a full commit SHA (tags are mutable).
+#   - harden-runner audits egress on the build job (flip to `block` with an
+#     allowlist once the audit confirms the endpoints: github + pypi).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/docs.yml"
+
+# Least privilege by default; jobs opt into more only where required.
+permissions:
+  contents: read
+
+# Never cancel an in-flight Pages deploy.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # no id-token / pages / secrets — untrusted deps run here
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up uv (pinned, cached)
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          version: "0.9.18"
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Build (strict) from the hash-locked lockfile
+        run: uv run --frozen mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to Pages
+    # Only deploy from main; PRs build-and-validate only.
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write # mint the Pages deployment
+      id-token: write # OIDC for deploy-pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy (first-party action only)
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,12 @@ coverage.html
 # Conductor workspace collaboration dir (agent scratch space)
 .context/
 
+# Docs site (Material for MkDocs): built output and the uv-managed venv.
+# pyproject.toml + uv.lock ARE committed (hash-locked deps); .venv/ is not.
+site/
+.venv/
+.python-version
+
 # IDE files
 .vscode/
 .idea/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -93,6 +93,17 @@ tasks:
     cmds:
       - go test -bench=. -benchmem -run=^$ ./internal/services/...
 
+  # Documentation site (Material for MkDocs via a uv-managed, hash-locked venv)
+  docs:serve:
+    desc: Serve the documentation site locally with live reload
+    cmds:
+      - uv run --frozen mkdocs serve
+
+  docs:build:
+    desc: Build the documentation site (strict — fails on broken links/nav)
+    cmds:
+      - uv run --frozen mkdocs build --strict
+
   # Dependency management
   deps:
     desc: Download and tidy dependencies

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,7 @@
+!!! info "Releases"
+    Full release notes, binaries, checksums, and signatures are on the
+    [GitHub releases page](https://github.com/dantech2000/refresh/releases).
+    The history below is embedded from the repository `CHANGELOG.md`
+    (maintained by release-please) and updates automatically on each docs build.
+
+--8<-- "CHANGELOG.md"

--- a/docs/commands/addon.md
+++ b/docs/commands/addon.md
@@ -1,0 +1,136 @@
+# addon
+
+Inspect and update the managed EKS add-ons (`vpc-cni`, `coredns`, `kube-proxy`,
+and others) on a cluster. List shows installed versions and status, describe
+drills into one add-on, and update rolls a single add-on or every add-on
+(`--all`) to a compatible version with optional health gating and waiting.
+
+```bash
+refresh addon <list|describe|update> [args] [flags]
+```
+
+The cluster is a positional on each subcommand, or `--cluster/-c`, falling back
+to the [active context](../concepts/contexts.md).
+
+---
+
+## list
+
+List the managed EKS add-ons installed on a cluster along with their current
+version, status, and (with `--show-health`) a health badge.
+
+```bash
+refresh addon list [cluster] [flags]
+```
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--cluster, -c` | EKS cluster name or pattern (or pass as positional) |
+| `--show-health, -H` | Include a health mapping/badge in table output |
+| `--format, -o` | `table` (default), `json`, `yaml`, `plain` |
+| `--watch, -w` | Re-run and redraw every `--watch-interval` until interrupted |
+| `--watch-interval` | Refresh interval for `--watch` (default `10s`) |
+| `--timeout, -t` | Operation timeout (env `REFRESH_TIMEOUT`) |
+
+!!! tip "Watch an update land"
+    `refresh addon list my-cluster --watch` keeps the listing live, so you can
+    watch an add-on update progress without re-running the command.
+
+### Examples
+
+```bash
+refresh addon list my-cluster
+refresh addon list my-cluster --show-health
+refresh addon list my-cluster -o plain
+refresh addon list my-cluster --watch --watch-interval 5s
+```
+
+---
+
+## describe
+
+Detailed information for one add-on: its version, status, and configuration.
+
+```bash
+refresh addon describe [cluster] [addon] [flags]
+```
+
+`describe` has the alias `get`. The add-on name may be the second positional or
+`--addon/-a`, and a case-insensitive substring is resolved against the
+installed add-ons.
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--cluster, -c` | EKS cluster name or pattern (or pass as positional) |
+| `--addon, -a` | Add-on name (e.g. `vpc-cni`); or pass as second positional |
+| `--format, -o` | `table` (default), `json`, `yaml`, `plain` |
+| `--timeout, -t` | Operation timeout (env `REFRESH_TIMEOUT`) |
+
+### Examples
+
+```bash
+refresh addon describe my-cluster vpc-cni
+refresh addon describe my-cluster coredns -o json
+```
+
+---
+
+## update
+
+Update a single managed add-on to a target version, or with `--all` update every
+add-on in the cluster to its latest compatible version.
+
+```bash
+refresh addon update [cluster] [addon] [version] [flags]
+```
+
+For a single add-on, pass the add-on name and an optional version (the third
+positional or `--version`, defaulting to `latest`). The command exits non-zero
+if any add-on update fails.
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--cluster, -c` | EKS cluster name or pattern (or pass as positional) |
+| `--addon, -a` | Add-on name (or pass as second positional) |
+| `--version` | Target version or `latest` (default; or pass as third positional) |
+| `--all` | Update every add-on in the cluster to its latest version |
+| `--health-check` | Verify the add-on is ACTIVE and version-compatible before updating |
+| `--dry-run, -d` | Preview without applying changes |
+| `--wait` | Wait for each update to complete |
+| `--wait-timeout` | Per-add-on wait timeout, with `--wait` (default `5m`) |
+| `--parallel, -p` | *(`--all` only)* Update add-ons in parallel |
+| `--dependency-order` | *(`--all` only)* Update in dependency-safe order: `vpc-cni` → `coredns`/`kube-proxy` → others |
+| `--skip, -s` | *(`--all` only)* Skip specific add-ons (repeatable) |
+| `--format, -o` | `table` (default), `json`, `yaml`, `plain` |
+| `--timeout, -t` | Operation timeout (default `10m`; env `REFRESH_TIMEOUT`) |
+
+!!! note "`--all`-only flags"
+    `--parallel`, `--dependency-order`, and `--skip` apply only with `--all`. On
+    a single-add-on update they're ignored with a warning. `--parallel` and
+    `--dependency-order` are mutually exclusive (parallel defeats ordering).
+    A single-add-on update honors `-o json|yaml` for a machine-readable result.
+
+### Examples
+
+```bash
+# vpc-cni -> latest
+refresh addon update my-cluster vpc-cni
+
+# Pin a version
+refresh addon update my-cluster coredns v1.11.1
+
+# Preview only
+refresh addon update my-cluster vpc-cni --dry-run
+
+# All add-ons, dependency-safe order, waiting for each to settle
+refresh addon update my-cluster --all --dependency-order --wait
+
+# All add-ons in parallel, skipping vpc-cni
+refresh addon update my-cluster --all --skip vpc-cni --parallel
+```

--- a/docs/commands/cluster.md
+++ b/docs/commands/cluster.md
@@ -1,0 +1,204 @@
+# cluster
+
+Discover and operate on EKS clusters: list them (optionally across every
+region), describe one in depth, run a read-only upgrade-readiness check, and
+orchestrate a full control-plane → add-on → nodegroup upgrade.
+
+```bash
+refresh cluster <list|describe|upgrade-check|upgrade> [args] [flags]
+```
+
+The cluster argument is a positional on most subcommands, or `--cluster/-c`,
+falling back to the [active context](../concepts/contexts.md).
+
+---
+
+## list
+
+Fast multi-region cluster discovery with integrated health status. Direct EKS
+API calls — no CloudFormation dependency.
+
+```bash
+refresh cluster list [name-pattern] [flags]
+```
+
+Scope with `-A` (every EKS-supported region) or repeated `-r`. Filter and sort
+in-process, then render as a table, structured output, or a region/cluster
+tree.
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--all-regions, -A` | Query all EKS-supported regions |
+| `--region, -r` | Specific region(s) to query (repeatable) |
+| `--filter, -f` | Filter clusters, `key=value` (keys: `name`, `status`, `version`); repeatable |
+| `--sort` | Sort by field: `name` (default), `status`, `version`, `region` |
+| `--desc` | Sort descending |
+| `--show-health, -H` | Include health status for each cluster |
+| `--format, -o` | `table` (default), `json`, `yaml`, `plain`, `tree` |
+| `--tree, -T` | Hierarchical region/cluster tree (implies `--all-regions`) |
+| `--watch, -w` | Re-run and redraw every `--watch-interval` until interrupted |
+| `--watch-interval` | Refresh interval for `--watch` (default `10s`) |
+| `--max-concurrency, -C` | Max concurrent region requests |
+| `--timeout, -t` | Operation timeout (default `60s`; env `REFRESH_TIMEOUT`) |
+
+!!! tip "`tree` view"
+    `-o tree` (or `--tree`) renders a region → cluster hierarchy and implies
+    `--all-regions`, so it's the quickest way to eyeball the whole fleet.
+
+### Examples
+
+```bash
+# Every active cluster across all regions
+refresh cluster list -A --filter status=ACTIVE
+
+# Just clusters whose name contains "prod", sorted by version (newest first)
+refresh cluster list prod --sort version --desc
+
+# Fleet hierarchy
+refresh cluster list -o tree
+
+# Live dashboard, redrawn every 5s
+refresh cluster list --watch --watch-interval 5s
+
+# Machine-readable for a script
+refresh cluster list -A -o json
+```
+
+---
+
+## describe
+
+Detailed information for a single cluster: networking, security configuration,
+add-ons, and health.
+
+```bash
+refresh cluster describe [cluster] [flags]
+```
+
+`describe` has the alias `get`.
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--cluster, -c` | EKS cluster name or pattern (or pass as positional) |
+| `--detailed, -d` | Show comprehensive networking and security information |
+| `--show-health, -H` | Include health status (default `true`) |
+| `--show-security, -s` | Include security configuration analysis |
+| `--include-addons, -a` | Include EKS add-on information (default `true`) |
+| `--format, -o` | `table` (default), `json`, `yaml`, `plain` |
+| `--timeout, -t` | Operation timeout (env `REFRESH_TIMEOUT`) |
+
+### Examples
+
+```bash
+refresh cluster describe prod-east
+refresh cluster get prod-east --detailed --show-security
+refresh cluster describe prod-east -o json
+```
+
+---
+
+## upgrade-check
+
+Read-only upgrade-readiness report. Nothing is mutated — this is the pre-flight
+read before [`cluster upgrade`](#upgrade).
+
+```bash
+refresh cluster upgrade-check [cluster] [flags]
+```
+
+Surfaces AWS **Cluster Insights** (the same upgrade checks the EKS console
+shows) plus a local **version-skew** picture: control-plane version vs. each
+managed nodegroup, and installed add-ons vs. the latest compatible version —
+with ordered, actionable findings.
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--cluster, -c` | EKS cluster name or pattern (or pass as positional) |
+| `--category` | Insight category: `UPGRADE_READINESS` (default), `MISCONFIGURATION` |
+| `--status` | Filter by insight status: `PASSING`, `WARNING`, `ERROR`, `UNKNOWN` (repeatable) |
+| `--show-passing` | Include `PASSING` insights (hidden by default) |
+| `--id` | Show the detail view (recommendation + resources) for a single insight ID |
+| `--format, -o` | `table` (default), `json`, `yaml`, `plain` |
+| `--timeout, -t` | Operation timeout (env `REFRESH_TIMEOUT`) |
+
+### Examples
+
+```bash
+# Readiness summary for prod-east
+refresh cluster upgrade-check -c prod-east
+
+# Include passing checks, as JSON for a gate
+refresh cluster upgrade-check -c prod-east --show-passing -o json
+
+# Drill into one insight
+refresh cluster upgrade-check -c prod-east --id <insight-id>
+```
+
+---
+
+## upgrade
+
+Plan and execute a full EKS cluster upgrade to a target Kubernetes version:
+control plane → add-ons → nodegroups, with a health gate after every phase.
+
+```bash
+refresh cluster upgrade [cluster] --to <version> [flags]
+```
+
+EKS upgrades one minor version at a time, so a multi-minor jump expands into
+sequential **hops**. Each hop runs: readiness (cluster insights + kubelet
+version skew) → control plane → add-ons (dependency order, versions compatible
+with the hop target) → nodegroup rolls.
+
+!!! note "Resumable by design"
+    The plan is re-derived from live cluster state on every run — no state
+    file. Rerunning after a failure (or Ctrl+C) resumes where it left off, and
+    rerunning after success is a no-op. On failure, `refresh` prints the exact
+    resume command.
+
+!!! warning "This mutates the control plane"
+    `cluster upgrade` uses strict credential validation and confirms each
+    mutating phase unless you pass `--yes`. A multi-hop upgrade legitimately
+    runs for hours; the default timeout is `4h`. Start with `--dry-run`.
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--to` | **Required.** Target Kubernetes version (e.g. `1.33`) |
+| `--cluster, -c` | EKS cluster name or pattern (or pass as positional) |
+| `--dry-run, -d` | Print the full ordered plan without mutating anything |
+| `--yes, -y` | Skip per-phase confirmation prompts |
+| `--force` | Force nodegroup rolls when pods can't be drained due to PDBs |
+| `--skip, -s` | Add-on to skip (repeatable; for add-ons managed via Helm/GitOps) |
+| `--skip-nodegroup` | Nodegroup name pattern to skip (repeatable) |
+| `--quiet, -q` | Suppress progress output |
+| `--poll-interval, -p` | How often to poll in-flight updates (default `15s`) |
+| `--format, -o` | Plan output format: `table` (default), `json`, `yaml`, `plain` |
+| `--timeout, -t` | Overall operation timeout (default `4h`; env `REFRESH_TIMEOUT`) |
+
+!!! tip "Exit code in dry-run"
+    A dry-run (or any run) whose plan contains a **blocker** prints the plan and
+    exits non-zero without mutating — handy as a readiness gate in CI.
+
+### Examples
+
+```bash
+# Print the plan only (exits non-zero if anything blocks the upgrade)
+refresh cluster upgrade -c prod-east --to 1.33 --dry-run
+
+# Execute, confirming each mutating phase
+refresh cluster upgrade -c prod-east --to 1.33
+
+# Non-interactive (CI) run, skipping a Helm-managed add-on
+refresh cluster upgrade -c prod-east --to 1.33 --yes --skip aws-load-balancer-controller
+```
+
+See the [upgrade lifecycle](../concepts/lifecycle.md) for how this fits the
+`status → upgrade-check → patch → upgrade` loop.

--- a/docs/commands/contexts.md
+++ b/docs/commands/contexts.md
@@ -1,0 +1,124 @@
+# Contexts (use / current / context)
+
+A kubectx-style workflow for EKS. Save named contexts that bind a cluster to an
+optional region and AWS profile, then switch between them by name instead of
+repeating `--cluster/--region/--profile` on every command.
+
+```bash
+refresh use <name>          # switch the active context
+refresh current             # print the active context
+refresh context add|list|remove [args] [flags]
+```
+
+The active context fills in cluster/region/profile defaults for every command.
+Per-invocation flags still override it. For the conceptual overview see
+[Contexts](../concepts/contexts.md); this page is the command-reference detail.
+
+!!! note "Where contexts are stored"
+    Contexts are saved as YAML under `$XDG_CONFIG_HOME/refresh/context.yaml`
+    (default `~/.config/refresh/context.yaml`). The `REFRESH_CONTEXT` env var
+    overrides the saved "current" pointer for a single shell.
+
+---
+
+## refresh use
+
+Switch the active context so subsequent commands inherit its cluster, region,
+and profile.
+
+```bash
+refresh use [context-name|-]
+```
+
+- `refresh use prod` — make `prod` active.
+- `refresh use -` — toggle back to the previously active context.
+- `refresh use` — no name: pick interactively from the saved list.
+
+Per-invocation `--region/--profile/--cluster` flags still override the active
+context.
+
+```bash
+refresh use prod
+refresh use -
+```
+
+---
+
+## refresh current
+
+Print the name and cluster/region/profile of the currently active context. Honors
+the `REFRESH_CONTEXT` override, and prints a hint when no context is active.
+
+```bash
+refresh current
+```
+
+---
+
+## refresh context
+
+Manage the named contexts that `refresh use` switches between. The group has the
+alias `ctx`.
+
+```bash
+refresh context <list|add|remove> [args] [flags]
+```
+
+### context list
+
+List every saved context with its cluster, region, and profile. The active
+context is marked with a `*`. Aliased as `ls`.
+
+```bash
+refresh context list
+```
+
+### context add
+
+Create or overwrite a named context. Re-running with the same name updates it in
+place.
+
+```bash
+refresh context add <name> --cluster <cluster> [flags]
+```
+
+| Flag | Description |
+|---|---|
+| `--cluster, -c` | **Required.** EKS cluster name |
+| `--region, -r` | AWS region (optional) |
+| `--profile, -p` | AWS shared-config profile (optional) |
+| `--use` | Switch to this context immediately after saving |
+
+```bash
+refresh context add prod --cluster prod-eks --region us-east-1 --profile prod
+refresh context add stage --cluster stage-eks --region us-west-2 --profile stage
+
+# Add and switch in one step
+refresh context add prod --cluster prod-eks --use
+```
+
+### context remove
+
+Delete a saved context by name. If the removed context was the active or
+previous one, those pointers are cleared. Aliased as `rm` / `delete`.
+
+```bash
+refresh context remove prod
+```
+
+---
+
+## Typical workflow
+
+```bash
+# Define your environments once
+refresh context add prod  --cluster prod-eks  --region us-east-1 --profile prod
+refresh context add stage --cluster stage-eks --region us-west-2 --profile stage
+
+# Switch, then run commands with no repeated flags
+refresh use prod
+refresh nodegroup list          # targets prod-eks / us-east-1 / prod
+refresh cluster upgrade-check   # same context
+
+refresh use stage               # flip the whole environment
+```

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -1,0 +1,34 @@
+# Command reference
+
+`refresh` is organized into a few command groups. Pick a page for the full
+flag-by-flag detail and examples.
+
+!!! note "Generated reference coming"
+    A complete, always-in-sync command/flag reference is generated directly from
+    the CLI (tracked as REF-108). Until that lands, these hand-written pages
+    cover every command and the flags you'll actually use. You can also always
+    run `refresh <command> --help` or `man refresh`.
+
+| Group | What it does |
+|---|---|
+| [`status`](status.md) | Fleet patch posture across clusters/regions |
+| [`cluster`](cluster.md) | `list`, `describe`, `upgrade-check`, `upgrade` |
+| [`nodegroup`](nodegroup.md) | `list`, `describe`, `scale`, `update` (AMI roll) |
+| [`addon`](addon.md) | `list`, `describe`, `update` (incl. `--all`) |
+| [Contexts](contexts.md) | `use`, `current`, `context add/list/remove` |
+| [Utility](utility.md) | `version`, `install-man`, `completion` |
+
+## Global flags
+
+Accepted on every command — see [Configuration & AWS auth](../concepts/configuration.md):
+
+`--profile`, `--region`, `--timeout/-t`, `--max-concurrency/-C`,
+`--log-level`, `--verbose`, `--no-color`.
+
+## Conventions
+
+- **Cluster argument** — most commands take the cluster as a positional
+  (`refresh nodegroup list my-cluster`) or via `--cluster/-c`, falling back to
+  the [active context](../concepts/contexts.md).
+- **Output** — `-o table|json|yaml|plain` (and `tree` for `cluster list`); see
+  [Output formats](../concepts/output.md).

--- a/docs/commands/nodegroup.md
+++ b/docs/commands/nodegroup.md
@@ -1,0 +1,221 @@
+# nodegroup
+
+Inspect and operate on a cluster's managed nodegroups: list them with AMI
+freshness, describe one in depth, scale desired/min/max size (with optional PDB
+and health gating), and roll nodegroups to the latest recommended AMI with
+pre-flight health checks and live monitoring.
+
+```bash
+refresh nodegroup <list|describe|scale|update> [args] [flags]
+```
+
+The group has the alias `ng`. The cluster is a positional on most subcommands,
+or `--cluster/-c`, falling back to the
+[active context](../concepts/contexts.md).
+
+---
+
+## list
+
+List the managed nodegroups in a cluster with their status, instance type, node
+counts, and AMI freshness (whether each is on the latest recommended AMI).
+
+```bash
+refresh nodegroup list [cluster] [flags]
+```
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--cluster, -c` | EKS cluster name or pattern (or pass as positional) |
+| `--filter, -f` | Filter, `key=value` (keys: `name`, `status`, `instanceType`, `amiStatus`); repeatable |
+| `--sort` | Sort by field: `name` (default), `status`, `instance`, `nodes` |
+| `--desc` | Sort descending |
+| `--format, -o` | `table` (default), `json`, `yaml`, `plain` |
+| `--watch, -w` | Re-run and redraw every `--watch-interval` until interrupted |
+| `--watch-interval` | Refresh interval for `--watch` (default `10s`) |
+| `--timeout, -t` | Operation timeout (env `REFRESH_TIMEOUT`) |
+
+### Examples
+
+```bash
+# Only nodegroups on a stale AMI
+refresh nodegroup list my-cluster --filter amiStatus=outdated
+
+# Plain TSV for scripting
+refresh nodegroup list my-cluster -o plain | awk '{print $1}'
+
+# Watch a roll progress live
+refresh nodegroup list my-cluster --watch
+```
+
+---
+
+## describe
+
+Detailed information for one nodegroup: scaling config, instance type(s),
+AMI/release version and freshness, and optional per-instance and workload
+placement details.
+
+```bash
+refresh nodegroup describe [cluster] [nodegroup] [flags]
+```
+
+`describe` has the alias `get`. The nodegroup name may be the second positional
+or `--nodegroup/-n`.
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--cluster, -c` | EKS cluster name |
+| `--nodegroup, -n` | Nodegroup name (or pass as second positional) |
+| `--show-instances, -I` | Include EC2 instance details |
+| `--show-workloads, -W` | Include workload/pod placement info |
+| `--format, -o` | `table` (default), `json`, `yaml`, `plain` |
+| `--timeout, -t` | Operation timeout (env `REFRESH_TIMEOUT`) |
+
+### Examples
+
+```bash
+refresh nodegroup describe my-cluster ng-default
+refresh nodegroup describe my-cluster ng-default --show-instances --show-workloads
+```
+
+---
+
+## scale
+
+Change a managed nodegroup's desired/min/max size. Any subset of
+`--desired/--min/--max` may be set; unspecified bounds are left unchanged.
+
+```bash
+refresh nodegroup scale [cluster] -n <nodegroup> [flags]
+```
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--cluster, -c` | EKS cluster name (or pass as positional) |
+| `--nodegroup, -n` | **Required.** Nodegroup name |
+| `--desired` | Desired node count |
+| `--min` | Minimum node count |
+| `--max` | Maximum node count |
+| `--health-check` | Validate cluster health before and after scaling |
+| `--check-pdbs` | Validate Pod Disruption Budgets before scaling down |
+| `--wait` | Wait for the scaling operation to complete |
+| `--op-timeout` | Scaling operation timeout (default `5m`) |
+| `--kubeconfig` | Kubeconfig for workload/PDB checks (defaults to `$KUBECONFIG`, then `~/.kube/config`) |
+| `--dry-run` | Preview the scaling impact without executing |
+| `--timeout, -t` | Operation timeout (env `REFRESH_TIMEOUT`) |
+
+!!! tip "Preview which PDBs would block a scale-down"
+    Combine `--dry-run --check-pdbs` to preview the **specific** Pod Disruption
+    Budgets that would constrain a scale-down — before you touch anything.
+
+### Examples
+
+```bash
+# Scale up to 5 nodes
+refresh nodegroup scale my-cluster -n ng-default --desired 5
+
+# Safe scale-down: preview the PDBs that would constrain it
+refresh nodegroup scale my-cluster -n ng-default --desired 2 --check-pdbs --dry-run
+
+# Scale down for real, gated on PDBs, and wait for it to settle
+refresh nodegroup scale my-cluster -n ng-default --desired 2 --check-pdbs --wait
+```
+
+---
+
+## update
+
+Roll managed nodegroups to the latest recommended AMI, with pre-flight health
+gates and live monitoring. This is the flagship patch command.
+
+```bash
+refresh nodegroup update [cluster] [nodegroup] [flags]
+```
+
+`update` has the alias `update-ami`. Omitting the nodegroup updates all
+nodegroups in the cluster.
+
+!!! note "Custom-AMI nodegroups are skipped"
+    Nodegroups whose AMI is managed via a launch template (`AmiType=CUSTOM`)
+    are detected and **skipped** with guidance: their AMI rolls when you publish
+    a new launch-template version, not via this command.
+
+### Fleet mode
+
+`--all-clusters` discovers clusters across regions (scope with `-r`) and rolls
+them serially with one batch confirmation, an aggregate summary, and a
+**worst-outcome** exit code.
+
+```bash
+refresh nodegroup update --all-clusters --dry-run            # fleet-wide plan
+refresh nodegroup update --all-clusters -r us-east-1 --yes   # execute in one region
+```
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--cluster, -c` | EKS cluster name or partial pattern (overrides kubeconfig; env `EKS_CLUSTER_NAME`) |
+| `--nodegroup, -n` | Nodegroup name or partial pattern (if unset, update all) |
+| `--all-clusters` | Fleet mode: roll matching nodegroups across all discovered clusters (serial); scope with `-r` |
+| `--region, -r` | Region(s) for `--all-clusters` discovery (default: partition EKS regions / `REFRESH_EKS_REGIONS`) |
+| `--dry-run, -d` | Preview changes without executing |
+| `--changelog` | In dry-run, print full `amazon-eks-ami` release notes between the current and target AMI |
+| `--force, -f` | Force the update where possible |
+| `--no-wait` | Don't wait for update completion (start-and-return) |
+| `--quiet, -q` | Minimal output |
+| `--skip-health-check, -s` | Skip pre-flight health validation |
+| `--health-only` | Run the health check only, don't update (exit `0`=pass / `2`=warn / `3`=block) |
+| `--yes, -y` | Assume yes: skip confirmation prompts (multi-match selection, warn-level health) for CI |
+| `--require-healthy` | Treat warn-level health findings as a hard stop (exit `2`) instead of prompting |
+| `--skip-verify` | Skip post-roll verification (nodes ACTIVE, no new stuck pods) |
+| `--kubeconfig` | Kubeconfig for workload/PDB checks (defaults to `$KUBECONFIG`, then `~/.kube/config`) |
+| `--poll-interval, -p` | Polling interval for update status (default `15s`) |
+| `--timeout, -t` | Max time to wait for update completion (default `40m`) |
+| `--format, -o` | `table` (default) or `json` (a JSON run summary) |
+
+!!! warning "Unattended / CI"
+    Without a TTY **and** without `--yes`, a run that would otherwise prompt
+    fails fast. For cron, pair `--yes` with `--require-healthy` and `-o json`.
+
+### Exit-code contract
+
+`nodegroup update` returns a meaningful exit code so unattended runs can branch:
+
+| Code | Meaning |
+|---|---|
+| `0` | Success — updates started/completed as expected |
+| `2` | Health **warnings** (with `--health-only` or `--require-healthy`) |
+| `3` | Health **blocked** — a pre-flight check failed; nothing was rolled |
+| `4` | One or more nodegroup updates **failed to start** |
+| `5` | Post-roll **verification** found issues (nodes not Ready / newly-stuck pods) |
+
+See [Exit codes](../concepts/exit-codes.md) for the full reference and a CI
+`case` example.
+
+### Examples
+
+```bash
+# Preview a single nodegroup roll with the AMI release notes
+refresh nodegroup update my-cluster ng-default --dry-run --changelog
+
+# Roll one nodegroup, requiring a clean health gate
+refresh nodegroup update -c prod -n ng-default --require-healthy
+
+# Health gate only — no roll (CI readiness check)
+refresh nodegroup update -c prod --health-only -o json
+
+# Unattended cron patch with a JSON summary
+refresh nodegroup update -c prod --yes --require-healthy -o json
+
+# Fleet-wide dry-run, then execute
+refresh nodegroup update --all-clusters -r us-east-1 -r us-west-2 --dry-run
+refresh nodegroup update --all-clusters -r us-east-1 -r us-west-2 --yes
+```

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -1,0 +1,35 @@
+# refresh status
+
+Fleet patch posture across clusters and regions — the front door.
+
+```bash
+refresh status [name-pattern] [flags]
+```
+
+Reports, per cluster: Kubernetes version, EKS support window (standard vs.
+extended support, with extended-support cost exposure), stale AMIs, and add-ons
+behind their latest compatible version. Exits non-zero when something needs
+attention, so it doubles as a CI gate.
+
+## Flags
+
+| Flag | Description |
+|---|---|
+| `--all-regions, -A` | Query all EKS-supported regions |
+| `--region, -r` | Specific region(s) to query (repeatable) |
+| `--max-concurrency, -C` | Max concurrent region requests |
+| `--format, -o` | `table` (default), `json`, `yaml`, `plain` |
+| `--timeout, -t` | Operation timeout |
+
+## Examples
+
+```bash
+# Everything, everywhere
+refresh status -A
+
+# Only clusters whose name contains "prod", in two regions
+refresh status prod -r us-east-1 -r us-west-2
+
+# Machine-readable for a dashboard / CI gate
+refresh status -A -o json
+```

--- a/docs/commands/utility.md
+++ b/docs/commands/utility.md
@@ -1,0 +1,92 @@
+# Utility (version / install-man / completion)
+
+Housekeeping commands: print the version, install the man page, and generate
+shell completion scripts.
+
+---
+
+## refresh version
+
+Print the running version (and, for release builds, the commit and build date).
+
+```bash
+refresh version [flags]
+```
+
+| Flag | Description |
+|---|---|
+| `--no-update-check` | Skip the check for a newer release (env `REFRESH_NO_UPDATE_CHECK`) |
+
+!!! note "Opt-in update hint"
+    On an interactive terminal, `version` performs a throttled, fail-silent
+    check against GitHub Releases and prints a one-line hint to **stderr** when a
+    newer release is available. The check runs at most once per day (cached
+    under the user config dir), adds no measurable latency, and is skipped when
+    stdout is piped/redirected or the build is `dev`. Disable it entirely with
+    `--no-update-check` or `REFRESH_NO_UPDATE_CHECK=1`.
+
+```bash
+refresh version
+refresh version --no-update-check
+```
+
+The global `--version` flag prints the same details.
+
+---
+
+## refresh install-man
+
+Generate the man page from the CLI definition and install it to a
+user-accessible directory — no `sudo` required. Works across macOS, Linux, and
+Unix.
+
+```bash
+refresh install-man
+```
+
+Aliased as `install-manpage`. By default the page is written to
+`$HOME/.local/share/man/man1/refresh.1`. If that man directory isn't on your
+`MANPATH`, the command prints the `export MANPATH=...` line to add to your shell
+profile. Once installed:
+
+```bash
+man refresh
+```
+
+---
+
+## refresh completion
+
+Output a shell completion script for `bash`, `zsh`, or `fish`.
+
+```bash
+refresh completion <bash|zsh|fish>
+```
+
+=== "bash"
+
+    ```bash
+    # Load for the current shell
+    source <(refresh completion bash)
+
+    # Or install persistently
+    refresh completion bash > /usr/local/etc/bash_completion.d/refresh
+    ```
+
+=== "zsh"
+
+    ```bash
+    # Write somewhere on your $fpath
+    refresh completion zsh > "${fpath[1]}/_refresh"
+    ```
+
+=== "fish"
+
+    ```bash
+    refresh completion fish > ~/.config/fish/completions/refresh.fish
+    ```
+
+!!! tip "Context-name completion"
+    With completion installed, `refresh use <TAB>` completes saved
+    [context](contexts.md) names straight from your local
+    `context.yaml` — no AWS calls.

--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -1,0 +1,68 @@
+# Configuration & AWS auth
+
+`refresh` uses your existing AWS credentials and (optionally) kubeconfig — there
+is no separate config to bootstrap. This page covers how it resolves the target
+account/region and the global flags and environment variables.
+
+## AWS credential & region resolution
+
+`refresh` resolves the **profile** and **region** in this order (first match
+wins):
+
+1. **Explicit CLI flags** — `--profile` / `--region` (global; work on every
+   command).
+2. **Standard AWS environment variables** — `AWS_PROFILE`, `AWS_REGION` /
+   `AWS_DEFAULT_REGION` (resolved by the AWS SDK).
+3. **The active `refresh` context** — see [Contexts](contexts.md).
+4. **AWS SDK defaults** — `~/.aws/config`, `~/.aws/credentials`, SSO, IMDS, etc.
+
+Flags always win, so you can override the active context for a single
+invocation:
+
+```bash
+refresh status --profile prod --region us-east-1
+```
+
+Credentials themselves come from the standard SDK chain — `refresh` never stores
+them.
+
+## Global flags
+
+These are accepted on every command:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--profile` | — | AWS shared-config profile (overrides the active context) |
+| `--region` | — | AWS region (overrides the active context) |
+| `--timeout, -t` | varies | Per-operation timeout for API calls (e.g. `60s`, `2m`) |
+| `--max-concurrency, -C` | — | Max concurrency for multi-region operations |
+| `--log-level` | `warn` | Log verbosity: `debug`, `info`, `warn`, `error` |
+| `--verbose` | off | Shortcut for `--log-level debug` |
+| `--no-color` | off | Disable colored output (`NO_COLOR` is also honored) |
+
+!!! note
+    Logs go to **stderr**; data goes to **stdout**. Spinners auto-disable when
+    output is piped, and `--log-level debug` surfaces service-level detail
+    (cache hits, retries, fallbacks).
+
+## Environment variables
+
+| Variable | Equivalent / effect |
+|---|---|
+| `AWS_PROFILE`, `AWS_REGION`, `AWS_DEFAULT_REGION` | Standard AWS SDK resolution |
+| `REFRESH_TIMEOUT` | Default for `--timeout` |
+| `REFRESH_MAX_CONCURRENCY` | Default for `--max-concurrency` |
+| `REFRESH_LOG_LEVEL` | Default for `--log-level` |
+| `REFRESH_EKS_REGIONS` | Region set for fleet discovery (`nodegroup update --all-clusters`) |
+| `EKS_CLUSTER_NAME` | Default cluster for `nodegroup update` |
+| `NO_COLOR` | Disable colored output |
+| `REFRESH_NO_UPDATE_CHECK` | Disable the `refresh version` self-update check |
+| `KUBECONFIG` | kubeconfig path for workload/PDB health checks |
+
+## Kubeconfig (optional)
+
+Only the workload-aware pre-flight checks need Kubernetes access — the
+PodDisruptionBudget and critical-workload checks used by `nodegroup update` and
+`nodegroup scale --check-pdbs`. Resolution order is `--kubeconfig` →
+`$KUBECONFIG` → `~/.kube/config`. If the cluster is unreachable, those checks are
+**skipped** (with a diagnostic), not failed.

--- a/docs/concepts/contexts.md
+++ b/docs/concepts/contexts.md
@@ -1,0 +1,36 @@
+# Contexts
+
+`refresh` has a kubectx-style context system so you don't have to repeat
+`--cluster` / `--region` / `--profile` on every command. Contexts are stored in
+a YAML file at `~/.config/refresh/context.yaml`.
+
+A context bundles a **cluster**, and optionally a **region** and **profile**.
+The *active* context fills in those values (unless a flag or AWS env var
+overrides it — see [Configuration & AWS auth](configuration.md)).
+
+## Saving and switching
+
+```bash
+# save a named context
+refresh context add prod --cluster prod-use1 --region us-east-1 --profile prod
+
+# list saved contexts (the active one is marked)
+refresh context list
+
+# switch the active context
+refresh use prod
+
+# show the active context
+refresh current
+```
+
+After `refresh use prod`, commands that take a cluster will default to
+`prod-use1` in `us-east-1` under the `prod` profile:
+
+```bash
+refresh nodegroup list          # uses the active context
+refresh nodegroup list -c other # one-off override, active context untouched
+```
+
+See the [contexts command reference](../commands/contexts.md) for every
+subcommand and flag.

--- a/docs/concepts/exit-codes.md
+++ b/docs/concepts/exit-codes.md
@@ -1,0 +1,43 @@
+# Exit codes
+
+`refresh` uses meaningful exit codes so it slots into CI/cron pipelines.
+
+## General
+
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | A general error (bad flags, AWS error, not found, etc.) |
+
+`refresh status` exits non-zero when the fleet has items needing attention, so
+it works as a gate (e.g. fail a pipeline if anything is on extended support or
+badly behind).
+
+## `nodegroup update`
+
+The patch command has a richer contract so unattended runs can branch on the
+outcome:
+
+| Code | Meaning |
+|---|---|
+| `0` | Success — updates started/completed as expected |
+| `2` | Health **warnings** (with `--health-only` or `--require-healthy`) |
+| `3` | Health **blocked** — a pre-flight check failed; nothing was rolled |
+| `4` | One or more nodegroup updates **failed to start** |
+| `5` | Post-roll **verification** found issues (nodes not Ready / newly-stuck pods) |
+
+Example CI usage:
+
+```bash
+refresh nodegroup update -c prod --yes --require-healthy -o json
+case $? in
+  0) echo "patched cleanly" ;;
+  2) echo "health warnings — review" ;;
+  3) echo "blocked by health — do not proceed" ;;
+  4) echo "some updates failed to start" ;;
+  5) echo "rolled, but verification flagged issues" ;;
+esac
+```
+
+See [`nodegroup update`](../commands/nodegroup.md#update) for the flags that
+drive these (`--health-only`, `--require-healthy`, `--skip-verify`).

--- a/docs/concepts/lifecycle.md
+++ b/docs/concepts/lifecycle.md
@@ -1,0 +1,63 @@
+# The upgrade lifecycle
+
+`refresh` is organized around a four-stage loop. Each stage has a command (or a
+small group), and each builds on the previous one.
+
+```
+   status  ─►  upgrade-check  ─►  nodegroup/addon update  ─►  cluster upgrade
+ (what's       (am I ready?)      (patch safely)              (orchestrate)
+  stale?)
+```
+
+## 1. Status — what's stale?
+
+[`refresh status`](../commands/status.md) is the front door. It fans out across
+clusters and regions and summarizes patch posture: Kubernetes version, the EKS
+support window (standard vs. extended support, with the extended-support cost
+exposure), stale AMIs, and add-ons behind their latest compatible version.
+
+It's designed to run in CI: a non-zero exit means "something needs attention."
+
+## 2. Readiness — am I safe to upgrade?
+
+[`refresh cluster upgrade-check`](../commands/cluster.md#upgrade-check) answers
+"can I bump the control plane?" It combines **EKS Cluster Insights** (the
+upstream-deprecation / config checks AWS surfaces in the console) with a local
+**version-skew** analysis. It is strictly read-only.
+
+## 3. Patch — roll it, safely
+
+This is the heart of the tool:
+
+- [`refresh nodegroup update`](../commands/nodegroup.md#update) rolls managed
+  nodegroups to the latest recommended AMI.
+- [`refresh addon update`](../commands/addon.md#update) updates EKS add-ons.
+
+Both run **pre-flight health gates** first (capacity, node readiness,
+PodDisruptionBudgets, critical workloads), support **dry-run** previews
+(including the AMI changelog), stream **live progress**, and — for nodegroup
+rolls — run **post-roll verification** that nodes returned Ready with no
+newly-stuck pods.
+
+The patch stage is also where the **safety story** lives:
+
+- **Health gates** block a roll when the cluster isn't healthy enough.
+- **`--dry-run`** shows exactly what would change.
+- **Idempotency** — mutating calls carry a client request token, so a retried
+  request can't trigger a second disruptive rollout.
+- **Custom-AMI awareness** — nodegroups whose AMI is managed via a launch
+  template are detected and skipped with guidance, not rolled blindly.
+
+## 4. Upgrade — orchestrate the whole thing
+
+[`refresh cluster upgrade`](../commands/cluster.md#upgrade) sequences a full
+cluster upgrade: **control plane → add-ons → nodegroups**, with a health gate
+after each phase. It's resumable by re-deriving the plan from live cluster
+state (no state files to corrupt).
+
+## Supporting surface
+
+Around the loop sit the everyday read commands — `cluster list/describe`,
+`nodegroup list/describe`, `addon list/describe` — plus `nodegroup scale` and
+kubectx-style [contexts](contexts.md). These don't mutate the upgrade path; they
+help you see and operate the fleet.

--- a/docs/concepts/output.md
+++ b/docs/concepts/output.md
@@ -1,0 +1,44 @@
+# Output formats
+
+Every list/describe command (and most others) supports `-o` / `--format`:
+
+| Format | Use it for |
+|---|---|
+| `table` *(default)* | Human-readable, colored terminal tables |
+| `json` | Scripting; stable camelCase keys |
+| `yaml` | Scripting; same keys as JSON |
+| `plain` | Uncolored, tab-separated values for `grep`/`awk`/`cut` |
+| `tree` | Hierarchical region → cluster view (**`cluster list` only**) |
+
+```bash
+refresh cluster list -o json | jq '.[] | select(.status=="ACTIVE") .name'
+refresh nodegroup list -c prod -o plain | awk -F'\t' '{print $1, $4}'
+refresh cluster list -o tree
+```
+
+!!! warning "Unknown formats fail fast"
+    An unrecognized `-o` value (a typo like `-o jsom`, or `-o xml`) is rejected
+    with a clear error and a non-zero exit — it will **not** silently fall back
+    to a table. This protects scripts that expect JSON.
+
+## Key consistency
+
+`json` and `yaml` emit the **same** camelCase keys (e.g. `instanceType`,
+`createdAt`), so `jq '.instanceType'` and `yq '.instanceType'` both work.
+
+## `plain` is robust TSV
+
+`plain` strips ANSI color and neutralizes any embedded tabs/newlines in a cell,
+so one logical row is always exactly one well-formed TSV line — safe for
+`awk -F'\t'`.
+
+## Color
+
+Color auto-disables when stdout is piped. Force it off with `--no-color` or the
+`NO_COLOR` environment variable.
+
+## Watch mode
+
+`cluster list`, `nodegroup list`, and `addon list` support `--watch`
+(with `--watch-interval`, default `10s`): top-style redraw on a terminal,
+append-only when piped.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,99 @@
+# Installation
+
+`refresh` ships as a single static binary (no runtime dependencies) for Linux,
+macOS, and Windows on amd64 and arm64.
+
+## Homebrew (macOS / Linux)
+
+```bash
+brew install dantech2000/tap/refresh
+# upgrade later with:
+brew upgrade dantech2000/tap/refresh
+```
+
+## go install
+
+Requires Go **1.26+**:
+
+```bash
+go install github.com/dantech2000/refresh@latest
+```
+
+The binary lands in `$(go env GOPATH)/bin` — make sure that's on your `PATH`.
+
+## Pre-built binary (with signature verification)
+
+Download the archive for your platform from the
+[releases page](https://github.com/dantech2000/refresh/releases/latest), then
+verify it before use.
+
+Release artifacts are checksummed, and the checksums file is signed with
+[cosign](https://github.com/sigstore/cosign) using keyless (OIDC) signing — no
+long-lived keys. Verify the checksum signature, then the archive:
+
+```bash
+# 1) verify the signed checksums file
+cosign verify-blob \
+  --certificate checksums.txt.pem \
+  --signature checksums.txt.sig \
+  --certificate-identity-regexp 'https://github.com/dantech2000/refresh' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  checksums.txt
+
+# 2) verify your downloaded archive against the (now-trusted) checksums
+sha256sum --check --ignore-missing checksums.txt
+
+# 3) extract and install
+tar -xzf refresh_*_$(uname -s)_$(uname -m).tar.gz
+sudo mv refresh /usr/local/bin/
+```
+
+!!! tip "macOS Gatekeeper"
+    The Homebrew cask clears the quarantine attribute automatically. For a
+    manually-downloaded binary you may need:
+    `xattr -dr com.apple.quarantine /usr/local/bin/refresh`.
+
+## Shell completion
+
+`refresh` generates completion scripts for bash, zsh, and fish:
+
+=== "zsh"
+
+    ```bash
+    refresh completion zsh > "${fpath[1]}/_refresh"
+    # then restart your shell
+    ```
+
+=== "bash"
+
+    ```bash
+    refresh completion bash | sudo tee /etc/bash_completion.d/refresh > /dev/null
+    ```
+
+=== "fish"
+
+    ```bash
+    refresh completion fish > ~/.config/fish/completions/refresh.fish
+    ```
+
+## Man page
+
+```bash
+refresh install-man   # installs to your man path (no sudo required)
+man refresh
+```
+
+## Prerequisites
+
+- **AWS credentials** via the standard chain (env vars, shared config/profiles,
+  SSO, or an instance/role profile). See
+  [Configuration & AWS auth](../concepts/configuration.md).
+- **A kubeconfig** *(optional)* — only needed for the workload/PDB pre-flight
+  health checks (`nodegroup update`, `nodegroup scale --check-pdbs`). Without
+  it, kube-dependent checks degrade gracefully to "skipped".
+
+## Verify the install
+
+```bash
+refresh version
+```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,66 @@
+# Quickstart
+
+This walks through one full pass of the upgrade loop against a real account.
+Everything here is read-only or dry-run until you opt in.
+
+!!! note "Prerequisites"
+    Working AWS credentials (`aws sts get-caller-identity` succeeds) and — for
+    the workload/PDB health checks — a kubeconfig pointing at the cluster.
+
+## 1. See what's stale
+
+```bash
+refresh status -A
+```
+
+`status` fans out across regions and reports, per cluster: Kubernetes version,
+EKS support window (and extended-support cost exposure), stale AMIs, and add-ons
+that are behind. It exits non-zero when something needs attention, so it doubles
+as a CI gate.
+
+## 2. Check upgrade readiness
+
+```bash
+refresh cluster upgrade-check -c prod
+```
+
+This pulls **EKS Cluster Insights** (the same checks the AWS console runs) plus a
+local version-skew analysis, and tells you whether the control plane is safe to
+bump. It's read-only.
+
+## 3. Preview a nodegroup patch
+
+```bash
+# What would change? Include the AMI release notes between current and target.
+refresh nodegroup update -c prod --dry-run --changelog
+```
+
+Dry-run shows the planned action per nodegroup (update / skip-if-latest /
+custom-AMI-skip) without touching anything.
+
+## 4. Patch with health gates
+
+```bash
+refresh nodegroup update -c prod
+```
+
+Before rolling, `refresh` runs pre-flight health checks (capacity, node
+readiness, PDBs, critical workloads). It rolls the managed nodegroups to the
+latest recommended AMI, streams live progress, and then verifies nodes came back
+Ready with no newly-stuck pods.
+
+## 5. Patch the add-ons
+
+```bash
+refresh addon update --all --dependency-order --wait
+```
+
+Updates every add-on to its latest compatible version, in a dependency-safe
+order (vpc-cni → coredns/kube-proxy → others).
+
+## Where to go next
+
+- [The upgrade lifecycle](../concepts/lifecycle.md) — how the four stages fit together.
+- [Configuration & AWS auth](../concepts/configuration.md) — profiles, regions, contexts, env vars.
+- [Cookbook](../usage/cookbook.md) — fleet mode, unattended/CI runs, scaling, and more.
+- [Command reference](../commands/index.md) — every command and flag.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,82 @@
+# refresh — the EKS upgrade companion
+
+`refresh` is a Go CLI for the **EKS cluster upgrade and patching lifecycle**.
+It turns "I think we're behind on patches" into a safe, repeatable loop:
+
+<div class="grid cards" markdown>
+
+- :material-radar: **Status** — *what's stale across the fleet?*
+
+    `refresh status` reports patch posture across every cluster and region:
+    version skew, stale AMIs, add-ons behind, and extended-support exposure.
+
+- :material-clipboard-check: **Readiness** — *am I safe to upgrade?*
+
+    `refresh cluster upgrade-check` reads EKS Cluster Insights and the local
+    version-skew picture. Read-only; it mutates nothing.
+
+- :material-update: **Patch** — *roll it, safely*
+
+    `refresh nodegroup update` / `refresh addon update` patch with pre-flight
+    health gates, dry-run previews, live monitoring, and post-roll verification.
+
+- :material-layers-triple: **Upgrade** — *orchestrate the whole thing*
+
+    `refresh cluster upgrade` sequences control plane → add-ons → nodegroups,
+    with a health gate after every phase.
+
+</div>
+
+## Why refresh
+
+The product is the **upgrade workflow**, with safety first:
+
+- **Pre-flight health gates** — capacity, node readiness, PodDisruptionBudgets,
+  and critical-workload checks run *before* anything mutates.
+- **Dry-run everything** — preview exactly what would change (including the AMI
+  changelog and which PDBs would constrain a scale-down) before you commit.
+- **Live monitoring + verification** — watch rollouts in real time, then confirm
+  nodes came back Ready with no newly-stuck pods.
+- **Built for CI/cron** — unattended flags, machine-readable output, and a
+  documented exit-code contract.
+
+It intentionally does **not** try to be a general EKS browser or a cost tool —
+that's `k9s`/the console/Kubecost territory. `refresh` does the upgrade loop well.
+
+## Install
+
+=== "Homebrew"
+
+    ```bash
+    brew install dantech2000/tap/refresh
+    ```
+
+=== "go install"
+
+    ```bash
+    go install github.com/dantech2000/refresh@latest
+    ```
+
+See the [installation guide](getting-started/installation.md) for binary
+downloads (with signature verification), shell completion, and the man page.
+
+## A 30-second tour
+
+```bash
+# What's stale across all regions?
+refresh status -A
+
+# Am I ready to upgrade prod?
+refresh cluster upgrade-check -c prod
+
+# Preview a nodegroup AMI roll (with release notes), then do it
+refresh nodegroup update -c prod --dry-run --changelog
+refresh nodegroup update -c prod --yes --require-healthy
+
+# Patch every add-on, in dependency-safe order
+refresh addon update --all --dependency-order --wait
+```
+
+Next: the [quickstart](getting-started/quickstart.md) walks through a first run
+end to end, and [the upgrade lifecycle](concepts/lifecycle.md) explains how the
+four stages fit together.

--- a/docs/usage/cookbook.md
+++ b/docs/usage/cookbook.md
@@ -1,0 +1,175 @@
+# Cookbook
+
+Task-oriented, copy-pasteable workflows that string the commands together. Each
+recipe follows the `refresh` loop: **status → readiness → patch → upgrade**. See
+the [upgrade lifecycle](../concepts/lifecycle.md) for the why.
+
+---
+
+## Fleet posture: what's stale, everywhere
+
+Start every session here. One table, all clusters, all regions — Kubernetes
+version, support window, stale AMIs, and add-ons behind latest.
+
+```bash
+# The front door
+refresh status -A
+
+# Narrow to "prod" clusters in two regions
+refresh status prod -r us-east-1 -r us-west-2
+
+# Machine-readable for a dashboard
+refresh status -A -o json
+```
+
+`status` exits non-zero when the fleet needs attention, so it doubles as a CI
+gate. See [`refresh status`](../commands/status.md).
+
+---
+
+## Readiness: am I safe to upgrade?
+
+A read-only pre-flight that surfaces AWS Cluster Insights plus control-plane vs.
+nodegroup/add-on version skew. Nothing is mutated.
+
+```bash
+refresh cluster upgrade-check -c prod-east
+
+# Include passing checks, as JSON for a gate
+refresh cluster upgrade-check -c prod-east --show-passing -o json
+
+# Drill into a flagged insight
+refresh cluster upgrade-check -c prod-east --id <insight-id>
+```
+
+See [`cluster upgrade-check`](../commands/cluster.md#upgrade-check).
+
+---
+
+## Patch a single nodegroup
+
+Always preview first. `--changelog` prints the `amazon-eks-ami` release notes
+between the current and target AMI so you know what's changing.
+
+```bash
+# Preview the roll + read the AMI changelog
+refresh nodegroup update prod-east ng-default --dry-run --changelog
+
+# Roll it, requiring a clean health gate
+refresh nodegroup update prod-east ng-default --require-healthy
+```
+
+See [`nodegroup update`](../commands/nodegroup.md#update).
+
+---
+
+## Patch the whole fleet
+
+Fleet mode discovers clusters across regions and rolls them serially with one
+batch confirmation and a worst-outcome exit code. Dry-run, eyeball, then commit.
+
+```bash
+# Fleet-wide plan
+refresh nodegroup update --all-clusters -r us-east-1 -r us-west-2 --dry-run
+
+# Execute once the plan looks right
+refresh nodegroup update --all-clusters -r us-east-1 -r us-west-2 --yes
+```
+
+---
+
+## Unattended / CI patch
+
+For cron, suppress prompts with `--yes`, treat health warnings as a hard stop
+with `--require-healthy`, and emit a JSON summary with `-o json`. Branch on the
+[exit code](../concepts/exit-codes.md).
+
+```bash
+refresh nodegroup update -c prod --yes --require-healthy -o json
+case $? in
+  0) echo "patched cleanly" ;;
+  2) echo "health warnings — review" ;;
+  3) echo "blocked by health — do not proceed" ;;
+  4) echo "some updates failed to start" ;;
+  5) echo "rolled, but verification flagged issues" ;;
+esac
+```
+
+!!! warning "TTY-less runs need `--yes`"
+    Without a terminal and without `--yes`, a run that would otherwise prompt
+    fails fast — so CI never hangs waiting on stdin.
+
+---
+
+## Update add-ons safely
+
+Update every add-on in dependency-safe order (`vpc-cni` → `coredns`/`kube-proxy`
+→ others), waiting for each to settle before the next.
+
+```bash
+refresh addon update prod-east --all --dependency-order --wait
+
+# Skip an add-on you manage via Helm/GitOps
+refresh addon update prod-east --all --dependency-order --wait --skip aws-load-balancer-controller
+```
+
+See [`addon update`](../commands/addon.md#update).
+
+---
+
+## Safe scale-down
+
+Scaling down can strand pods behind a PodDisruptionBudget. Preview the exact PDBs
+that would constrain the operation before touching anything.
+
+```bash
+# Preview the constraining PDBs (no changes)
+refresh nodegroup scale prod-east -n ng-default --desired 2 --check-pdbs --dry-run
+
+# Scale down for real, gated on PDBs, waiting for it to settle
+refresh nodegroup scale prod-east -n ng-default --desired 2 --check-pdbs --wait
+```
+
+See [`nodegroup scale`](../commands/nodegroup.md#scale).
+
+---
+
+## Stop repeating `--region` / `--profile`
+
+Save your environments once as [contexts](../commands/contexts.md), then switch
+by name. The active context fills in cluster/region/profile defaults.
+
+```bash
+refresh context add prod  --cluster prod-eks  --region us-east-1 --profile prod
+refresh context add stage --cluster stage-eks --region us-west-2 --profile stage
+
+refresh use prod
+refresh nodegroup list           # targets prod-eks / us-east-1 / prod
+refresh cluster upgrade-check    # same context, no flags
+
+refresh use stage                # flip the whole environment
+```
+
+---
+
+## Orchestrate a full cluster upgrade
+
+When you're ready to move a minor version, let `refresh` sequence the whole
+thing: control plane → add-ons → nodegroups, with a health gate after every
+phase. EKS upgrades one minor at a time, so a multi-minor jump expands into
+sequential hops. Always dry-run first.
+
+```bash
+# Print the ordered plan (exits non-zero if anything blocks)
+refresh cluster upgrade -c prod-east --to 1.33 --dry-run
+
+# Execute, confirming each mutating phase
+refresh cluster upgrade -c prod-east --to 1.33
+
+# Non-interactive run, skipping a Helm-managed add-on
+refresh cluster upgrade -c prod-east --to 1.33 --yes --skip aws-load-balancer-controller
+```
+
+The plan is re-derived from live state on every run, so rerunning after a
+failure (or Ctrl+C) resumes where it left off. See
+[`cluster upgrade`](../commands/cluster.md#upgrade).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: refresh — the EKS upgrade companion
 site_description: >-
   Documentation for refresh, the EKS upgrade companion: a Go CLI for the
   cluster upgrade/patching lifecycle — status, readiness, patch, upgrade.
-site_url: https://dantech2000.github.io/refresh/
+site_url: https://drod.dev/refresh/
 repo_url: https://github.com/dantech2000/refresh
 repo_name: dantech2000/refresh
 edit_uri: edit/main/docs/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,107 @@
+site_name: refresh — the EKS upgrade companion
+site_description: >-
+  Documentation for refresh, the EKS upgrade companion: a Go CLI for the
+  cluster upgrade/patching lifecycle — status, readiness, patch, upgrade.
+site_url: https://dantech2000.github.io/refresh/
+repo_url: https://github.com/dantech2000/refresh
+repo_name: dantech2000/refresh
+edit_uri: edit/main/docs/
+copyright: Copyright &copy; Daniel Rodriguez
+
+# Source markdown lives in docs/; the built site goes to site/ (gitignored).
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle: { icon: material/brightness-auto, name: Switch to light mode }
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle: { icon: material/brightness-7, name: Switch to dark mode }
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle: { icon: material/brightness-4, name: Switch to system preference }
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.indexes
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+    - content.action.edit
+
+plugins:
+  - search
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.snippets:
+      base_path: ["."]
+      check_paths: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/dantech2000/refresh
+
+nav:
+  - Home: index.md
+  - Getting started:
+      - Installation: getting-started/installation.md
+      - Quickstart: getting-started/quickstart.md
+  - Concepts:
+      - The upgrade lifecycle: concepts/lifecycle.md
+      - Configuration & AWS auth: concepts/configuration.md
+      - Contexts: concepts/contexts.md
+      - Output formats: concepts/output.md
+      - Exit codes: concepts/exit-codes.md
+  - Commands:
+      - Overview: commands/index.md
+      - refresh status: commands/status.md
+      - cluster: commands/cluster.md
+      - nodegroup: commands/nodegroup.md
+      - addon: commands/addon.md
+      - Contexts (use/current/context): commands/contexts.md
+      - Utility (version/man/completion): commands/utility.md
+  - Usage & examples:
+      - Cookbook: usage/cookbook.md
+      - Migrating from eksctl / aws CLI: migration.md
+  - Changelog: changelog.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+# Documentation-site tooling only (Material for MkDocs). This is NOT a Python
+# package and has nothing to do with the Go module — it exists so `uv` can
+# manage a reproducible, hash-locked virtual env for building the docs site.
+# See docs/ for content and mkdocs.yml for site config. (REF-106)
+[project]
+name = "refresh-docs"
+version = "0"
+description = "Documentation site for the refresh CLI — Material for MkDocs"
+requires-python = ">=3.11"
+dependencies = [
+    "mkdocs-material>=9.5,<10",
+]
+
+[tool.uv]
+# Docs tooling only — don't try to build/install this dir as a package.
+package = false

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,546 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/a7dd63622beef68cc0d3c3c36d472e143dd95443d5ebf14cd1a5b4dfbf11/backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82", size = 7012453, upload-time = "2026-04-28T16:28:04.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/39/39a31d7eae729ea14ed10c3ccef79371197177b9355a86cb3525709e8502/backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9", size = 380824, upload-time = "2026-04-28T16:27:55.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b5/9302644225ba7dfa934a2ff2b9c7bb85701313a90dddb3dfaf693fa5bae2/backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475", size = 392626, upload-time = "2026-04-28T16:27:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/36/da/87912ddec6e06feffbaa3d7aa18fc6352bee2e8f1fee185d7d1690f8f4e8/backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12", size = 398537, upload-time = "2026-04-28T16:27:58.913Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bb/90ba423612b6aa0adccc6b1874bcd4a9b44b660c0c16f346611e00f64ac3/backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a", size = 400491, upload-time = "2026-04-28T16:28:00.928Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5c/fb93d3092640a24dfb7bd7727a24016d7c01774ca013e60efd3f683c8002/backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9", size = 412349, upload-time = "2026-04-28T16:28:02.412Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pymdown-extensions"
+version = "10.21.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "refresh-docs"
+version = "0"
+source = { virtual = "." }
+dependencies = [
+    { name = "mkdocs-material" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "mkdocs-material", specifier = ">=9.5,<10" }]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]


### PR DESCRIPTION
First slice of the documentation site (Phase 10 / epic **REF-105**). **Material for MkDocs**, in-repo under `docs/`, with a **uv-managed, hash-locked** virtual env so the Python build surface is reproducible and tamper-evident — the supply-chain priority baked in from the start.

## Tooling
- **`pyproject.toml` + `uv.lock`** — 30 packages, `mkdocs-material 9.7.x`, **271 hashes**. Builds run `uv sync --frozen` / `uv run --frozen mkdocs …` (reproducible, no floating deps).
- **`mkdocs.yml`** — Material theme (light/dark, instant nav, built-in search), pymdownx extensions (admonitions, content tabs, superfences, snippets), full nav.
- **Taskfile** — `task docs:serve` (live reload), `task docs:build` (strict).
- **`.gitignore`** — built `site/` and `.venv/` ignored; `pyproject.toml` + `uv.lock` committed.

## Content — 18 pages, ~9.7k words, `mkdocs build --strict` clean
- **Home / overview**, **Getting started** (installation incl. cosign signature verification; quickstart).
- **Concepts** — the upgrade lifecycle, configuration & AWS auth precedence, contexts, output formats, the exit-code contract.
- **Command reference** — `status`, `cluster`, `nodegroup`, `addon`, contexts, utility. Hand-written from the actual `command.go` definitions (flags/aliases/defaults verified against source), as the bridge until the **generated** reference lands (REF-108).
- **Usage cookbook** + the existing eksctl/aws-cli **migration guide** wired into the nav.
- **Changelog** page embeds the repo `CHANGELOG.md` via snippets (auto-updates).

## Supply chain
The moderate Python surface is fully hash-pinned (`uv.lock`), and the hardened, isolated **Pages deploy workflow** (split build/deploy, no tokens in the build job, SHA-pinned actions, harden-runner) is its own follow-up — **REF-107**.

No Go code touched; `go build` / `gofmt` unaffected. Preview locally with `task docs:serve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)