### PR TITLE
fix(upgrade): attach to in-flight addon updates on resume (REF-114)

### DIFF
--- a/internal/services/addons/service.go
+++ b/internal/services/addons/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"gopkg.in/yaml.v3"
 
 	awsinternal "github.com/dantech2000/refresh/internal/aws"
@@ -163,6 +164,26 @@ func (s *ServiceImpl) Describe(ctx context.Context, clusterName, addonName strin
 	}
 
 	return details, nil
+}
+
+// AddonStatus returns the addon's currently installed version and raw EKS
+// lifecycle status (no health mapping), for callers that need to make
+// control-flow decisions — e.g. the upgrade orchestrator attaching to an
+// in-flight update on resume rather than re-submitting it.
+func (s *ServiceImpl) AddonStatus(ctx context.Context, clusterName, addonName string) (version string, status ekstypes.AddonStatus, err error) {
+	out, err := common.WithRetry(ctx, common.DefaultRetryConfig, func(rc context.Context) (*eks.DescribeAddonOutput, error) {
+		return s.eksClient.DescribeAddon(rc, &eks.DescribeAddonInput{
+			ClusterName: aws.String(clusterName),
+			AddonName:   aws.String(addonName),
+		})
+	})
+	if err != nil {
+		return "", "", awsinternal.FormatAWSError(err, fmt.Sprintf("describing addon %s", addonName))
+	}
+	if out.Addon == nil {
+		return "", "", fmt.Errorf("describing addon %s: empty response", addonName)
+	}
+	return aws.ToString(out.Addon.AddonVersion), out.Addon.Status, nil
 }
 
 // Update updates an addon to a specified version

--- a/internal/services/addons/version_analyzer.go
+++ b/internal/services/addons/version_analyzer.go
@@ -109,6 +109,19 @@ func compareAddonVersions(a, b string) int {
 	return len(as) - len(bs)
 }
 
+// WaitUntilActive blocks until the addon reaches ACTIVE — attaching to an
+// in-flight update started by a previous run — or the update fails, bounded by
+// timeout. It is the exported entry point the upgrade orchestrator uses to
+// resume an addon that is still CREATING/UPDATING.
+func (s *ServiceImpl) WaitUntilActive(ctx context.Context, clusterName, addonName string, timeout, pollInterval time.Duration) error {
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	return s.waitForAddonUpdate(ctx, clusterName, addonName, pollInterval)
+}
+
 // waitForAddonUpdate polls until an addon update completes. pollInterval
 // falls back to addonUpdatePollInterval when zero.
 func (s *ServiceImpl) waitForAddonUpdate(ctx context.Context, clusterName, addonName string, pollInterval time.Duration) error {

--- a/internal/services/upgrade/addons.go
+++ b/internal/services/upgrade/addons.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
 	"github.com/dantech2000/refresh/internal/services/addons"
 )
 
@@ -44,12 +46,32 @@ func (s *Service) UpgradeAddons(ctx context.Context, clusterName, targetVersion 
 		}
 		chosen := versions[0].Version
 
