### PR TITLE
fix: harden defensive nil-checks and input validation (REF-115, REF-116, REF-117)

### DIFF
--- a/internal/aws/nodegroup.go
+++ b/internal/aws/nodegroup.go
@@ -126,6 +126,9 @@ func getNodegroupInfo(
 	}
 
 	ng := ngDesc.Nodegroup
+	if ng == nil {
+		return refreshTypes.NodegroupInfo{}, fmt.Errorf("empty DescribeNodegroup response for %s", ngName)
+	}
 	currentAmi := CurrentAmiID(ctx, ng, ec2Client, autoscalingClient)
 	info := refreshTypes.NodegroupInfo{
 		Name:         aws.ToString(ng.NodegroupName),

--- a/internal/commands/nodegroup/actions_scale.go
+++ b/internal/commands/nodegroup/actions_scale.go
@@ -3,6 +3,7 @@ package nodegroup
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
@@ -49,7 +50,18 @@ func runScale(ctx context.Context, cmd *cli.Command) error {
 		DryRun:      cmd.Bool("dry-run"),
 	}
 
-	desired, minSize, maxSize := int32PtrIfSet(cmd, "desired"), int32PtrIfSet(cmd, "min"), int32PtrIfSet(cmd, "max")
+	desired, err := int32PtrIfSet(cmd, "desired")
+	if err != nil {
+		return err
+	}
+	minSize, err := int32PtrIfSet(cmd, "min")
+	if err != nil {
+		return err
+	}
+	maxSize, err := int32PtrIfSet(cmd, "max")
+	if err != nil {
+		return err
+	}
 
 	if opts.DryRun {
 		// With --check-pdbs, surface the actual PDBs that would constrain a
@@ -140,11 +152,17 @@ func printScaleDownPDBImpact(pdbs []health.PDBInfo) {
 }
 
 // int32PtrIfSet returns &v for cmd.Int(name) when the flag was explicitly set,
-// otherwise nil.
-func int32PtrIfSet(cmd *cli.Command, name string) *int32 {
+// otherwise nil. It rejects values outside [0, math.MaxInt32] so a too-large
+// count can't silently wrap to a negative/garbage size in the mutating
+// UpdateNodegroupConfig call.
+func int32PtrIfSet(cmd *cli.Command, name string) (*int32, error) {
 	if !cmd.IsSet(name) {
-		return nil
+		return nil, nil
 	}
-	v := int32(cmd.Int(name))
-	return &v
+	v := cmd.Int(name)
+	if v < 0 || v > math.MaxInt32 {
+		return nil, fmt.Errorf("--%s must be between 0 and %d, got %d", name, math.MaxInt32, v)
+	}
+	out := int32(v)
+	return &out, nil
 }

--- a/internal/commands/nodegroup/actions_update.go
+++ b/internal/commands/nodegroup/actions_update.go
@@ -406,6 +406,11 @@ func startNodegroupUpdates(ctx context.Context, awsCfg aws.Config, eksClient *ek
 			outcomes.Failed = append(outcomes.Failed, ng)
 			continue
 		}
+		if desc.Nodegroup == nil {
+			color.Red("Failed to describe nodegroup %s: empty response", ng)
+			outcomes.Failed = append(outcomes.Failed, ng)
+			continue
+		}
 		// Custom-AMI nodegroups: EKS doesn't manage the AMI (it lives in the
 		// user's launch template), so UpdateNodegroupVersion can't pick a
 		// recommended AMI. Skip with clear guidance instead of mis-rolling.
@@ -439,6 +444,11 @@ func startNodegroupUpdates(ctx context.Context, awsCfg aws.Config, eksClient *ek
 		})
 		if err != nil {
 			color.Red("Failed to update nodegroup %s: %v", ng, err)
+			outcomes.Failed = append(outcomes.Failed, ng)
+			continue
+		}
+		if resp.Update == nil || resp.Update.Id == nil {
+			color.Red("Update for nodegroup %s returned no update ID", ng)
 			outcomes.Failed = append(outcomes.Failed, ng)
 			continue
 		}

--- a/internal/commands/nodegroup/output_test.go
+++ b/internal/commands/nodegroup/output_test.go
@@ -217,16 +217,20 @@ func TestPrintChangelog_FullShowsAll(t *testing.T) {
 
 func TestInt32PtrIfSet(t *testing.T) {
 	var got *int32
+	var gotErr error
 	cmd := &cli.Command{
 		Name:  "test",
 		Flags: []cli.Flag{&cli.IntFlag{Name: "desired"}},
 		Action: func(_ context.Context, c *cli.Command) error {
-			got = int32PtrIfSet(c, "desired")
+			got, gotErr = int32PtrIfSet(c, "desired")
 			return nil
 		},
 	}
 	if err := cmd.Run(context.Background(), []string{"test", "--desired", "7"}); err != nil {
 		t.Fatal(err)
+	}
+	if gotErr != nil {
+		t.Fatalf("set flag: unexpected error %v", gotErr)
 	}
 	if got == nil || *got != 7 {
 		t.Errorf("set flag: got %v, want 7", got)
@@ -237,14 +241,38 @@ func TestInt32PtrIfSet(t *testing.T) {
 		Name:  "test",
 		Flags: []cli.Flag{&cli.IntFlag{Name: "desired"}},
 		Action: func(_ context.Context, c *cli.Command) error {
-			got = int32PtrIfSet(c, "desired")
+			got, gotErr = int32PtrIfSet(c, "desired")
 			return nil
 		},
 	}
 	if err := cmd2.Run(context.Background(), []string{"test"}); err != nil {
 		t.Fatal(err)
 	}
+	if gotErr != nil {
+		t.Fatalf("unset flag: unexpected error %v", gotErr)
+	}
 	if got != nil {
 		t.Errorf("unset flag: got %v, want nil", got)
+	}
+
+	// Out-of-range value must error instead of silently wrapping to int32.
+	got = nil
+	gotErr = nil
+	cmd3 := &cli.Command{
+		Name:  "test",
+		Flags: []cli.Flag{&cli.IntFlag{Name: "desired"}},
+		Action: func(_ context.Context, c *cli.Command) error {
+			got, gotErr = int32PtrIfSet(c, "desired")
+			return nil
+		},
+	}
+	if err := cmd3.Run(context.Background(), []string{"test", "--desired", "3000000000"}); err != nil {
+		t.Fatal(err)
+	}
+	if gotErr == nil {
+		t.Errorf("out-of-range flag: expected an error, got nil (value %v)", got)
+	}
+	if got != nil {
+		t.Errorf("out-of-range flag: got %v, want nil", got)
 	}
 }

--- a/internal/commands/nodegroup/verify.go
+++ b/internal/commands/nodegroup/verify.go
@@ -65,6 +65,10 @@ func verifyPostRoll(ctx context.Context, eksClient nodegroupDescriber, k8sClient
 			v.Issues = append(v.Issues, fmt.Sprintf("%s: could not describe after roll: %v", ng, err))
 			continue
 		}
+		if desc.Nodegroup == nil {
+			v.Issues = append(v.Issues, fmt.Sprintf("%s: empty describe response after roll", ng))
+			continue
+		}
 		if desc.Nodegroup.Status == ekstypes.NodegroupStatusActive {
 			v.Checks = append(v.Checks, fmt.Sprintf("nodegroup %s is ACTIVE", ng))
 		} else {

--- a/internal/health/nodes.go
+++ b/internal/health/nodes.go
@@ -62,6 +62,10 @@ func (hc *HealthChecker) CheckNodeHealth(ctx context.Context, clusterName string
 		}
 
 		nodegroup := ngDesc.Nodegroup
+		if nodegroup == nil {
+			result.Details = append(result.Details, fmt.Sprintf("Empty describe response for nodegroup %s", ngName))
+			continue
+		}
 
 		// Count total desired nodes
 		if nodegroup.ScalingConfig != nil && nodegroup.ScalingConfig.DesiredSize != nil {

--- a/internal/monitoring/monitor.go
+++ b/internal/monitoring/monitor.go
@@ -235,6 +235,12 @@ func checkUpdateWithRetry(ctx context.Context, eksClient *eks.Client, update *re
 	var lastErr error
 	backoff := time.Second
 
+	// Guard against a misconfigured MaxRetries: a value <= 0 would skip the loop
+	// entirely and return (nil, nil), nil-panicking the caller. Always try once.
+	if config.MaxRetries <= 0 {
+		config.MaxRetries = 1
+	}
+
 	for attempt := 0; attempt < config.MaxRetries; attempt++ {
 		updateStatus, err := eksClient.DescribeUpdate(ctx, &eks.DescribeUpdateInput{
 			Name:          aws.String(update.ClusterName),

--- a/internal/services/addons/service.go
+++ b/internal/services/addons/service.go
@@ -195,6 +195,9 @@ func (s *ServiceImpl) Update(ctx context.Context, clusterName, addonName string,
 	if err != nil {
 		return nil, fmt.Errorf("getting current addon version: %w", err)
 	}
+	if currentDesc.Addon == nil {
+		return nil, fmt.Errorf("getting current addon version: empty DescribeAddon response for %s", addonName)
+	}
 	previousVersion := aws.ToString(currentDesc.Addon.AddonVersion)
 
 	// Pre-update health check: refuse to update while the addon is mid-operation.
@@ -234,6 +237,9 @@ func (s *ServiceImpl) Update(ctx context.Context, clusterName, addonName string,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("updating addon: %w", err)
+	}
+	if out.Update == nil {
+		return nil, fmt.Errorf("updating addon: empty Update in UpdateAddon response for %s", addonName)
 	}
 
 	result.UpdateID = aws.ToString(out.Update.Id)

--- a/internal/services/addons/version_analyzer.go
+++ b/internal/services/addons/version_analyzer.go
@@ -127,7 +127,7 @@ func (s *ServiceImpl) waitForAddonUpdate(ctx context.Context, clusterName, addon
 				ClusterName: aws.String(clusterName),
 				AddonName:   aws.String(addonName),
 			})
-			if err != nil {
+			if err != nil || desc.Addon == nil {
 				continue
 			}
 			switch desc.Addon.Status {

--- a/internal/services/nodegroup/nodegroup_scale.go
+++ b/internal/services/nodegroup/nodegroup_scale.go
@@ -47,6 +47,9 @@ func (s *ServiceImpl) Scale(ctx context.Context, clusterName, nodegroupName stri
 			// it on a describe failure would scale down without the check.
 			return fmt.Errorf("PDB validation: failed to describe nodegroup %s/%s: %w", clusterName, nodegroupName, err)
 		}
+		if desc.Nodegroup == nil {
+			return fmt.Errorf("PDB validation: empty describe response for nodegroup %s/%s", clusterName, nodegroupName)
+		}
 		if desc.Nodegroup.ScalingConfig != nil && desc.Nodegroup.ScalingConfig.DesiredSize != nil &&
 			*desired < *desc.Nodegroup.ScalingConfig.DesiredSize {
 			pdb := s.healthChecker.CheckPodDisruptionBudgets(ctx)
@@ -122,6 +125,9 @@ func (s *ServiceImpl) waitForScaleCompletion(ctx context.Context, clusterName, n
 				continue
 			}
 			ng := out.Nodegroup
+			if ng == nil {
+				continue
+			}
 			if ng.Status == ekstypes.NodegroupStatusActive {
 				if desired == nil || (ng.ScalingConfig != nil && ng.ScalingConfig.DesiredSize != nil && *ng.ScalingConfig.DesiredSize == *desired) {
 					return nil

--- a/internal/services/nodegroup/service.go
+++ b/internal/services/nodegroup/service.go
@@ -168,6 +168,10 @@ func (s *ServiceImpl) List(ctx context.Context, clusterName string, options List
 				return nil
 			}
 			ng := desc.Nodegroup
+			if ng == nil {
+				s.logger.Warn("empty DescribeNodegroup response", "cluster", clusterName, "nodegroup", name)
+				return nil
+			}
 			var desiredSize int32
 			if ng.ScalingConfig != nil {
 				desiredSize = aws.ToInt32(ng.ScalingConfig.DesiredSize)
@@ -252,6 +256,9 @@ func (s *ServiceImpl) Describe(ctx context.Context, clusterName, nodegroupName s
 	})
 	if err != nil {
 		return nil, awsinternal.FormatAWSError(err, fmt.Sprintf("describing nodegroup %s/%s", clusterName, nodegroupName))
+	}
+	if out.Nodegroup == nil {
+		return nil, fmt.Errorf("describing nodegroup %s/%s: empty response", clusterName, nodegroupName)
 	}
 	ng := out.Nodegroup
 

--- a/internal/services/status/service.go
+++ b/internal/services/status/service.go
@@ -296,7 +296,7 @@ func (s *Service) hasKarpenterInstances(ctx context.Context) bool {
 
 func dedupe(in []string) []string {
 	seen := make(map[string]struct{}, len(in))
-	out := in[:0]
+	out := make([]string, 0, len(in))
 	for _, v := range in {
 		if _, ok := seen[v]; ok {
 			continue


### PR DESCRIPTION
Code-review hardening batch from the 2026-06-12 review. **No happy-path behavior change** — all changes are defensive guards + one input-validation fix. Build, `go vet`, full `go test ./...`, and `golangci-lint` are green locally.

## REF-115 — Harden defensive nil-checks on EKS Describe/Update responses
Several call sites dereferenced an AWS SDK response pointer without a nil guard after a successful call. AWS populates these on success, so none fired against live AWS, but the codebase was **inconsistent** (sibling paths already guarded the same pattern) and a malformed/mocked response would panic the whole run. Now uniform:
- **addons** — `UpdateAddon` `out.Update`, `DescribeAddon` `currentDesc.Addon`, and the `waitForAddonUpdate` poll loop's `desc.Addon`.
- **nodegroup** — `service.go`/`nodegroup_scale.go`, `internal/aws/nodegroup.go`, `internal/health/nodes.go`, and the `nodegroup update`/`verify` command paths: `desc.Nodegroup` / `resp.Update.Id`.
- **monitoring** — `checkUpdateWithRetry` now guards `MaxRetries <= 0`, which otherwise returned `(nil, nil)` and nil-panicked the caller (latent; callers hardcode 3 today).

## REF-116 — nodegroup scale flags silently truncated to int32
`--desired/--min/--max` were cast `int32(cmd.Int(...))` with no bounds check, so a typo like `--desired 3000000000` wrapped to a negative/garbage value sent to `UpdateNodegroupConfig`. `int32PtrIfSet` now returns an error for values outside `[0, math.MaxInt32]`. New test covers the rejection.

## REF-117 — status `dedupe()` aliased the caller's backing array
`out := in[:0]` overwrote the input's backing array in place. No live caller affected, but a latent footgun — now allocates a fresh slice.

Closes REF-115, REF-116, REF-117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)