### PR TITLE
ci: lean + harden the PR pipeline (concurrency, dedup, pinned actions, tamed auto-review)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
       # let major bumps through because `.*` swallowed the major component. (REF-60)
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -39,7 +39,7 @@ jobs:
       # the build/tests but passes lint must NOT auto-merge. (REF-60)
       - name: Wait for Test check
         if: steps.check.outputs.eligible == 'true'
-        uses: fountainhead/action-wait-for-check@v1.2.0
+        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
         id: wait-test
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Wait for Lint check
         if: steps.check.outputs.eligible == 'true'
-        uses: fountainhead/action-wait-for-check@v1.2.0
+        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
         id: wait-lint
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,79 +1,49 @@
 name: Claude Code Review
 
+# Automated review, ONCE per PR when it's opened — not on every push. This keeps
+# the API usage (and the check) sane; push an `@claude` comment any time you want
+# a re-review (see claude.yml). Drafts, Dependabot, and [skip-review]/[WIP] PRs
+# are skipped.
 on:
   pull_request:
-    # Re-review when new commits are pushed to the PR, not just on open. (REF-75)
-    types: [opened, synchronize, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    types: [opened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]' &&
+      !contains(github.event.pull_request.title, '[skip-review]') &&
+      !contains(github.event.pull_request.title, '[WIP]')
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        id: claude-review
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
-          # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-            
-            Be constructive and helpful in your feedback.
-
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
-          
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
-
+            Review this PR for a Go CLI (urfave/cli v3) that patches/upgrades AWS
+            EKS clusters. Focus on:
+            - Correctness bugs and edge cases (especially around AWS calls,
+              concurrency, and context cancellation).
+            - Idempotency on mutating calls and error handling.
+            - Test coverage for new logic.
+            - Security / supply-chain concerns.
+            Be concise and concrete; skip nits already enforced by golangci-lint.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,22 +6,29 @@ on:
   pull_request:
     branches: ["main", "master"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   golangci-lint:
     name: Run golangci-lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: v2.12.2
           args: --timeout=5m

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,27 +6,35 @@ on:
   pull_request:
     branches: ["main", "master"]
 
+# Cancel superseded runs when new commits are pushed to the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run go test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           # Resolve the Go version from go.mod so CI never drifts from the
-          # module's declared toolchain. (REF-72)
+          # module's declared toolchain.
           go-version-file: go.mod
           cache: true
 
       - name: Build
         run: go build ./...
 
-      - name: Vet
-        run: go vet ./...
+      # `go vet` is intentionally NOT a separate step — golangci-lint's `govet`
+      # linter (lint.yml) covers it.
 
       - name: Docs command reference is up to date
         run: |
@@ -41,7 +49,7 @@ jobs:
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           files: coverage.out
           flags: unittests
@@ -54,15 +62,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
 
       - name: govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
           govulncheck ./...


### PR DESCRIPTION
Cleanup pass on CI per the "is it overkill?" review. Net: leaner, cheaper, and more consistent — without losing the gates that matter.

## Changes
| # | Change | Why |
|---|---|---|
| 1 | **Auto Claude review → once per PR** (`opened`/`ready_for_review`, not every push); skips drafts, Dependabot, `[skip-review]`/`[WIP]` | Removes per-push **Anthropic API** charges and the flaky per-push `claude-review` check. On-demand `@claude` still works. |
| 2 | **Concurrency** on test + lint (`cancel-in-progress`) | Cancels superseded runs when you push again — no stacked runs. |
| 3 | **Dropped the duplicate `go vet` step** | `golangci-lint`'s `govet` already runs it. |
| 4 | **Pinned `govulncheck` to v1.3.0** | Was `@latest` — ironic for a supply-chain-conscious repo. |
| 5 | **SHA-pinned every action** in test/lint/claude×2/auto-merge | Matches `docs.yml`; tags are mutable. Dependabot keeps them updated. (`claude-code-action@beta` intentionally left — fast-moving beta.) |
| 6 | `permissions: contents: read` on test/lint | Least privilege. |

## Kept (justified — not overkill)
`go test -race` + coverage (this code fans out concurrent AWS mutations), `govulncheck` (caught real x/net CVEs this session), `golangci-lint`, the docs-reference freshness check, and Dependabot auto-merge.

## "Automate more" — already in place / available
- **Dependabot** (gomod + github-actions + pip) + **auto-merge** (patch/minor, gated on Test+Lint, blocks majors) — fully automated dep updates.
- **release-please** + **GoReleaser** (signing/SBOM) — automated releases.
- **Docs** auto-build + deploy on every `docs/**` merge.

This PR exercises the new config on itself (test/lint with concurrency + pins; one Claude review on open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)