-		if addons.CompareVersions(a.Version, chosen) >= 0 {
-			progress("addon %s already at %s (latest compatible with %s), skipping", a.Name, a.Version, targetVersion)
+		// Resume support: a re-run after Ctrl+C may find an addon still
+		// CREATING/UPDATING from the previous run. The control-plane and
+		// nodegroup phases attach to such in-flight updates; the addon phase
+		// must too, or svc.Update's pre-update health gate hard-fails on the
+		// UPDATING status. Wait for it to settle, then re-read the installed
+		// version and let the normal skip/converge logic below decide.
+		current, status, err := svc.AddonStatus(ctx, clusterName, a.Name)
+		if err != nil {
+			return fmt.Errorf("addon %s: reading status: %w", a.Name, err)
+		}
+		if status == ekstypes.AddonStatusCreating || status == ekstypes.AddonStatusUpdating {
+			progress("addon %s is %s (in-flight update from a previous run); attaching and waiting for it to settle", a.Name, status)
+			if err := svc.WaitUntilActive(ctx, clusterName, a.Name, addonWaitTimeout, s.PollInterval); err != nil {
+				return fmt.Errorf("addon %s: waiting for in-flight update to finish: %w", a.Name, err)
+			}
+			if current, _, err = svc.AddonStatus(ctx, clusterName, a.Name); err != nil {
+				return fmt.Errorf("addon %s: reading status after attach: %w", a.Name, err)
+			}
+		}
+
+		if addons.CompareVersions(current, chosen) >= 0 {
+			progress("addon %s already at %s (latest compatible with %s), skipping", a.Name, current, targetVersion)
 			continue
 		}
 
-		progress("addon %s: %s → %s", a.Name, a.Version, chosen)
+		progress("addon %s: %s → %s", a.Name, current, chosen)
 		result, err := svc.Update(ctx, clusterName, a.Name, addons.UpdateOptions{
 			Version:      chosen,
 			HealthCheck:  true,

--- a/internal/services/upgrade/addons_test.go
+++ b/internal/services/upgrade/addons_test.go
@@ -176,6 +176,102 @@ func TestUpgradeAddons_FailureHaltsPhase(t *testing.T) {
 	}
 }
 
+// Resume support (REF-114): a re-run that finds an addon still UPDATING from a
+// previous run attaches to that in-flight update (waits for ACTIVE) instead of
+// hard-failing the pre-update health gate. Here the in-flight update settles at
+// the target version, so no new UpdateAddon is submitted.
+func TestUpgradeAddons_ResumeAttachesToInFlightUpdate(t *testing.T) {
+	const chosen = "v1.32.2-eksbuild.1"
+	var mu sync.Mutex
+	describeCalls := 0
+
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.32").
+		WithAddon("vpc-cni", "v1.31.5-eksbuild.1", ekstypes.AddonStatusActive).
+		Build()
+	versionsByK8s(m, "vpc-cni", map[string][]string{"1.32": {chosen}})
+	m.DescribeAddonFn = func(_ context.Context, in *eks.DescribeAddonInput, _ ...func(*eks.Options)) (*eks.DescribeAddonOutput, error) {
+		mu.Lock()
+		describeCalls++
+		n := describeCalls
+		mu.Unlock()
+		// First two observations: still mid-update from the previous run.
+		// Then it settles ACTIVE at the target version.
+		status, version := ekstypes.AddonStatusActive, chosen
+		if n <= 2 {
+			status, version = ekstypes.AddonStatusUpdating, "v1.31.5-eksbuild.1"
+		}
+		return &eks.DescribeAddonOutput{Addon: &ekstypes.Addon{
+			AddonName:    in.AddonName,
+			AddonVersion: aws.String(version),
+			Status:       status,
+		}}, nil
+	}
+	svc := newTestService(m)
+
+	if err := svc.UpgradeAddons(context.Background(), "prod-east", "1.32", nil, nil); err != nil {
+		t.Fatalf("UpgradeAddons: %v", err)
+	}
+	if m.Calls.UpdateAddon != 0 {
+		t.Fatalf("UpdateAddon calls = %d, want 0 (attached to in-flight update already at target)", m.Calls.UpdateAddon)
+	}
+	mu.Lock()
+	got := describeCalls
+	mu.Unlock()
+	if got < 3 {
+		t.Fatalf("DescribeAddon calls = %d, want >=3 (status read, poll until ACTIVE, re-read)", got)
+	}
+}
+
+// Resume support (REF-114): if the attached-to in-flight update settles below
+// the chosen target, the phase converges by issuing the update — and the
+// pre-update health gate passes because the addon is ACTIVE again by then.
+func TestUpgradeAddons_ResumeThenConverges(t *testing.T) {
+	var mu sync.Mutex
+	describeCalls := 0
+	updated := false
+
+	m := mocks.NewEKSAPI().
+		WithCluster("prod-east", "1.32").
+		WithAddon("vpc-cni", "v1.31.5-eksbuild.1", ekstypes.AddonStatusActive).
+		Build()
+	versionsByK8s(m, "vpc-cni", map[string][]string{"1.32": {"v1.32.2-eksbuild.1"}})
+	m.DescribeAddonFn = func(_ context.Context, in *eks.DescribeAddonInput, _ ...func(*eks.Options)) (*eks.DescribeAddonOutput, error) {
+		mu.Lock()
+		describeCalls++
+		n := describeCalls
+		mu.Unlock()
+		status := ekstypes.AddonStatusUpdating
+		if n >= 3 { // settles ACTIVE but still below target → must converge
+			status = ekstypes.AddonStatusActive
+		}
+		return &eks.DescribeAddonOutput{Addon: &ekstypes.Addon{
+			AddonName:    in.AddonName,
+			AddonVersion: aws.String("v1.31.5-eksbuild.1"),
+			Status:       status,
+		}}, nil
+	}
+	m.UpdateAddonFn = func(_ context.Context, _ *eks.UpdateAddonInput, _ ...func(*eks.Options)) (*eks.UpdateAddonOutput, error) {
+		mu.Lock()
+		updated = true
+		mu.Unlock()
+		return &eks.UpdateAddonOutput{Update: &ekstypes.Update{
+			Id:     aws.String("u-converge"),
+			Status: ekstypes.UpdateStatusInProgress,
+		}}, nil
+	}
+	svc := newTestService(m)
+
+	if err := svc.UpgradeAddons(context.Background(), "prod-east", "1.32", nil, nil); err != nil {
+		t.Fatalf("UpgradeAddons: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !updated {
+		t.Fatal("expected UpdateAddon to be called to converge to target after attaching to the in-flight update")
+	}
+}
+
 // An addon with no target-compatible version fails the phase up front.
 func TestUpgradeAddons_NoCompatibleVersionFails(t *testing.T) {
 	m := mocks.NewEKSAPI().


### PR DESCRIPTION
## REF-114 — addon phase couldn't resume an in-flight addon update

The cluster-upgrade orchestrator is resumable: a re-run after Ctrl+C re-derives the plan from live state and **attaches** to in-flight EKS updates. The control-plane (`controlplane.go`) and nodegroup phases do this. The **addon phase didn't** — `UpgradeAddons` called `addons.Update` with the pre-update health gate on, which hard-fails when the addon is still `CREATING`/`UPDATING` from the previous run ("wait for it to reach ACTIVE before updating"). So a resume mid-addon-update failed and the operator had to wait and retry by hand.

## Fix

`UpgradeAddons` now reads the addon's live status before acting:
- If it's `CREATING`/`UPDATING`, **attach**: wait for `ACTIVE` (bounded by `addonWaitTimeout`), then re-read the settled version and fall through to the normal skip/converge logic.
- If it settled **at** the target → skip. If still **below** → converge with a fresh update (now permitted, since the addon is `ACTIVE` again, so the pre-update gate passes).
- The version comparison now uses the freshly-read installed version instead of the possibly-stale value from the initial `List`.

I chose **attach-and-reconverge** over erroring on a "different in-flight version" because the chosen version is deterministic across runs, so reconverging is strictly more robust and needs no `ListUpdates` round-trip.

### New addons service methods
- `AddonStatus(ctx, cluster, name) → (version, raw ekstypes.AddonStatus, err)` — status for control-flow decisions, no health mapping; guarded against a nil `Addon`.
- `WaitUntilActive(ctx, cluster, name, timeout, poll)` — timeout-bounded exported wrapper over the existing `waitForAddonUpdate` loop.

## Tests
- `TestUpgradeAddons_ResumeAttachesToInFlightUpdate` — in-flight update lands on target → **no** new `UpdateAddon`, and DescribeAddon is polled until ACTIVE.
- `TestUpgradeAddons_ResumeThenConverges` — settles below target → update **is** issued.

Build, `go vet`, full `go test ./...`, and `golangci-lint` green locally. No happy-path behavior change (steady-state ACTIVE addons take the same path).

Closes REF-114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)