### PR TITLE
feat: output redesign + live cluster-roll observability (REF-119)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ command (CLI wiring)  internal/commands/{cluster,nodegroup,addon,ctxcmd,workload
   → runner            internal/commands/runner   (SetupAWS, WithSpinner, EncodeStdout, positional/flag helpers)
   → factory           internal/commands/factory  (service constructors)
   → service           internal/services/*        (business logic + AWS calls)
-  → view              internal/commands/clusterview, internal/ui (tables/formatting)
+  → view              internal/commands/clusterview, internal/render, internal/ui (tables/formatting)
 ```
 
 Supporting packages: `internal/aws` (SDK abstractions, error formatting), `internal/awsconfig`
@@ -58,6 +58,28 @@ Supporting packages: `internal/aws` (SDK abstractions, error formatting), `inter
 `internal/types`, `internal/mocks`, `internal/services/upgrade` (cluster upgrade
 orchestrator: plan generation + control-plane/addon/nodegroup phases + sequencing
 engine; resumable by re-deriving the plan from live cluster state, not state files).
+
+**Output / rendering** (`internal/render`): the human-facing design system —
+palette (Catppuccin, truecolor with 256/none downgrade + capability detection),
+status tokens (`glyph + label + color`, with an ASCII fallback so color is
+always *additive*), primitives (section/table/KV/callout/bar) that reuse the
+ANSI-width math in `internal/ui`, and `LiveRegion` for in-place redraw (degrades
+to appended snapshots when piped). **Rule: render in the view layer, never from
+services.** Machine formats (`-o json/yaml/plain`) do NOT go through `render` —
+they stay in `runner.EncodeStdout`, byte-for-byte unchanged; each restyled view
+branches `if ui.PlainOutput()` to keep the `-o plain` TSV path.
+
+**Live node-roll** (`internal/noderoll`): observes a managed-nodegroup roll in
+real time (nodes draining/joining/terminating) from live Kubernetes Node state —
+the per-node truth EKS's coarse `DescribeUpdate` can't give. `KubeObserver`
+scopes by the `eks.amazonaws.com/nodegroup` label and classifies by Ready /
+cordon-or-drain-taint, with old-vs-new from either the `nodegroup-image` AMI
+label or a roll-start `CaptureBaseline`. `Tracker` diffs snapshots into a
+lifecycle event feed. Testable with **zero AWS / zero cluster** via
+`client-go/kubernetes/fake` (see `observer_test.go`) and a `ScriptedObserver`
+(`DemoTimeline`). `refresh nodegroup update --simulate` (hidden flag) drives the
+whole live panel from the scripted observer — demos, asciinema, and manual QA
+with no AWS.
 
 ## Conventions (follow these when editing)
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ refresh/
 
 -   **Pre-flight Health Checks**: Validate cluster readiness before AMI updates using default EC2 metrics (no additional setup required)
 -   **Real-time Monitoring**: Live progress tracking with professional spinner displays and clean completion summaries
+-   **Live Node-Roll View**: `nodegroup update` can show a real-time, per-node view of a roll — nodes draining (with pod-eviction progress), terminating, and coming online — driven from live Kubernetes state. Line-oriented (redraws in place on a TTY, appends when piped), not a TUI. Preview it with no AWS via `nodegroup update --simulate`
 -   **Fleet Status**: `refresh status -A` shows patch posture (version, EKS support window + extended-support cost, stale AMIs, addons behind) across all clusters/regions, with CI-friendly exit codes
 -   **Cluster Management**: List clusters and nodegroups with status and versions
 -   **Smart Updates**: Update AMI for all or specific nodegroups with rolling updates and optional force mode
@@ -117,7 +118,7 @@ refresh/
 -   **Security Visibility**: Display cluster deletion protection status and security configuration details
 -   **Dry Run Mode**: Preview changes with comprehensive details before execution
 -   **Short Flags**: Convenient short flags for all commands (`-c`, `-n`, `-d`, `-f`, etc.)
--   **Enhanced UI**: Color-coded output with perfect table alignment and clear status indicators
+-   **Enhanced UI**: A consistent design system across every surface — status tokens pair a glyph with a label so **color is additive** (fully legible with `--no-color`, when piped, or on a non‑UTF‑8 terminal), 24‑bit truecolor that degrades to 256‑color/none by terminal capability, and ANSI‑aware table alignment. `-o json/yaml/plain` are unaffected by terminal or color settings
 -   **Graceful Degradation**: Works with just AWS credentials, provides clear guidance for optional features
 -   **Timeouts Everywhere**: Global and per-command `--timeout, -t` to avoid hangs on slow networks (default 60s)
 -   **Multi-Region Discovery**: `cluster list` supports `-A/--all-regions` with a concurrency cap (`-C/--max-concurrency`)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ refresh/
 
 -   **Pre-flight Health Checks**: Validate cluster readiness before AMI updates using default EC2 metrics (no additional setup required)
 -   **Real-time Monitoring**: Live progress tracking with professional spinner displays and clean completion summaries
--   **Live Node-Roll View**: `nodegroup update` can show a real-time, per-node view of a roll — nodes draining (with pod-eviction progress), terminating, and coming online — driven from live Kubernetes state. Line-oriented (redraws in place on a TTY, appends when piped), not a TUI. Preview it with no AWS via `nodegroup update --simulate`
+-   **Live Node-Roll View**: `nodegroup update --live` shows a real-time, per-node view of a roll — nodes draining (with pod-eviction progress), terminating, and coming online — driven from live Kubernetes state (requires cluster access + a single nodegroup; degrades to standard monitoring otherwise, EKS stays authoritative). Line-oriented (redraws in place on a TTY, appends when piped), not a TUI. Preview it with no AWS via `nodegroup update --simulate`
 -   **Fleet Status**: `refresh status -A` shows patch posture (version, EKS support window + extended-support cost, stale AMIs, addons behind) across all clusters/regions, with CI-friendly exit codes
 -   **Cluster Management**: List clusters and nodegroups with status and versions
 -   **Smart Updates**: Update AMI for all or specific nodegroups with rolling updates and optional force mode

--- a/docs/concepts/output.md
+++ b/docs/concepts/output.md
@@ -57,20 +57,28 @@ Color auto-disables when stdout is piped. Force it off with `--no-color` or the
 
 ## Live node-roll view
 
-When you patch a nodegroup's AMI, `refresh nodegroup update` can show a **live,
-per-node view** of the roll — nodes draining (with pod-eviction progress),
-terminating, and coming online — instead of a single spinner. It is
+When you patch a nodegroup's AMI, `refresh nodegroup update --live` shows a
+**real-time, per-node view** of the roll — nodes draining (with pod-eviction
+progress), terminating, and coming online — instead of a single spinner. It is
 line-oriented (it redraws in place on a terminal and appends snapshots when
 piped); it is **not** a full-screen TUI.
 
-To preview the live view with no AWS and no cluster (handy for demos or just to
-see the shape of it):
+```bash
+refresh nodegroup update -c prod -n web --live
+```
+
+`--live` requires cluster (kubeconfig) access and a single nodegroup; it falls
+back to standard monitoring otherwise, and the EKS update status stays
+authoritative for the result regardless. Old-vs-new is determined from a
+roll-start baseline, so it works for any roll.
+
+To preview the view with **no AWS and no cluster** (demos, or just to see the
+shape of it), a hidden flag drives the panel from a scripted roll of 3 old → 3
+new nodes:
 
 ```bash
 refresh nodegroup update --simulate
 ```
-
-This drives the panel from a scripted roll of 3 old → 3 new nodes.
 
 ## Watch mode
 

--- a/docs/concepts/output.md
+++ b/docs/concepts/output.md
@@ -32,10 +32,45 @@ refresh cluster list -o tree
 so one logical row is always exactly one well-formed TSV line — safe for
 `awk -F'\t'`.
 
+## The human display (design system)
+
+The default `table` output is rendered by a small design system so every
+surface — `status`, `cluster`, `nodegroup`, `addon` — reads consistently:
+
+- **Status tokens** pair a glyph with a label and color: `●` healthy/current,
+  `▲` warn/stale, `✗` failed/unsupported, `◷` in-progress, `○` unknown. The
+  glyph and label always carry the meaning, so **color is purely additive** —
+  output stays fully legible with `--no-color`, when piped, or on a non‑UTF‑8
+  terminal (where glyphs fall back to `[OK] [!] [X] [~] [?]`).
+- **Color depth adapts to the terminal:** 24‑bit truecolor when the terminal
+  advertises it (`COLORTERM=truecolor`), a 256‑color approximation otherwise,
+  and no color when piped / `NO_COLOR` / `--no-color`.
+
+This styling applies only to the human view. **`-o json`, `-o yaml`, and
+`-o plain` are unaffected** — their bytes are identical regardless of terminal
+or color settings, so scripts are never surprised.
+
 ## Color
 
 Color auto-disables when stdout is piped. Force it off with `--no-color` or the
 `NO_COLOR` environment variable.
+
+## Live node-roll view
+
+When you patch a nodegroup's AMI, `refresh nodegroup update` can show a **live,
+per-node view** of the roll — nodes draining (with pod-eviction progress),
+terminating, and coming online — instead of a single spinner. It is
+line-oriented (it redraws in place on a terminal and appends snapshots when
+piped); it is **not** a full-screen TUI.
+
+To preview the live view with no AWS and no cluster (handy for demos or just to
+see the shape of it):
+
+```bash
+refresh nodegroup update --simulate
+```
+
+This drives the panel from a scripted roll of 3 old → 3 new nodes.
 
 ## Watch mode
 

--- a/docs/reference/nodegroup.md
+++ b/docs/reference/nodegroup.md
@@ -180,5 +180,6 @@ Example (cron): refresh nodegroup update -c prod --yes --require-healthy -o json
 | `--changelog` | — | — | In dry-run, print full amazon-eks-ami release notes between the current and target AMI |
 | `--kubeconfig string` | — | — | Path to the kubeconfig for workload/PDB health checks (defaults to $KUBECONFIG, then ~/.kube/config) |
 | `--format, -o string` | — | `table` | Output format: health results with --health-only; a JSON run summary with -o json |
+| `--live` | — | — | Show a live per-node roll view (nodes draining/joining/terminating) during the update — requires cluster access, single nodegroup, interactive |
 | `--help, -h` | — | — | show help |
 

--- a/internal/commands/addon/formatters.go
+++ b/internal/commands/addon/formatters.go
@@ -2,24 +2,41 @@ package addon
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/fatih/color"
 
+	"github.com/dantech2000/refresh/internal/render"
 	"github.com/dantech2000/refresh/internal/services/addons"
 	"github.com/dantech2000/refresh/internal/ui"
 	"gopkg.in/yaml.v3"
 )
 
+// outputAddonsTable renders the add-on list. The human path uses the render
+// design system (tokenized STATUS/HEALTH cells); `-o plain` keeps the uncolored
+// tab-separated table.
 func outputAddonsTable(cluster string, rows []addons.AddonSummary, elapsed time.Duration) error {
-	ui.Outf("Add-ons for cluster: %s\n", color.CyanString(cluster))
-	ui.PrintElapsed(elapsed)
-
 	if len(rows) == 0 {
+		ui.Outf("Add-ons for cluster: %s\n", color.CyanString(cluster))
+		ui.PrintElapsed(elapsed)
 		color.Yellow("No add-ons found")
 		return nil
 	}
+	if !ui.PlainOutput() {
+		th := render.Default(os.Stdout)
+		for _, line := range addonListLines(th, cluster, rows) {
+			fmt.Println(line)
+		}
+		return nil
+	}
+	return outputAddonsPlain(cluster, rows, elapsed)
+}
+
+func outputAddonsPlain(cluster string, rows []addons.AddonSummary, elapsed time.Duration) error {
+	ui.Outf("Add-ons for cluster: %s\n", color.CyanString(cluster))
+	ui.PrintElapsed(elapsed)
 
 	columns := []ui.Column{
 		{Title: "NAME", Min: 4, Max: 24, Align: ui.AlignLeft},

--- a/internal/commands/addon/formatters_test.go
+++ b/internal/commands/addon/formatters_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/dantech2000/refresh/internal/services/addons"
+	"github.com/dantech2000/refresh/internal/ui"
 )
 
 func captureStdout(t *testing.T, fn func() error) (string, error) {
@@ -56,19 +57,27 @@ func TestOutputAddonsTable_Empty(t *testing.T) {
 }
 
 func TestOutputAddonsTable_WithRows(t *testing.T) {
-	// pterm table rows (vpc-cni, version, status) are rendered to the original stdout
-	// file handle and are not captured by captureStdout. We verify the header is correct
-	// and that no error is returned. The JSON/YAML tests validate the data itself.
-	out, err := captureStdout(t, func() error {
-		return outputAddonsTable("prod", []addons.AddonSummary{{Name: "vpc-cni", Version: "v1.18.3", Status: "ACTIVE", Health: "PASS"}}, time.Second)
-	})
+	rows := []addons.AddonSummary{{Name: "vpc-cni", Version: "v1.18.3", Status: "ACTIVE", Health: "PASS"}}
+
+	// Human path (render design system): ADD-ONS header + tokenized rows.
+	out, err := captureStdout(t, func() error { return outputAddonsTable("prod", rows, time.Second) })
 	if err != nil {
 		t.Fatalf("addons table: %v", err)
 	}
-	if !strings.Contains(out, "prod") {
-		t.Errorf("addons table: missing cluster name 'prod' in header: %q", out)
+	for _, want := range []string{"ADD-ONS", "prod", "vpc-cni", "ACTIVE"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("addons table missing %q: %q", want, out)
+		}
 	}
-	if !strings.Contains(out, "Retrieved") {
-		t.Errorf("addons table: missing 'Retrieved' timing line: %q", out)
+
+	// Plain path (-o plain) keeps the cluster banner + "Retrieved" timing line.
+	ui.SetPlainOutput(true)
+	defer ui.SetPlainOutput(false)
+	plain, err := captureStdout(t, func() error { return outputAddonsTable("prod", rows, time.Second) })
+	if err != nil {
+		t.Fatalf("addons plain: %v", err)
+	}
+	if !strings.Contains(plain, "Retrieved") {
+		t.Errorf("addons plain: missing 'Retrieved' timing line: %q", plain)
 	}
 }

--- a/internal/commands/addon/list_render.go
+++ b/internal/commands/addon/list_render.go
@@ -1,0 +1,43 @@
+package addon
+
+import (
+	"fmt"
+
+	"github.com/dantech2000/refresh/internal/render"
+	"github.com/dantech2000/refresh/internal/services/addons"
+	"github.com/dantech2000/refresh/internal/ui"
+)
+
+// addonListLines builds the human `addon list` table (pure, golden-testable)
+// with tokenized STATUS and HEALTH cells.
+func addonListLines(th *render.Theme, cluster string, rows []addons.AddonSummary) []string {
+	pal := th.Pal
+	out := []string{
+		th.Bold(pal.Mauve, "ADD-ONS") + "  " + th.Paint(pal.White, cluster) +
+			th.Paint(pal.Dim, fmt.Sprintf(" · %d", len(rows))),
+		"",
+	}
+	tbl := th.NewTable(
+		ui.Column{Title: "NAME", Min: 4, Max: 24},
+		ui.Column{Title: "VERSION", Min: 8},
+		ui.Column{Title: "STATUS", Min: 10},
+		ui.Column{Title: "HEALTH", Min: 8},
+	)
+	for _, r := range rows {
+		tbl.Row(
+			th.Paint(pal.White, r.Name),
+			th.Paint(pal.Text, r.Version),
+			th.Token(render.StatusFromString(r.Status), r.Status),
+			addonHealthToken(th, r.Health),
+		)
+	}
+	out = append(out, tbl.Render()...)
+	return out
+}
+
+func addonHealthToken(th *render.Theme, health string) string {
+	if health == "" {
+		return th.Paint(th.Pal.Dim, "—")
+	}
+	return th.Token(render.StatusFromString(health), health)
+}

--- a/internal/commands/addon/list_render_test.go
+++ b/internal/commands/addon/list_render_test.go
@@ -1,0 +1,45 @@
+package addon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dantech2000/refresh/internal/render"
+	"github.com/dantech2000/refresh/internal/services/addons"
+)
+
+func TestAddonListLines(t *testing.T) {
+	th := render.New(render.ColorNone, true)
+	rows := []addons.AddonSummary{
+		{Name: "vpc-cni", Version: "v1.18.3", Status: "ACTIVE", Health: "Healthy"},
+		{Name: "coredns", Version: "v1.11.1", Status: "DEGRADED", Health: "Degraded"},
+		{Name: "kube-proxy", Version: "v1.30.0", Status: "ACTIVE", Health: ""},
+	}
+	joined := strings.Join(addonListLines(th, "prod", rows), "\n")
+
+	if strings.Contains(joined, "\x1b") {
+		t.Fatalf("ColorNone output contains ANSI escapes:\n%s", joined)
+	}
+	for _, want := range []string{
+		"ADD-ONS  prod · 3",
+		"vpc-cni",
+		"● ACTIVE",
+		"● Healthy",
+		"✗ DEGRADED",
+		"✗ Degraded",
+		"—", // empty health renders as a dim dash
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("addon list missing %q in:\n%s", want, joined)
+		}
+	}
+}
+
+func TestAddonListLines_ASCII(t *testing.T) {
+	th := render.New(render.ColorNone, false)
+	rows := []addons.AddonSummary{{Name: "vpc-cni", Version: "v1.18.3", Status: "ACTIVE", Health: "Healthy"}}
+	joined := strings.Join(addonListLines(th, "prod", rows), "\n")
+	if !strings.Contains(joined, "[OK] ACTIVE") || !strings.Contains(joined, "[OK] Healthy") {
+		t.Errorf("ASCII tokens missing:\n%s", joined)
+	}
+}

--- a/internal/commands/clusterview/clusterview_test.go
+++ b/internal/commands/clusterview/clusterview_test.go
@@ -283,9 +283,9 @@ func TestOutputClustersTable(t *testing.T) {
 	}{
 		// "No EKS clusters found" is printed via color.Yellow (original stdout handle, not captured).
 		{"empty", false, false, nil, ""},
-		{"single-no-health", false, false, sampleSummaries()[:1], "1 cluster"},
-		{"single-health", false, true, sampleSummaries(), "2 cluster"},
-		{"multi-region-health", true, true, sampleSummaries(), "2 cluster"},
+		{"single-no-health", false, false, sampleSummaries()[:1], "CLUSTERS  1"},
+		{"single-health", false, true, sampleSummaries(), "CLUSTERS  2"},
+		{"multi-region-health", true, true, sampleSummaries(), "CLUSTERS  2"},
 	} {
 		t.Run("table/"+tc.name, func(t *testing.T) {
 			out, err := captureStdout(t, func() error {

--- a/internal/commands/clusterview/clusterview_test.go
+++ b/internal/commands/clusterview/clusterview_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dantech2000/refresh/internal/health"
 	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
+	"github.com/dantech2000/refresh/internal/ui"
 )
 
 func captureStdout(t *testing.T, fn func() error) (string, error) {
@@ -332,13 +333,26 @@ func TestOutputClusterDetailsTable(t *testing.T) {
 		Nodegroups: []clustersvc.NodegroupSummary{{Name: "ng-workers", Status: "ACTIVE", ReadyNodes: 2}},
 	}
 
+	// Human path (render design system): sectioned detail, no "Cluster
+	// Information" banner.
 	out, err := captureStdout(t, func() error { return OutputClusterDetailsTable(details, time.Second) })
 	if err != nil {
 		t.Fatalf("table error: %v", err)
 	}
-	for _, want := range []string{"Cluster Information", "prod", "1.30", "vpc-1"} {
+	for _, want := range []string{"▸ OVERVIEW", "prod", "1.30", "vpc-1", "vpc-cni"} {
 		if !strings.Contains(out, want) {
-			t.Errorf("table output missing %q: %q", want, out)
+			t.Errorf("detail output missing %q: %q", want, out)
 		}
+	}
+
+	// Plain path (-o plain) keeps the uncolored key/value banner for grep/awk.
+	ui.SetPlainOutput(true)
+	defer ui.SetPlainOutput(false)
+	plain, err := captureStdout(t, func() error { return OutputClusterDetailsTable(details, time.Second) })
+	if err != nil {
+		t.Fatalf("plain error: %v", err)
+	}
+	if !strings.Contains(plain, "Cluster Information") {
+		t.Errorf("plain output missing banner: %q", plain)
 	}
 }

--- a/internal/commands/clusterview/detail.go
+++ b/internal/commands/clusterview/detail.go
@@ -2,17 +2,34 @@ package clusterview
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/fatih/color"
 
+	"github.com/dantech2000/refresh/internal/render"
 	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
 	"github.com/dantech2000/refresh/internal/ui"
 )
 
-// OutputClusterDetailsTable renders a single cluster's expanded details.
+// OutputClusterDetailsTable renders a single cluster's expanded details. The
+// human path uses the render design system (sections, status tokens, a health
+// card); `-o plain` keeps the uncolored key/value + tab-separated tables.
 func OutputClusterDetailsTable(details *clustersvc.ClusterDetails, elapsed time.Duration) error {
+	if ui.PlainOutput() {
+		return outputClusterDetailsPlain(details, elapsed)
+	}
+	th := render.Default(os.Stdout)
+	for _, line := range clusterDetailLines(th, details, elapsed) {
+		fmt.Println(line)
+	}
+	return nil
+}
+
+// outputClusterDetailsPlain renders the uncolored key/value + tab-separated
+// add-ons table for `-o plain`.
+func outputClusterDetailsPlain(details *clustersvc.ClusterDetails, elapsed time.Duration) error {
 	ui.Outf("Cluster Information: %s\n", color.CyanString(details.Name))
 	ui.PrintElapsed(elapsed)
 

--- a/internal/commands/clusterview/detail_render.go
+++ b/internal/commands/clusterview/detail_render.go
@@ -1,0 +1,163 @@
+package clusterview
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dantech2000/refresh/internal/health"
+	"github.com/dantech2000/refresh/internal/render"
+	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
+	"github.com/dantech2000/refresh/internal/ui"
+)
+
+// clusterDetailLines builds the human `cluster describe` view as a slice of
+// lines (pure, so it is golden-testable). Sections: a name/status header,
+// OVERVIEW key/values, NODEGROUPS + ADD-ONS tables, and a HEALTH card.
+func clusterDetailLines(th *render.Theme, d *clustersvc.ClusterDetails, elapsed time.Duration) []string {
+	pal := th.Pal
+
+	header := th.Bold(pal.White, d.Name) + "   " + statusToken(th, d.Status)
+	if d.Region != "" {
+		header += th.Paint(pal.Dim, "   "+d.Region)
+	}
+	out := []string{header, "", th.Section("OVERVIEW")}
+
+	version := th.Paint(pal.White, d.Version)
+	if d.PlatformVersion != "" {
+		version += th.Paint(pal.Dim, " · "+d.PlatformVersion)
+	}
+	kv := [][2]string{
+		{"version", version},
+		{"status", statusToken(th, d.Status)},
+	}
+	if d.Endpoint != "" {
+		kv = append(kv, [2]string{"endpoint", th.Paint(pal.Sky, truncateEndpoint(d.Endpoint))})
+	}
+	if d.Networking.VpcId != "" {
+		vpc := d.Networking.VpcId
+		if d.Networking.VpcCidr != "" {
+			vpc += " (" + d.Networking.VpcCidr + ")"
+		}
+		kv = append(kv, [2]string{"vpc", th.Paint(pal.Text, vpc)})
+	}
+	logging := "disabled"
+	if len(d.Security.LoggingEnabled) > 0 {
+		logging = strings.Join(d.Security.LoggingEnabled, ",") + " enabled"
+	}
+	kv = append(kv, [2]string{"logging", th.Paint(pal.Text, logging)})
+	if d.Security.EncryptionEnabled {
+		kv = append(kv, [2]string{"encryption", th.Token(render.Healthy, "enabled (KMS)")})
+	} else {
+		kv = append(kv, [2]string{"encryption", th.Token(render.Fail, "disabled")})
+	}
+	if d.CreatedAt.IsZero() {
+		kv = append(kv, [2]string{"created", th.Paint(pal.Dim, "unknown")})
+	} else {
+		kv = append(kv, [2]string{"created",
+			th.Paint(pal.Text, d.CreatedAt.Format("2006-01-02")) +
+				th.Paint(pal.Dim, "  ("+formatAge(time.Since(d.CreatedAt))+")")})
+	}
+	for _, line := range th.KV(kv) {
+		out = append(out, "  "+line)
+	}
+
+	if len(d.Nodegroups) > 0 {
+		active, nodes := 0, int32(0)
+		for _, ng := range d.Nodegroups {
+			nodes += ng.ReadyNodes
+			if ng.Status == "ACTIVE" {
+				active++
+			}
+		}
+		out = append(out, "", th.Section("NODEGROUPS")+th.Paint(pal.Dim, fmt.Sprintf("  %d active · %d nodes", active, nodes)))
+		tbl := th.NewTable(
+			ui.Column{Title: "NAME", Min: 8, Max: 28},
+			ui.Column{Title: "INSTANCE", Min: 8},
+			ui.Column{Title: "NODES", Min: 5},
+			ui.Column{Title: "STATUS", Min: 8},
+		)
+		for _, ng := range d.Nodegroups {
+			tbl.Row(
+				th.Paint(pal.White, ng.Name),
+				th.Paint(pal.Text, ng.InstanceType),
+				th.Paint(pal.Text, fmt.Sprintf("%d/%d", ng.ReadyNodes, ng.DesiredSize)),
+				th.Token(render.StatusFromString(ng.Status), ng.Status),
+			)
+		}
+		for _, l := range tbl.Render() {
+			out = append(out, "  "+l)
+		}
+	}
+
+	if len(d.Addons) > 0 {
+		out = append(out, "", th.Section("ADD-ONS")+th.Paint(pal.Dim, fmt.Sprintf("  %d installed", len(d.Addons))))
+		tbl := th.NewTable(
+			ui.Column{Title: "NAME", Min: 8, Max: 24},
+			ui.Column{Title: "VERSION", Min: 8},
+			ui.Column{Title: "HEALTH", Min: 8},
+		)
+		for _, a := range d.Addons {
+			h := a.Health
+			if h == "" {
+				h = "Unknown"
+			}
+			tbl.Row(
+				th.Paint(pal.White, a.Name),
+				th.Paint(pal.Text, a.Version),
+				th.Token(render.StatusFromString(h), h),
+			)
+		}
+		for _, l := range tbl.Render() {
+			out = append(out, "  "+l)
+		}
+	}
+
+	if d.Health != nil {
+		out = append(out, "")
+		out = append(out, healthCardLines(th, d.Health)...)
+	}
+	return out
+}
+
+// statusToken renders a free-form status as a colored glyph + the status text.
+func statusToken(th *render.Theme, status string) string {
+	if status == "" {
+		return th.Token(render.Unknown, "unknown")
+	}
+	return th.Token(render.StatusFromString(status), status)
+}
+
+// healthCardLines renders the HEALTH section: a verdict + score bar + a
+// one-line summary. Shared by `cluster describe` and `upgrade-check`.
+func healthCardLines(th *render.Theme, h *health.HealthSummary) []string {
+	st, col := decisionStatusColor(th, h.Decision)
+	head := th.Section("HEALTH") +
+		th.Paint(th.Pal.Dim, fmt.Sprintf("  %d/100 · ", h.OverallScore)) +
+		th.Tokenf(st, string(h.Decision))
+	bar := th.Bar(h.OverallScore, 100, 24, col)
+	return []string{head, "  " + bar + "  " + th.Paint(th.Pal.Dim, healthSummaryMsg(h))}
+}
+
+func decisionStatusColor(th *render.Theme, d health.Decision) (render.Status, render.Color) {
+	switch d {
+	case health.DecisionProceed:
+		return render.Healthy, th.Pal.Green
+	case health.DecisionWarn:
+		return render.Warn, th.Pal.Yellow
+	case health.DecisionBlock:
+		return render.Fail, th.Pal.Red
+	default:
+		return render.Unknown, th.Pal.Dim
+	}
+}
+
+func healthSummaryMsg(h *health.HealthSummary) string {
+	if len(h.Errors) > 0 {
+		return h.Errors[0]
+	}
+	if len(h.Warnings) > 0 {
+		return h.Warnings[0]
+	}
+	return "all checks passed"
+}

--- a/internal/commands/clusterview/detail_render_test.go
+++ b/internal/commands/clusterview/detail_render_test.go
@@ -1,0 +1,88 @@
+package clusterview
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dantech2000/refresh/internal/health"
+	"github.com/dantech2000/refresh/internal/render"
+	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
+)
+
+func sampleDetails() *clustersvc.ClusterDetails {
+	return &clustersvc.ClusterDetails{
+		Name:            "prod-west",
+		Status:          "ACTIVE",
+		Version:         "1.32",
+		PlatformVersion: "eks.8",
+		Endpoint:        "https://ABC123.gr7.us-west-2.eks.amazonaws.com",
+		Region:          "us-west-2",
+		Networking:      clustersvc.NetworkingInfo{VpcId: "vpc-0a1b", VpcCidr: "10.0.0.0/16"},
+		Security:        clustersvc.SecurityInfo{EncryptionEnabled: true, LoggingEnabled: []string{"api", "audit"}},
+		Nodegroups: []clustersvc.NodegroupSummary{
+			{Name: "general", Status: "ACTIVE", InstanceType: "m6i.large", DesiredSize: 6, ReadyNodes: 6},
+			{Name: "spot", Status: "DEGRADED", InstanceType: "m6i.xlarge", DesiredSize: 2, ReadyNodes: 1},
+		},
+		Addons: []clustersvc.AddonInfo{
+			{Name: "vpc-cni", Version: "v1.18.3", Status: "ACTIVE", Health: "Healthy"},
+		},
+		Health: &health.HealthSummary{
+			OverallScore: 82,
+			Decision:     health.DecisionWarn,
+			Warnings:     []string{"node balance skewed across AZs"},
+		},
+	}
+}
+
+func TestClusterDetailLines_Pretty(t *testing.T) {
+	th := render.New(render.ColorNone, true)
+	joined := strings.Join(clusterDetailLines(th, sampleDetails(), 0), "\n")
+
+	if strings.Contains(joined, "\x1b") {
+		t.Fatalf("ColorNone detail output contains ANSI escapes:\n%s", joined)
+	}
+	for _, want := range []string{
+		"prod-west   ● ACTIVE",             // header with status token
+		"▸ OVERVIEW",                       // section header
+		"1.32 · eks.8",                     // version KV with platform
+		"encryption  ● enabled (KMS)",      // security token
+		"▸ NODEGROUPS  1 active · 7 nodes", // section + meta (spot is DEGRADED)
+		"✗ DEGRADED",                       // spot's status cell
+		"6/6",                              // nodes cell
+		"▸ ADD-ONS  1 installed",
+		"vpc-cni",
+		"▸ HEALTH  82/100 · ▲ WARN",      // health card verdict
+		"node balance skewed across AZs", // health summary line
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("detail output missing %q in:\n%s", want, joined)
+		}
+	}
+}
+
+func TestClusterDetailLines_ASCIIAndMinimal(t *testing.T) {
+	th := render.New(render.ColorNone, false)
+	// Minimal cluster: no addons, no nodegroups, no health, zero CreatedAt.
+	d := &clustersvc.ClusterDetails{Name: "bare", Status: "ACTIVE", Version: "1.30"}
+	joined := strings.Join(clusterDetailLines(th, d, 0), "\n")
+	if strings.Contains(joined, "NODEGROUPS") || strings.Contains(joined, "ADD-ONS") || strings.Contains(joined, "HEALTH") {
+		t.Errorf("minimal cluster should omit empty sections:\n%s", joined)
+	}
+	if !strings.Contains(joined, "[OK] ACTIVE") { // ASCII status token
+		t.Errorf("ASCII status token missing:\n%s", joined)
+	}
+	if strings.ContainsAny(joined, "●▲✗▸") {
+		t.Errorf("ASCII fallback still contains Unicode glyphs:\n%s", joined)
+	}
+}
+
+func TestClusterDetailLines_CreatedAge(t *testing.T) {
+	th := render.New(render.ColorNone, true)
+	d := sampleDetails()
+	d.CreatedAt = time.Now().Add(-48 * time.Hour)
+	joined := strings.Join(clusterDetailLines(th, d, 0), "\n")
+	if !strings.Contains(joined, "created") {
+		t.Errorf("created row missing:\n%s", joined)
+	}
+}

--- a/internal/commands/clusterview/insights.go
+++ b/internal/commands/clusterview/insights.go
@@ -2,21 +2,30 @@ package clusterview
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/fatih/color"
 
+	"github.com/dantech2000/refresh/internal/render"
 	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
 	"github.com/dantech2000/refresh/internal/ui"
 )
 
 const insightTimeLayout = "2006-01-02 15:04"
 
-// OutputUpgradeCheck renders the upgrade-check report: AWS Cluster Insights
-// followed by the local control-plane/nodegroup/addon version-skew section.
+// OutputUpgradeCheck renders the upgrade-check report. The human path uses the
+// render design system (a readiness verdict + tokenized insights + skew); `-o
+// plain` keeps the uncolored tables.
 func OutputUpgradeCheck(report *clustersvc.UpgradeReport) error {
+	if !ui.PlainOutput() {
+		th := render.Default(os.Stdout)
+		for _, line := range upgradeCheckLines(th, report) {
+			fmt.Println(line)
+		}
+		return nil
+	}
 	ui.Outf("Upgrade readiness for %s\n", report.Cluster)
-
 	outputInsights(report.Insights)
 	fmt.Println()
 	outputSkew(report.Skew)

--- a/internal/commands/clusterview/insights_render.go
+++ b/internal/commands/clusterview/insights_render.go
@@ -1,0 +1,119 @@
+package clusterview
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dantech2000/refresh/internal/render"
+	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
+	"github.com/dantech2000/refresh/internal/ui"
+)
+
+// upgradeVerdict collapses the insight/skew severity into one readiness token:
+// any error → not ready (fail); any warning or version skew → review (warn);
+// otherwise ready (healthy).
+func upgradeVerdict(report *clustersvc.UpgradeReport) (render.Status, string) {
+	errc, warnc := 0, 0
+	for _, in := range report.Insights {
+		switch strings.ToUpper(in.Status) {
+		case clustersvc.InsightStatusError:
+			errc++
+		case clustersvc.InsightStatusWarning:
+			warnc++
+		}
+	}
+	switch {
+	case errc > 0:
+		return render.Fail, "NOT READY"
+	case warnc > 0 || len(report.Skew.Findings) > 0:
+		return render.Warn, "REVIEW"
+	default:
+		return render.Healthy, "READY"
+	}
+}
+
+func insightToken(th *render.Theme, status string) string {
+	switch strings.ToUpper(status) {
+	case clustersvc.InsightStatusError:
+		return th.Token(render.Fail, status)
+	case clustersvc.InsightStatusWarning:
+		return th.Token(render.Warn, status)
+	case clustersvc.InsightStatusPassing:
+		return th.Token(render.Healthy, status)
+	default:
+		return th.Token(render.Unknown, status)
+	}
+}
+
+// upgradeCheckLines builds the human `cluster upgrade-check` view (pure,
+// golden-testable): a readiness verdict, the AWS Cluster Insights table, and the
+// local version-skew section.
+func upgradeCheckLines(th *render.Theme, report *clustersvc.UpgradeReport) []string {
+	pal := th.Pal
+	st, verdict := upgradeVerdict(report)
+	out := []string{
+		th.Bold(pal.White, "UPGRADE READINESS") + th.Paint(pal.Dim, "  "+report.Cluster) + "   " + th.Tokenf(st, verdict),
+		"",
+		th.Section("INSIGHTS") + th.Paint(pal.Dim, fmt.Sprintf("  %d", len(report.Insights))),
+	}
+
+	if len(report.Insights) == 0 {
+		out = append(out, "  "+th.Token(render.Healthy, "no upgrade insights to address"))
+	} else {
+		tbl := th.NewTable(
+			ui.Column{Title: "NAME", Min: 20, Max: 48},
+			ui.Column{Title: "CATEGORY", Min: 14},
+			ui.Column{Title: "STATUS", Min: 10},
+			ui.Column{Title: "K8S", Min: 6},
+			ui.Column{Title: "LAST REFRESH", Min: 14},
+		)
+		var errc, warnc, passc int
+		for _, in := range report.Insights {
+			switch strings.ToUpper(in.Status) {
+			case clustersvc.InsightStatusError:
+				errc++
+			case clustersvc.InsightStatusWarning:
+				warnc++
+			case clustersvc.InsightStatusPassing:
+				passc++
+			}
+			refresh := "-"
+			if in.LastRefreshTime != nil {
+				refresh = in.LastRefreshTime.Format(insightTimeLayout)
+			}
+			tbl.Row(
+				th.Paint(pal.White, in.Name),
+				th.Paint(pal.Text, in.Category),
+				insightToken(th, in.Status),
+				th.Paint(pal.Text, valueOrDash(in.KubernetesVersion)),
+				th.Paint(pal.Dim, refresh),
+			)
+		}
+		for _, l := range tbl.Render() {
+			out = append(out, "  "+l)
+		}
+		out = append(out, "  "+insightCountChips(th, errc, warnc, passc))
+	}
+
+	out = append(out, "", th.Section("VERSION SKEW")+th.Paint(pal.Dim, "  control plane "+valueOrDash(report.Skew.ControlPlaneVersion)))
+	if len(report.Skew.Findings) == 0 {
+		out = append(out, "  "+th.Token(render.Healthy, "nodegroups and addons are current"))
+	} else {
+		for _, f := range report.Skew.Findings {
+			out = append(out, "  "+th.Token(render.Warn, f))
+		}
+	}
+	return out
+}
+
+func insightCountChips(th *render.Theme, errc, warnc, passc int) string {
+	var parts []string
+	if errc > 0 {
+		parts = append(parts, th.Token(render.Fail, fmt.Sprintf("%d error", errc)))
+	}
+	if warnc > 0 {
+		parts = append(parts, th.Token(render.Warn, fmt.Sprintf("%d warning", warnc)))
+	}
+	parts = append(parts, th.Token(render.Healthy, fmt.Sprintf("%d passing", passc)))
+	return joinSpaced(parts)
+}

--- a/internal/commands/clusterview/insights_render_test.go
+++ b/internal/commands/clusterview/insights_render_test.go
@@ -1,0 +1,62 @@
+package clusterview
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dantech2000/refresh/internal/render"
+	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
+)
+
+func TestUpgradeCheckLines_Verdicts(t *testing.T) {
+	th := render.New(render.ColorNone, true)
+
+	// Error insight → NOT READY.
+	rptErr := &clustersvc.UpgradeReport{
+		Cluster: "data-eu",
+		Insights: []clustersvc.InsightSummary{
+			{Name: "Deprecated APIs removed in 1.30", Category: "UPGRADE_READINESS", Status: clustersvc.InsightStatusError, KubernetesVersion: "1.30"},
+			{Name: "EKS add-on compatibility", Category: "ADDON", Status: clustersvc.InsightStatusPassing},
+		},
+		Skew: clustersvc.SkewReport{ControlPlaneVersion: "1.29", Findings: []string{"nodegroup ng-a is 2 minors behind"}},
+	}
+	joined := strings.Join(upgradeCheckLines(th, rptErr), "\n")
+	if strings.Contains(joined, "\x1b") {
+		t.Fatalf("ColorNone output contains ANSI:\n%s", joined)
+	}
+	for _, want := range []string{
+		"UPGRADE READINESS  data-eu   ✗ NOT READY",
+		"▸ INSIGHTS  2",
+		"✗ ERROR",
+		"● PASSING",
+		"1 error", "1 passing",
+		"▸ VERSION SKEW  control plane 1.29",
+		"▲ nodegroup ng-a is 2 minors behind",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("upgrade-check missing %q in:\n%s", want, joined)
+		}
+	}
+
+	// No insights, no skew → READY.
+	rptReady := &clustersvc.UpgradeReport{Cluster: "prod", Skew: clustersvc.SkewReport{ControlPlaneVersion: "1.33"}}
+	ready := strings.Join(upgradeCheckLines(th, rptReady), "\n")
+	for _, want := range []string{
+		"● READY",
+		"● no upgrade insights to address",
+		"● nodegroups and addons are current",
+	} {
+		if !strings.Contains(ready, want) {
+			t.Errorf("ready upgrade-check missing %q in:\n%s", want, ready)
+		}
+	}
+
+	// Warning only → REVIEW.
+	rptWarn := &clustersvc.UpgradeReport{
+		Cluster:  "stage",
+		Insights: []clustersvc.InsightSummary{{Name: "x", Status: clustersvc.InsightStatusWarning}},
+	}
+	if got := strings.Join(upgradeCheckLines(th, rptWarn), "\n"); !strings.Contains(got, "▲ REVIEW") {
+		t.Errorf("warning-only verdict should be REVIEW:\n%s", got)
+	}
+}

--- a/internal/commands/clusterview/list.go
+++ b/internal/commands/clusterview/list.go
@@ -2,6 +2,7 @@ package clusterview
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -9,17 +10,32 @@ import (
 	"github.com/fatih/color"
 
 	"github.com/dantech2000/refresh/internal/health"
+	"github.com/dantech2000/refresh/internal/render"
 	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
 	"github.com/dantech2000/refresh/internal/ui"
 )
 
-// OutputClustersTable renders a table of cluster summaries.
+// OutputClustersTable renders a table of cluster summaries. The human path uses
+// the render design system (tokenized status/health cells, a health summary
+// chip line); `-o plain` keeps the uncolored tab-separated table.
 func OutputClustersTable(summaries []clustersvc.ClusterSummary, elapsed time.Duration, multiRegion bool, showHealth bool) error {
 	if len(summaries) == 0 {
 		color.Yellow("No EKS clusters found")
 		return nil
 	}
+	if !ui.PlainOutput() {
+		th := render.Default(os.Stdout)
+		for _, line := range clusterListLines(th, summaries, multiRegion, showHealth) {
+			fmt.Println(line)
+		}
+		return nil
+	}
+	return outputClustersPlain(summaries, elapsed, multiRegion, showHealth)
+}
 
+// outputClustersPlain renders the uncolored tab-separated cluster table for
+// `-o plain`.
+func outputClustersPlain(summaries []clustersvc.ClusterSummary, elapsed time.Duration, multiRegion bool, showHealth bool) error {
 	if multiRegion {
 		regions := make(map[string]bool)
 		for _, s := range summaries {

--- a/internal/commands/clusterview/list_render.go
+++ b/internal/commands/clusterview/list_render.go
@@ -1,0 +1,112 @@
+package clusterview
+
+import (
+	"fmt"
+
+	"github.com/dantech2000/refresh/internal/health"
+	"github.com/dantech2000/refresh/internal/render"
+	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
+	"github.com/dantech2000/refresh/internal/ui"
+)
+
+func distinctRegionsSummary(summaries []clustersvc.ClusterSummary) int {
+	seen := make(map[string]struct{}, len(summaries))
+	for _, s := range summaries {
+		seen[s.Region] = struct{}{}
+	}
+	return len(seen)
+}
+
+// clusterListLines builds the human `cluster list` table (pure, golden-testable)
+// with tokenized status/health cells and an optional health summary chip line.
+func clusterListLines(th *render.Theme, summaries []clustersvc.ClusterSummary, multiRegion, showHealth bool) []string {
+	pal := th.Pal
+	head := th.Bold(pal.Mauve, "CLUSTERS") + "  " + th.Paint(pal.White, fmt.Sprintf("%d", len(summaries)))
+	if multiRegion {
+		head += th.Paint(pal.Dim, fmt.Sprintf(" · %d regions", distinctRegionsSummary(summaries)))
+	}
+	out := []string{head, ""}
+
+	cols := []ui.Column{{Title: "CLUSTER", Min: 14}}
+	if multiRegion {
+		cols = append(cols, ui.Column{Title: "REGION", Min: 10})
+	}
+	cols = append(cols, ui.Column{Title: "STATUS", Min: 9}, ui.Column{Title: "VERSION", Min: 7})
+	if showHealth {
+		cols = append(cols, ui.Column{Title: "HEALTH", Min: 8})
+	}
+	cols = append(cols, ui.Column{Title: "READY/DESIRED", Min: 15, Align: ui.AlignRight})
+
+	tbl := th.NewTable(cols...)
+	for _, s := range summaries {
+		row := []string{th.Paint(pal.White, s.Name)}
+		if multiRegion {
+			row = append(row, th.Paint(pal.Dim, s.Region))
+		}
+		row = append(row, statusToken(th, s.Status), th.Paint(pal.White, s.Version))
+		if showHealth {
+			row = append(row, decisionToken(th, s.Health))
+		}
+		row = append(row, th.Paint(pal.Text, fmt.Sprintf("%d/%d", s.NodeCount.Ready, s.NodeCount.Total)))
+		tbl.Row(row...)
+	}
+	out = append(out, tbl.Render()...)
+	if showHealth {
+		if chips := clusterHealthChips(th, summaries); chips != "" {
+			out = append(out, "", chips)
+		}
+	}
+	return out
+}
+
+// decisionToken renders a cluster's health decision as a colored token, or a
+// dim dash when health wasn't gathered.
+func decisionToken(th *render.Theme, h *health.HealthSummary) string {
+	if h == nil {
+		return th.Paint(th.Pal.Dim, "—")
+	}
+	st, _ := decisionStatusColor(th, h.Decision)
+	return th.Tokenf(st, string(h.Decision))
+}
+
+func clusterHealthChips(th *render.Theme, summaries []clustersvc.ClusterSummary) string {
+	var healthy, warning, critical int
+	for _, s := range summaries {
+		if s.Health == nil {
+			continue
+		}
+		switch s.Health.Decision {
+		case health.DecisionProceed:
+			healthy++
+		case health.DecisionWarn:
+			warning++
+		case health.DecisionBlock:
+			critical++
+		}
+	}
+	var parts []string
+	if healthy > 0 {
+		parts = append(parts, th.Token(render.Healthy, fmt.Sprintf("%d healthy", healthy)))
+	}
+	if warning > 0 {
+		parts = append(parts, th.Token(render.Warn, fmt.Sprintf("%d warning", warning)))
+	}
+	if critical > 0 {
+		parts = append(parts, th.Token(render.Fail, fmt.Sprintf("%d critical", critical)))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return joinSpaced(parts)
+}
+
+func joinSpaced(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += "   "
+		}
+		out += p
+	}
+	return out
+}

--- a/internal/commands/nodegroup/actions_update.go
+++ b/internal/commands/nodegroup/actions_update.go
@@ -78,6 +78,9 @@ func runUpdateAMI(ctx context.Context, cmd *cli.Command) error {
 	if err := runner.ValidateFormat(cmd.String("format"), runner.FormatsTableJSON); err != nil {
 		return err
 	}
+	if cmd.Bool("simulate") {
+		return runSimulatedRoll(ctx, cmd.String("nodegroup"))
+	}
 	if cmd.Bool("all-clusters") {
 		return runFleetUpdate(ctx, cmd)
 	}

--- a/internal/commands/nodegroup/actions_update.go
+++ b/internal/commands/nodegroup/actions_update.go
@@ -31,7 +31,7 @@ import (
 // updateAMIFlags collects the flags that govern runUpdateAMI's behavior.
 type updateAMIFlags struct {
 	force, dryRun, noWait, quiet, skipHealthCheck, healthOnly bool
-	yes, requireHealthy, skipVerify, changelog                bool
+	yes, requireHealthy, skipVerify, changelog, live          bool
 	timeout, pollInterval                                     time.Duration
 	format                                                    string
 	kubeconfig                                                string
@@ -51,6 +51,7 @@ func readUpdateAMIFlags(cmd *cli.Command) updateAMIFlags {
 		requireHealthy:  cmd.Bool("require-healthy"),
 		skipVerify:      cmd.Bool("skip-verify"),
 		changelog:       cmd.Bool("changelog"),
+		live:            cmd.Bool("live"),
 		timeout:         cmd.Duration("timeout"),
 		pollInterval:    cmd.Duration("poll-interval"),
 		format:          strings.ToLower(cmd.String("format")),
@@ -184,6 +185,17 @@ func executeUpdates(ctx context.Context, awsCfg aws.Config, eksClient *eks.Clien
 		NoWait:          flags.noWait,
 		Timeout:         flags.timeout,
 	}
+	// Live per-node roll view (opt-in, single nodegroup, interactive). Purely
+	// visual: it shows nodes draining/joining/terminating during the wait, then
+	// EKS DescribeUpdate (below) stays authoritative for the result. Any failure
+	// to observe degrades silently to the standard monitor output.
+	if flags.live && len(updates) == 1 && !quiet {
+		if kube := resolveHealthKubeClient(ctx, flags.kubeconfig, true); kube != nil {
+			runLiveRollForUpdate(ctx, kube, updates[0].NodegroupName, flags.timeout, flags.pollInterval)
+			monitor.Quiet, config.Quiet = true, true
+		}
+	}
+
 	monErr := monitoring.MonitorUpdates(ctx, eksClient, monitor, config)
 
 	verifyFailed := false

--- a/internal/commands/nodegroup/command.go
+++ b/internal/commands/nodegroup/command.go
@@ -165,6 +165,11 @@ Example (cron): refresh nodegroup update -c prod --yes --require-healthy -o json
 			&cli.BoolFlag{Name: "changelog", Usage: "In dry-run, print full amazon-eks-ami release notes between the current and target AMI"},
 			&cli.StringFlag{Name: "kubeconfig", Usage: "Path to the kubeconfig for workload/PDB health checks (defaults to $KUBECONFIG, then ~/.kube/config)"},
 			&cli.StringFlag{Name: "format", Aliases: []string{"o"}, Usage: "Output format: health results with --health-only; a JSON run summary with -o json", Value: "table"},
+			// --live shows the real-time per-node roll panel during the wait,
+			// driven from live Kubernetes state. Requires cluster (kubeconfig)
+			// access and a single nodegroup; falls back to standard monitoring
+			// otherwise. EKS DescribeUpdate stays authoritative for the result.
+			&cli.BoolFlag{Name: "live", Usage: "Show a live per-node roll view (nodes draining/joining/terminating) during the update — requires cluster access, single nodegroup, interactive"},
 			// --simulate drives the live node-roll panel from a scripted observer
 			// (no AWS, no cluster) — for demos, asciinema, and manual QA of the
 			// live view. Hidden: it's a dev/demo aid, not a real operation.

--- a/internal/commands/nodegroup/command.go
+++ b/internal/commands/nodegroup/command.go
@@ -165,6 +165,10 @@ Example (cron): refresh nodegroup update -c prod --yes --require-healthy -o json
 			&cli.BoolFlag{Name: "changelog", Usage: "In dry-run, print full amazon-eks-ami release notes between the current and target AMI"},
 			&cli.StringFlag{Name: "kubeconfig", Usage: "Path to the kubeconfig for workload/PDB health checks (defaults to $KUBECONFIG, then ~/.kube/config)"},
 			&cli.StringFlag{Name: "format", Aliases: []string{"o"}, Usage: "Output format: health results with --health-only; a JSON run summary with -o json", Value: "table"},
+			// --simulate drives the live node-roll panel from a scripted observer
+			// (no AWS, no cluster) — for demos, asciinema, and manual QA of the
+			// live view. Hidden: it's a dev/demo aid, not a real operation.
+			&cli.BoolFlag{Name: "simulate", Hidden: true, Usage: "Demo the live node-roll panel with simulated data (no AWS)"},
 		},
 		Action: runUpdateAMI,
 	}

--- a/internal/commands/nodegroup/formatters.go
+++ b/internal/commands/nodegroup/formatters.go
@@ -2,21 +2,37 @@ package nodegroup
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/fatih/color"
 
+	"github.com/dantech2000/refresh/internal/render"
 	nodegroupsvc "github.com/dantech2000/refresh/internal/services/nodegroup"
 	"github.com/dantech2000/refresh/internal/ui"
 )
 
+// outputNodegroupsTable renders the nodegroup list. The human path uses the
+// render design system (tokenized STATUS/AMI cells); `-o plain` keeps the
+// uncolored tab-separated table.
 func outputNodegroupsTable(clusterName string, items []nodegroupsvc.NodegroupSummary, elapsed time.Duration) error {
 	if len(items) == 0 {
 		color.Yellow("No nodegroups found for cluster: %s", clusterName)
 		return nil
 	}
+	if !ui.PlainOutput() {
+		th := render.Default(os.Stdout)
+		for _, line := range nodegroupListLines(th, clusterName, items) {
+			fmt.Println(line)
+		}
+		return nil
+	}
+	return outputNodegroupsPlain(clusterName, items, elapsed)
+}
+
+func outputNodegroupsPlain(clusterName string, items []nodegroupsvc.NodegroupSummary, elapsed time.Duration) error {
 	ui.Outf("Nodegroups for cluster: %s\n", clusterName)
 	ui.Outf("Retrieved in %s\n", ui.ElapsedString(elapsed))
 	ui.Outln()

--- a/internal/commands/nodegroup/list_render.go
+++ b/internal/commands/nodegroup/list_render.go
@@ -1,0 +1,51 @@
+package nodegroup
+
+import (
+	"fmt"
+
+	"github.com/dantech2000/refresh/internal/render"
+	nodegroupsvc "github.com/dantech2000/refresh/internal/services/nodegroup"
+	"github.com/dantech2000/refresh/internal/types"
+	"github.com/dantech2000/refresh/internal/ui"
+)
+
+// nodegroupListLines builds the human `nodegroup list` table (pure,
+// golden-testable) with tokenized STATUS and AMI cells.
+func nodegroupListLines(th *render.Theme, cluster string, items []nodegroupsvc.NodegroupSummary) []string {
+	pal := th.Pal
+	out := []string{
+		th.Bold(pal.Mauve, "NODEGROUPS") + "  " + th.Paint(pal.White, cluster) +
+			th.Paint(pal.Dim, fmt.Sprintf(" · %d", len(items))),
+		"",
+	}
+	tbl := th.NewTable(
+		ui.Column{Title: "NAME", Min: 4, Max: 60},
+		ui.Column{Title: "STATUS", Min: 10},
+		ui.Column{Title: "INSTANCE", Min: 10},
+		ui.Column{Title: "AMI", Min: 9},
+		ui.Column{Title: "NODES", Min: 7, Align: ui.AlignRight},
+	)
+	for _, ng := range items {
+		tbl.Row(
+			th.Paint(pal.White, ng.Name),
+			th.Token(render.StatusFromString(ng.Status), ng.Status),
+			th.Paint(pal.Text, ng.InstanceType),
+			amiToken(th, ng.AMIStatus),
+			th.Paint(pal.Text, fmt.Sprintf("%d/%d", ng.ReadyNodes, ng.DesiredSize)),
+		)
+	}
+	out = append(out, tbl.Render()...)
+	return out
+}
+
+// amiToken renders a nodegroup's AMI freshness as a status token.
+func amiToken(th *render.Theme, s types.AMIStatus) string {
+	switch s {
+	case types.AMILatest:
+		return th.Token(render.Healthy, s.String())
+	case types.AMIOutdated:
+		return th.Token(render.Warn, s.String())
+	default:
+		return th.Token(render.Unknown, s.String())
+	}
+}

--- a/internal/commands/nodegroup/list_render_test.go
+++ b/internal/commands/nodegroup/list_render_test.go
@@ -1,0 +1,50 @@
+package nodegroup
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dantech2000/refresh/internal/render"
+	nodegroupsvc "github.com/dantech2000/refresh/internal/services/nodegroup"
+	"github.com/dantech2000/refresh/internal/types"
+)
+
+func sampleNodegroups() []nodegroupsvc.NodegroupSummary {
+	return []nodegroupsvc.NodegroupSummary{
+		{Name: "general", Status: "ACTIVE", InstanceType: "m6i.large", AMIStatus: types.AMILatest, ReadyNodes: 6, DesiredSize: 6},
+		{Name: "spot", Status: "DEGRADED", InstanceType: "m6i.xlarge", AMIStatus: types.AMIOutdated, ReadyNodes: 1, DesiredSize: 2},
+	}
+}
+
+func TestNodegroupListLines(t *testing.T) {
+	th := render.New(render.ColorNone, true)
+	joined := strings.Join(nodegroupListLines(th, "prod", sampleNodegroups()), "\n")
+
+	if strings.Contains(joined, "\x1b") {
+		t.Fatalf("ColorNone output contains ANSI escapes:\n%s", joined)
+	}
+	for _, want := range []string{
+		"NODEGROUPS  prod · 2",
+		"● ACTIVE",
+		"✗ DEGRADED", // DEGRADED -> fail token
+		"6/6",
+		"1/2",
+		"● " + types.AMILatest.String(),   // up-to-date AMI -> healthy token
+		"▲ " + types.AMIOutdated.String(), // outdated AMI -> warn token
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("nodegroup list missing %q in:\n%s", want, joined)
+		}
+	}
+}
+
+func TestNodegroupListLines_ASCII(t *testing.T) {
+	th := render.New(render.ColorNone, false)
+	joined := strings.Join(nodegroupListLines(th, "prod", sampleNodegroups()), "\n")
+	if !strings.Contains(joined, "[OK] ACTIVE") || !strings.Contains(joined, "[X] DEGRADED") {
+		t.Errorf("ASCII tokens missing:\n%s", joined)
+	}
+	if strings.ContainsAny(joined, "●▲✗") {
+		t.Errorf("ASCII fallback still has Unicode glyphs:\n%s", joined)
+	}
+}

--- a/internal/commands/nodegroup/output_test.go
+++ b/internal/commands/nodegroup/output_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dantech2000/refresh/internal/health"
 	nodegroupsvc "github.com/dantech2000/refresh/internal/services/nodegroup"
 	"github.com/dantech2000/refresh/internal/types"
+	"github.com/dantech2000/refresh/internal/ui"
 )
 
 // captureStdout is defined in health_decision_test.go (redirects both
@@ -36,16 +37,28 @@ func TestOutputNodegroupsTable_WithRows(t *testing.T) {
 		{Name: "workers", Status: "ACTIVE", InstanceType: "m5.large", AMIStatus: types.AMILatest, ReadyNodes: 3, DesiredSize: 3},
 		{Name: "spot", Status: "UPDATING", InstanceType: "t3.medium", AMIStatus: types.AMIOutdated, ReadyNodes: 1, DesiredSize: 2},
 	}
-	// pterm renders the table body to its own (TTY-detecting) writer, which a
-	// captured pipe suppresses; assert on the reliably-captured intro line and
-	// that the call itself succeeds for a non-empty set.
+	// Human path (render design system): captured in full via fmt.Println.
 	out := captureStdout(t, func() {
 		if err := outputNodegroupsTable("my-cluster", items, 2*time.Second); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
-	if !strings.Contains(out, "Nodegroups for cluster: my-cluster") {
-		t.Errorf("table output missing cluster header; got:\n%s", out)
+	for _, want := range []string{"NODEGROUPS", "my-cluster"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q; got:\n%s", want, out)
+		}
+	}
+
+	// Plain path keeps the original cluster banner.
+	ui.SetPlainOutput(true)
+	defer ui.SetPlainOutput(false)
+	plain := captureStdout(t, func() {
+		if err := outputNodegroupsTable("my-cluster", items, 2*time.Second); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(plain, "Nodegroups for cluster: my-cluster") {
+		t.Errorf("plain output missing cluster banner; got:\n%s", plain)
 	}
 }
 

--- a/internal/commands/nodegroup/rollpanel.go
+++ b/internal/commands/nodegroup/rollpanel.go
@@ -132,6 +132,9 @@ func nodeStateCell(th *render.Theme, n noderoll.NodeView) string {
 		s := th.Paint(th.Pal.Yellow, "draining")
 		if n.PodsTotal > 0 {
 			evicted := n.PodsTotal - n.Pods
+			if evicted < 0 {
+				evicted = 0
+			}
 			s += th.Paint(th.Pal.Dim, " · evicting ") + th.Bar(evicted, n.PodsTotal, 5, th.Pal.Yellow) +
 				th.Paint(th.Pal.Dim, fmt.Sprintf(" %d/%d pods", evicted, n.PodsTotal))
 		}

--- a/internal/commands/nodegroup/rollpanel.go
+++ b/internal/commands/nodegroup/rollpanel.go
@@ -1,0 +1,187 @@
+package nodegroup
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/dantech2000/refresh/internal/noderoll"
+	"github.com/dantech2000/refresh/internal/render"
+	"github.com/dantech2000/refresh/internal/ui"
+)
+
+// rollMeta is the static context for a live roll panel.
+type rollMeta struct {
+	Nodegroup      string
+	OldAMI, NewAMI string
+	Desired        int
+	Frame          int // spinner tick, advanced by the driver
+}
+
+var rollSpinner = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+func phaseStatus(p noderoll.Phase) render.Status {
+	switch p {
+	case noderoll.PhaseReady:
+		return render.Healthy
+	case noderoll.PhaseJoining:
+		return render.Progress
+	case noderoll.PhaseDraining:
+		return render.Warn
+	default:
+		return render.Unknown
+	}
+}
+
+func eventToken(kind noderoll.EventKind) (render.Status, string) {
+	switch kind {
+	case noderoll.EvtJoining:
+		return render.Progress, "scaling up, joining"
+	case noderoll.EvtOnline:
+		return render.Healthy, "came online (Ready)"
+	case noderoll.EvtDraining:
+		return render.Warn, "cordoned, draining"
+	case noderoll.EvtTerminated:
+		return render.Neutral, "drained & terminated"
+	default:
+		return render.Neutral, string(kind)
+	}
+}
+
+// rollPanelLines builds the live node-roll panel as a slice of lines (pure, so
+// it is golden-testable): a header with overall progress, a per-node table
+// (AMI + lifecycle state + pod-eviction bar), and a recent-events feed.
+func rollPanelLines(th *render.Theme, snap noderoll.Snapshot, events []noderoll.Event, m rollMeta) []string {
+	pal := th.Pal
+
+	oldRemaining := 0
+	for _, n := range snap.Nodes {
+		if !n.OnTarget {
+			oldRemaining++
+		}
+	}
+	replaced := m.Desired - oldRemaining
+	if replaced < 0 {
+		replaced = 0
+	}
+	active := snap.Joining > 0 || snap.Draining > 0 || replaced < m.Desired
+
+	head := th.Glyph(render.Healthy)
+	if active {
+		head = spin(th, m.Frame)
+	}
+	out := []string{
+		head + " " + th.Paint(pal.White, "rolling "+m.Nodegroup) +
+			th.Paint(pal.Dim, "   ") + th.Paint(pal.Peach, m.OldAMI) +
+			th.Paint(pal.Dim, " → ") + th.Paint(pal.Green, m.NewAMI),
+		th.Bar(replaced, m.Desired, 16, pal.Green) + "  " +
+			th.Paint(pal.White, fmt.Sprintf("%d/%d replaced", replaced, m.Desired)) +
+			th.Paint(pal.Dim, " · ") + th.Paint(pal.White, fmt.Sprintf("%d new ready", snap.ReadyTarget)),
+		"",
+	}
+
+	tbl := th.NewTable(
+		ui.Column{Title: "", Min: 1},
+		ui.Column{Title: "NODE", Min: 14},
+		ui.Column{Title: "AMI", Min: 3},
+		ui.Column{Title: "STATE", Min: 10},
+	)
+	for _, n := range snap.Nodes {
+		tbl.Row(
+			th.Glyph(phaseStatus(n.Phase)),
+			th.Paint(pal.White, n.Name),
+			amiWord(th, n.OnTarget),
+			nodeStateCell(th, n),
+		)
+	}
+	for _, l := range tbl.Render() {
+		out = append(out, "  "+l)
+	}
+
+	out = append(out, "", th.Paint(pal.Dim, "events"))
+	for _, e := range events {
+		st, text := eventToken(e.Kind)
+		out = append(out, "    "+th.Glyph(st)+" "+th.Paint(pal.White, e.Node)+th.Paint(pal.Dim, "  "+text))
+	}
+	return out
+}
+
+func spin(th *render.Theme, frame int) string {
+	if !th.Unicode {
+		return th.Paint(th.Pal.Teal, "*")
+	}
+	return th.Paint(th.Pal.Teal, rollSpinner[frame%len(rollSpinner)])
+}
+
+func amiWord(th *render.Theme, onTarget bool) string {
+	if onTarget {
+		return th.Paint(th.Pal.Green, "new")
+	}
+	return th.Paint(th.Pal.Peach, "old")
+}
+
+func nodeStateCell(th *render.Theme, n noderoll.NodeView) string {
+	switch n.Phase {
+	case noderoll.PhaseReady:
+		return th.Paint(th.Pal.Green, "Ready")
+	case noderoll.PhaseJoining:
+		return th.Paint(th.Pal.Dim, "joining (NotReady)")
+	case noderoll.PhaseDraining:
+		s := th.Paint(th.Pal.Yellow, "draining")
+		if n.PodsTotal > 0 {
+			evicted := n.PodsTotal - n.Pods
+			s += th.Paint(th.Pal.Dim, " · evicting ") + th.Bar(evicted, n.PodsTotal, 5, th.Pal.Yellow) +
+				th.Paint(th.Pal.Dim, fmt.Sprintf(" %d/%d pods", evicted, n.PodsTotal))
+		}
+		return s
+	default:
+		return th.Paint(th.Pal.Dim, "unknown")
+	}
+}
+
+// runRoll drives the live panel from obs until done(snapshot) is true or ctx is
+// cancelled, repainting in place on a TTY and appending snapshots when piped.
+func runRoll(ctx context.Context, th *render.Theme, w io.Writer, obs noderoll.Observer, m rollMeta, interval time.Duration, done func(noderoll.Snapshot) bool) error {
+	tr := noderoll.NewTracker()
+	lr := th.NewLiveRegion(w)
+	frame := 0
+	return lr.Run(ctx, interval, func() ([]string, bool) {
+		snap, err := obs.Snapshot(ctx)
+		if err != nil {
+			return []string{th.Token(render.Fail, "observer error: "+err.Error())}, true
+		}
+		tr.Observe(snap)
+		frame++
+		m.Frame = frame
+		return rollPanelLines(th, snap, tr.Recent(6), m), done(snap)
+	})
+}
+
+// rollComplete reports whether every node is the desired count, Ready, and on
+// the target AMI.
+func rollComplete(desired int) func(noderoll.Snapshot) bool {
+	return func(s noderoll.Snapshot) bool {
+		return s.Total > 0 && s.ReadyTarget >= desired && s.Draining == 0 && s.Joining == 0
+	}
+}
+
+// runSimulatedRoll renders the live node-roll panel against a scripted observer
+// (no AWS / no cluster). Backs `nodegroup update --simulate` for demos and QA.
+func runSimulatedRoll(ctx context.Context, nodegroup string) error {
+	if nodegroup == "" {
+		nodegroup = "spot-burst"
+	}
+	th := render.Default(os.Stdout)
+	m := rollMeta{Nodegroup: nodegroup, OldAMI: "ami-0a1b…", NewAMI: "ami-0f9e…", Desired: 3}
+	obs := noderoll.NewScriptedObserver(noderoll.DemoTimeline())
+
+	fmt.Println()
+	if err := runRoll(ctx, th, os.Stdout, obs, m, 160*time.Millisecond, rollComplete(m.Desired)); err != nil {
+		return err
+	}
+	fmt.Println()
+	fmt.Println(th.Token(render.Healthy, fmt.Sprintf("%s rolled — 3/3 on %s", nodegroup, m.NewAMI)))
+	return nil
+}

--- a/internal/commands/nodegroup/rollpanel.go
+++ b/internal/commands/nodegroup/rollpanel.go
@@ -7,10 +7,17 @@ import (
 	"os"
 	"time"
 
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/dantech2000/refresh/internal/noderoll"
 	"github.com/dantech2000/refresh/internal/render"
 	"github.com/dantech2000/refresh/internal/ui"
 )
+
+// liveRollPoll is how often the live roll panel re-reads cluster state. Kept
+// snappy (vs the EKS --poll-interval) so the view feels live, while staying
+// cheap: a node + pod list every few seconds.
+const liveRollPoll = 3 * time.Second
 
 // rollMeta is the static context for a live roll panel.
 type rollMeta struct {
@@ -187,4 +194,41 @@ func runSimulatedRoll(ctx context.Context, nodegroup string) error {
 	fmt.Println()
 	fmt.Println(th.Token(render.Healthy, fmt.Sprintf("%s rolled — 3/3 on %s", nodegroup, m.NewAMI)))
 	return nil
+}
+
+// runLiveRollForUpdate renders the live per-node roll panel for a real update by
+// observing live Kubernetes state until every roll-start node is replaced
+// (rollComplete) or the timeout fires. Purely visual and best-effort: it never
+// returns an error to the caller, so it cannot affect the update or its exit
+// code — EKS DescribeUpdate remains authoritative. Old-vs-new is determined by a
+// roll-start baseline (no need to know the target AMI ID up front).
+func runLiveRollForUpdate(ctx context.Context, kube kubernetes.Interface, nodegroup string, timeout, pollInterval time.Duration) {
+	if kube == nil {
+		return
+	}
+	obs := noderoll.NewKubeObserver(kube, nodegroup, "")
+	if err := obs.CaptureBaseline(ctx); err != nil {
+		return // can't read the cluster — degrade to the standard monitor
+	}
+	snap0, err := obs.Snapshot(ctx)
+	if err != nil || snap0.Total == 0 {
+		return
+	}
+	desired := snap0.Total
+
+	poll := pollInterval
+	if poll <= 0 || poll > liveRollPoll {
+		poll = liveRollPoll
+	}
+	rollCtx := ctx
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		rollCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	th := render.Default(os.Stdout)
+	m := rollMeta{Nodegroup: nodegroup, OldAMI: "current AMI", NewAMI: "recommended AMI", Desired: desired}
+	fmt.Println()
+	_ = runRoll(rollCtx, th, os.Stdout, obs, m, poll, rollComplete(desired))
 }

--- a/internal/commands/nodegroup/rollpanel_integration_test.go
+++ b/internal/commands/nodegroup/rollpanel_integration_test.go
@@ -1,0 +1,89 @@
+package nodegroup
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/dantech2000/refresh/internal/noderoll"
+	"github.com/dantech2000/refresh/internal/render"
+)
+
+func kn(name string, ready, cordoned bool) *corev1.Node {
+	cond := corev1.ConditionFalse
+	if ready {
+		cond = corev1.ConditionTrue
+	}
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{noderoll.LabelNodegroup: "spot-burst"},
+		},
+		Spec:   corev1.NodeSpec{Unschedulable: cordoned},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: cond}}},
+	}
+}
+
+// Proves the REAL observer path (KubeObserver over a fake cluster, baseline
+// mode) feeds the live panel — no AWS, no live cluster. A mid-roll fake cluster
+// renders the expected draining/joining/ready view.
+func TestRollPanel_FromKubeObserver(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewClientset(
+		kn("ip-1", true, false),
+		kn("ip-2", true, false),
+		kn("ip-3", true, false),
+	)
+	obs := noderoll.NewKubeObserver(client, "spot-burst", "")
+	if err := obs.CaptureBaseline(ctx); err != nil { // ip-1..3 are "old"
+		t.Fatal(err)
+	}
+
+	// Mid-roll: surge a new node (joining), cordon an old one (draining).
+	if _, err := client.CoreV1().Nodes().Create(ctx, kn("ip-4", false, false), metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	n1, _ := client.CoreV1().Nodes().Get(ctx, "ip-1", metav1.GetOptions{})
+	n1.Spec.Unschedulable = true
+	if _, err := client.CoreV1().Nodes().Update(ctx, n1, metav1.UpdateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := obs.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := noderoll.NewTracker()
+	tr.Observe(snap) // baseline-seed for the panel feed
+
+	th := render.New(render.ColorNone, true)
+	m := rollMeta{Nodegroup: "spot-burst", OldAMI: "ami-old", NewAMI: "ami-new", Desired: 3}
+	joined := strings.Join(rollPanelLines(th, snap, tr.Recent(6), m), "\n")
+
+	for _, want := range []string{
+		"rolling spot-burst",
+		"ip-1", "ip-4",
+		"draining",           // cordoned old node
+		"joining (NotReady)", // new node not ready
+		"old",                // baseline nodes are old
+		"new",                // ip-4 is new (appeared after baseline)
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("panel from KubeObserver missing %q in:\n%s", want, joined)
+		}
+	}
+	// ip-4 appeared after the baseline → must be classified on-target (new).
+	var ip4 noderoll.NodeView
+	for _, n := range snap.Nodes {
+		if n.Name == "ip-4" {
+			ip4 = n
+		}
+	}
+	if !ip4.OnTarget {
+		t.Errorf("ip-4 should be OnTarget (appeared after baseline): %+v", ip4)
+	}
+}

--- a/internal/commands/nodegroup/rollpanel_live_test.go
+++ b/internal/commands/nodegroup/rollpanel_live_test.go
@@ -1,0 +1,27 @@
+package nodegroup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// runLiveRollForUpdate must be best-effort and bounded: a nil client returns
+// immediately, and a cluster that never converges is bounded by the timeout
+// (never hangs the update). Output is swallowed via captureStdout.
+func TestRunLiveRollForUpdate_DegradesAndBounds(t *testing.T) {
+	_ = captureStdout(t, func() {
+		// nil client → immediate, no panic.
+		runLiveRollForUpdate(context.Background(), nil, "ng", time.Second, time.Second)
+
+		// A fake cluster whose old node never gets replaced → bounded by timeout.
+		client := fake.NewClientset(kn("ip-1", true, false))
+		start := time.Now()
+		runLiveRollForUpdate(context.Background(), client, "spot-burst", 40*time.Millisecond, 10*time.Millisecond)
+		if elapsed := time.Since(start); elapsed > 5*time.Second {
+			t.Fatalf("runLiveRollForUpdate did not respect timeout bound: %v", elapsed)
+		}
+	})
+}

--- a/internal/commands/nodegroup/rollpanel_test.go
+++ b/internal/commands/nodegroup/rollpanel_test.go
@@ -1,0 +1,59 @@
+package nodegroup
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dantech2000/refresh/internal/noderoll"
+	"github.com/dantech2000/refresh/internal/render"
+)
+
+func TestRollPanelLines_MidRoll(t *testing.T) {
+	th := render.New(render.ColorNone, true)
+	snap := noderoll.Snapshot{
+		Total: 4, ReadyTarget: 1, Draining: 1, Joining: 1,
+		Nodes: []noderoll.NodeView{
+			{Name: "ip-1", OnTarget: false, Ready: true, Phase: noderoll.PhaseDraining, Pods: 1, PodsTotal: 4},
+			{Name: "ip-2", OnTarget: false, Ready: true, Phase: noderoll.PhaseReady},
+			{Name: "ip-3", OnTarget: true, Ready: true, Phase: noderoll.PhaseReady},
+			{Name: "ip-4", OnTarget: true, Ready: false, Phase: noderoll.PhaseJoining},
+		},
+	}
+	events := []noderoll.Event{
+		{Node: "ip-3", Kind: noderoll.EvtOnline},
+		{Node: "ip-1", Kind: noderoll.EvtDraining},
+	}
+	m := rollMeta{Nodegroup: "spot-burst", OldAMI: "ami-old", NewAMI: "ami-new", Desired: 3, Frame: 2}
+	joined := strings.Join(rollPanelLines(th, snap, events, m), "\n")
+
+	if strings.Contains(joined, "\x1b") {
+		t.Fatalf("ColorNone panel contains ANSI escapes:\n%s", joined)
+	}
+	// Assert the salient, stable bits.
+	for _, want := range []string{
+		"rolling spot-burst",
+		"ami-old → ami-new",
+		"1/3 replaced",
+		"1 new ready",
+		"old", "new", // AMI words
+		"draining · evicting",
+		"3/4 pods",
+		"joining (NotReady)",
+		"events",
+		"ip-3", "ip-1", // event feed nodes
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("panel missing %q in:\n%s", want, joined)
+		}
+	}
+}
+
+func TestRollComplete(t *testing.T) {
+	done := rollComplete(3)
+	if done(noderoll.Snapshot{Total: 3, ReadyTarget: 3}) != true {
+		t.Error("expected complete when 3/3 ready on target")
+	}
+	if done(noderoll.Snapshot{Total: 4, ReadyTarget: 2, Draining: 1}) != false {
+		t.Error("expected not complete mid-roll")
+	}
+}

--- a/internal/commands/statusview/fleet_render.go
+++ b/internal/commands/statusview/fleet_render.go
@@ -1,0 +1,228 @@
+package statusview
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dantech2000/refresh/internal/render"
+	statussvc "github.com/dantech2000/refresh/internal/services/status"
+	"github.com/dantech2000/refresh/internal/ui"
+)
+
+// overall collapses a cluster's posture into one status token: unsupported EKS
+// is a failure, extended support or stale AMIs/addons is a warning, otherwise
+// it's current.
+func overall(c statussvc.ClusterStatus) render.Status {
+	switch {
+	case c.Support.Tier == statussvc.SupportUnsupported:
+		return render.Fail
+	case c.SupportRisk() || c.NeedsAttention():
+		return render.Warn
+	default:
+		return render.Healthy
+	}
+}
+
+func distinctRegions(statuses []statussvc.ClusterStatus) int {
+	seen := make(map[string]struct{}, len(statuses))
+	for _, c := range statuses {
+		seen[c.Region] = struct{}{}
+	}
+	return len(seen)
+}
+
+func nameOr(c statussvc.ClusterStatus) string {
+	if c.Name == "" {
+		return "unknown"
+	}
+	return c.Name
+}
+
+// fleetLines builds the human fleet dashboard as a slice of lines (pure, so it
+// is golden-testable). th carries the color level / unicode capability.
+func fleetLines(th *render.Theme, statuses []statussvc.ClusterStatus, elapsed time.Duration) []string {
+	pal := th.Pal
+	out := []string{
+		th.Bold(pal.Mauve, "FLEET") + "  " +
+			th.Paint(pal.White, fmt.Sprintf("%d clusters", len(statuses))) +
+			th.Paint(pal.Dim, fmt.Sprintf(" · %d region(s)", distinctRegions(statuses))),
+		"",
+		chipsLine(th, statuses),
+		"",
+	}
+
+	tbl := th.NewTable(
+		ui.Column{Title: "", Min: 1},
+		ui.Column{Title: "CLUSTER", Min: 8},
+		ui.Column{Title: "REGION", Min: 6},
+		ui.Column{Title: "VERSION", Min: 7},
+		ui.Column{Title: "SUPPORT", Min: 10, Max: 34},
+		ui.Column{Title: "COMPUTE", Min: 8, Max: 22},
+		ui.Column{Title: "STALE AMI", Min: 6},
+		ui.Column{Title: "ADDONS", Min: 6, Max: 26},
+	)
+	for _, c := range statuses {
+		version := c.Version
+		if version == "" {
+			version = "unknown"
+		}
+		tbl.Row(
+			th.Glyph(overall(c)),
+			th.Paint(pal.White, nameOr(c)),
+			th.Paint(pal.Dim, c.Region),
+			th.Paint(pal.White, version),
+			supportPretty(th, c.Support),
+			computePretty(th, c),
+			stalePretty(th, c),
+			addonsPretty(th, c.AddonsBehind),
+		)
+	}
+	out = append(out, tbl.Render()...)
+	out = append(out, "", footerPretty(th, statuses, elapsed))
+	if h := hintLine(th, statuses); h != "" {
+		out = append(out, "", h)
+	}
+	return out
+}
+
+func chipsLine(th *render.Theme, statuses []statussvc.ClusterStatus) string {
+	var healthy, warn, fail int
+	for _, c := range statuses {
+		switch overall(c) {
+		case render.Healthy:
+			healthy++
+		case render.Warn:
+			warn++
+		case render.Fail:
+			fail++
+		}
+	}
+	parts := []string{th.Token(render.Healthy, fmt.Sprintf("%d current", healthy))}
+	if warn > 0 {
+		parts = append(parts, th.Token(render.Warn, fmt.Sprintf("%d need attention", warn)))
+	}
+	if fail > 0 {
+		parts = append(parts, th.Token(render.Fail, fmt.Sprintf("%d unsupported", fail)))
+	}
+	return strings.Join(parts, "   ")
+}
+
+func supportPretty(th *render.Theme, s statussvc.SupportPosture) string {
+	switch s.Tier {
+	case statussvc.SupportStandard:
+		txt := "standard"
+		if s.DaysRemaining != nil {
+			txt += fmt.Sprintf(" (%dd)", *s.DaysRemaining)
+		}
+		return th.Paint(th.Pal.Green, txt)
+	case statussvc.SupportExtended:
+		txt := "extended"
+		if s.DaysRemaining != nil {
+			txt += fmt.Sprintf(" (%dd)", *s.DaysRemaining)
+		}
+		return th.Token(render.Warn, txt)
+	case statussvc.SupportUnsupported:
+		return th.Token(render.Fail, "unsupported")
+	default:
+		return th.Paint(th.Pal.Dim, "unknown")
+	}
+}
+
+func computePretty(th *render.Theme, c statussvc.ClusterStatus) string {
+	switch c.Compute {
+	case statussvc.ComputeManaged:
+		return th.Paint(th.Pal.Dim, fmt.Sprintf("%d nodegroups", c.NodegroupCount))
+	case statussvc.ComputeAutoMode:
+		return th.Paint(th.Pal.Teal, "Auto Mode")
+	case statussvc.ComputeKarpenter:
+		return th.Paint(th.Pal.Teal, "Karpenter")
+	default:
+		return th.Paint(th.Pal.Dim, "none")
+	}
+}
+
+func stalePretty(th *render.Theme, c statussvc.ClusterStatus) string {
+	if c.Compute != statussvc.ComputeManaged {
+		return th.Paint(th.Pal.Dim, "n/a")
+	}
+	if c.StaleAMI.Behind == 0 {
+		return th.Paint(th.Pal.Green, "0")
+	}
+	txt := fmt.Sprintf("%d/%d", c.StaleAMI.Behind, c.StaleAMI.Total)
+	if c.StaleAMI.OldestDays != nil {
+		txt += fmt.Sprintf(" (%dd)", *c.StaleAMI.OldestDays)
+	}
+	return th.Token(render.Warn, txt)
+}
+
+func addonsPretty(th *render.Theme, a statussvc.AddonsBehindSummary) string {
+	if a.Behind == 0 {
+		return th.Paint(th.Pal.Green, "0")
+	}
+	names := a.Names
+	suffix := ""
+	const maxNames = 2
+	if len(names) > maxNames {
+		suffix = fmt.Sprintf(" +%d", len(names)-maxNames)
+		names = names[:maxNames]
+	}
+	return th.Token(render.Warn, fmt.Sprintf("%d (%s%s)", a.Behind, strings.Join(names, ","), suffix))
+}
+
+func footerPretty(th *render.Theme, statuses []statussvc.ClusterStatus, elapsed time.Duration) string {
+	staleNG, addonsBehind, supportRisk := 0, 0, 0
+	for _, c := range statuses {
+		staleNG += c.StaleAMI.Behind
+		addonsBehind += c.AddonsBehind.Behind
+		if c.SupportRisk() {
+			supportRisk++
+		}
+	}
+	txt := fmt.Sprintf("%d clusters · %d stale nodegroups · %d addons behind · %d extended/unsupported",
+		len(statuses), staleNG, addonsBehind, supportRisk)
+	clean := staleNG == 0 && addonsBehind == 0 && supportRisk == 0
+	line := th.Paint(th.Pal.Dim, txt)
+	if clean {
+		line = th.Paint(th.Pal.Green, txt)
+	}
+	if elapsed > 0 {
+		line += th.Paint(th.Pal.Dim, fmt.Sprintf("  (%s)", elapsed.Round(time.Millisecond)))
+	}
+	return line
+}
+
+// hintLine points at the most urgent cluster (a failure first, else a warning)
+// with the command to dig in.
+func hintLine(th *render.Theme, statuses []statussvc.ClusterStatus) string {
+	var worst *statussvc.ClusterStatus
+	for i := range statuses {
+		if overall(statuses[i]) == render.Fail {
+			worst = &statuses[i]
+			break
+		}
+	}
+	if worst == nil {
+		for i := range statuses {
+			if overall(statuses[i]) == render.Warn {
+				worst = &statuses[i]
+				break
+			}
+		}
+	}
+	if worst == nil {
+		return ""
+	}
+	st := overall(*worst)
+	reason := "needs attention"
+	switch {
+	case st == render.Fail:
+		reason = "is on unsupported EKS"
+	case worst.NeedsAttention():
+		reason = "has stale AMIs/addons"
+	}
+	name := nameOr(*worst)
+	return th.Glyph(st) + " " + th.Paint(th.Pal.White, name) +
+		th.Paint(th.Pal.Dim, " "+reason+" → ") +
+		th.Paint(th.Pal.Blue, "refresh cluster upgrade-check -c "+name)
+}

--- a/internal/commands/statusview/fleet_render_test.go
+++ b/internal/commands/statusview/fleet_render_test.go
@@ -1,0 +1,106 @@
+package statusview
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dantech2000/refresh/internal/render"
+	statussvc "github.com/dantech2000/refresh/internal/services/status"
+)
+
+func iptr(i int) *int { return &i }
+
+func sampleFleet() []statussvc.ClusterStatus {
+	return []statussvc.ClusterStatus{
+		{ // current: standard support, nothing stale
+			Name: "prod-east", Region: "us-east-1", Version: "1.32",
+			Support:        statussvc.SupportPosture{Tier: statussvc.SupportStandard, DaysRemaining: iptr(200)},
+			Compute:        statussvc.ComputeManaged,
+			NodegroupCount: 3,
+		},
+		{ // warning: standard support but an addon behind
+			Name: "staging", Region: "us-west-2", Version: "1.31",
+			Support:        statussvc.SupportPosture{Tier: statussvc.SupportStandard, DaysRemaining: iptr(320)},
+			Compute:        statussvc.ComputeManaged,
+			NodegroupCount: 2,
+			AddonsBehind:   statussvc.AddonsBehindSummary{Total: 4, Behind: 1, Names: []string{"kube-proxy"}},
+		},
+		{ // failure: unsupported EKS + stale AMIs
+			Name: "data-eu", Region: "eu-central-1", Version: "1.29",
+			Support:        statussvc.SupportPosture{Tier: statussvc.SupportUnsupported},
+			Compute:        statussvc.ComputeManaged,
+			NodegroupCount: 5,
+			StaleAMI:       statussvc.StaleAMISummary{Total: 5, Behind: 5, OldestDays: iptr(47)},
+			AddonsBehind:   statussvc.AddonsBehindSummary{Total: 4, Behind: 2, Names: []string{"vpc-cni", "coredns"}},
+		},
+	}
+}
+
+func TestFleetLines_Pretty(t *testing.T) {
+	th := render.New(render.ColorNone, true) // deterministic: glyphs, no ANSI
+	lines := fleetLines(th, sampleFleet(), 0)
+	joined := strings.Join(lines, "\n")
+
+	// No color escapes leak under ColorNone (additive-color contract).
+	if strings.Contains(joined, "\x1b") {
+		t.Fatalf("ColorNone output contains ANSI escapes:\n%s", joined)
+	}
+
+	// Header + summary chips (chips have no column padding, so exact-match).
+	if lines[0] != "FLEET  3 clusters · 3 region(s)" {
+		t.Errorf("header = %q", lines[0])
+	}
+	if lines[2] != "● 1 current   ▲ 1 need attention   ✗ 1 unsupported" {
+		t.Errorf("chips = %q", lines[2])
+	}
+
+	// Each cluster's row carries its status glyph (its own column, 2-space gap)
+	// + the salient facts.
+	mustContain(t, joined, "●  prod-east")
+	mustContain(t, joined, "▲  staging")
+	mustContain(t, joined, "✗  data-eu")
+	mustContain(t, joined, "5/5 (47d)")           // stale AMI cell
+	mustContain(t, joined, "2 (vpc-cni,coredns)") // addons-behind cell
+	mustContain(t, joined, "standard (200d)")     // support cell
+
+	// Footer aggregates and the next-step hint point at the worst cluster.
+	mustContain(t, joined, "3 clusters · 5 stale nodegroups · 3 addons behind · 1 extended/unsupported")
+	mustContain(t, joined, "refresh cluster upgrade-check -c data-eu")
+}
+
+func TestFleetLines_ASCIIFallback(t *testing.T) {
+	th := render.New(render.ColorNone, false) // non-UTF-8 terminal
+	joined := strings.Join(fleetLines(th, sampleFleet(), 0), "\n")
+	// Glyphs degrade to ASCII tokens; meaning preserved without color or Unicode.
+	mustContain(t, joined, "[X] data-eu")
+	mustContain(t, joined, "[OK] 1 current")
+	if strings.ContainsAny(joined, "●▲✗") {
+		t.Errorf("ASCII fallback still contains Unicode glyphs:\n%s", joined)
+	}
+}
+
+func TestFleetLines_AllHealthy(t *testing.T) {
+	th := render.New(render.ColorNone, true)
+	healthy := []statussvc.ClusterStatus{{
+		Name: "ok", Region: "us-east-1", Version: "1.33",
+		Support: statussvc.SupportPosture{Tier: statussvc.SupportStandard, DaysRemaining: iptr(300)},
+		Compute: statussvc.ComputeManaged, NodegroupCount: 1,
+	}}
+	lines := fleetLines(th, healthy, 0)
+	joined := strings.Join(lines, "\n")
+	// Chips show only the "current" count; no warn/fail chips.
+	if lines[2] != "● 1 current" {
+		t.Errorf("chips = %q, want %q", lines[2], "● 1 current")
+	}
+	// No next-step hint when everything is current.
+	if strings.Contains(joined, "upgrade-check") {
+		t.Errorf("healthy fleet should not emit a hint:\n%s", joined)
+	}
+}
+
+func mustContain(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("output missing %q in:\n%s", needle, haystack)
+	}
+}

--- a/internal/commands/statusview/status.go
+++ b/internal/commands/statusview/status.go
@@ -3,20 +3,36 @@ package statusview
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/fatih/color"
 
+	"github.com/dantech2000/refresh/internal/render"
 	statussvc "github.com/dantech2000/refresh/internal/services/status"
 	"github.com/dantech2000/refresh/internal/ui"
 )
 
 const dateLayout = "2006-01-02"
 
-// OutputFleetTable renders the fleet status as a table (or plain TSV when plain
-// output is active) followed by a one-line summary footer.
+// OutputFleetTable renders the fleet status. The human path uses the render
+// design system (status tokens, summary chips, a next-step hint); `-o plain`
+// keeps the uncolored tab-separated table for grep/awk.
 func OutputFleetTable(statuses []statussvc.ClusterStatus, elapsed time.Duration) error {
+	if ui.PlainOutput() {
+		return outputFleetPlain(statuses, elapsed)
+	}
+	th := render.Default(os.Stdout)
+	for _, line := range fleetLines(th, statuses, elapsed) {
+		fmt.Println(line)
+	}
+	return nil
+}
+
+// outputFleetPlain renders the uncolored, tab-separated fleet table for
+// `-o plain` (grep/awk-friendly), via the PTable plain path.
+func outputFleetPlain(statuses []statussvc.ClusterStatus, elapsed time.Duration) error {
 	columns := []ui.Column{
 		{Title: "CLUSTER", Min: 8},
 		{Title: "REGION", Min: 9},

--- a/internal/noderoll/observer.go
+++ b/internal/noderoll/observer.go
@@ -1,0 +1,148 @@
+// Package noderoll observes a managed-nodegroup rolling update in real time —
+// which nodes are draining, terminating, and coming online — by reconciling
+// against live Kubernetes Node state. It is the data source behind the live
+// roll panel; rendering lives in internal/render.
+//
+// EKS's UpdateNodegroupVersion API only reports one coarse status for the whole
+// roll (via DescribeUpdate). The per-node truth comes from the cluster: managed
+// nodegroup nodes carry the labels used below, so a label-scoped Node list/watch
+// gives us exactly the nodegroup being rolled, classified by AMI and lifecycle.
+package noderoll
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// EKS-managed nodegroup node labels.
+const (
+	// LabelNodegroup scopes nodes to a single managed nodegroup.
+	LabelNodegroup = "eks.amazonaws.com/nodegroup"
+	// LabelImage is the AMI ID a node was launched with — the signal for
+	// old-vs-new during an AMI roll.
+	LabelImage = "eks.amazonaws.com/nodegroup-image"
+)
+
+// Phase is a node's lifecycle position during a roll.
+type Phase string
+
+const (
+	PhaseReady    Phase = "Ready"    // serving (Ready, not cordoned)
+	PhaseJoining  Phase = "Joining"  // new node not yet Ready
+	PhaseDraining Phase = "Draining" // cordoned / tainted for removal
+)
+
+// NodeView is one node's observed state.
+type NodeView struct {
+	Name     string `json:"name"`
+	OnTarget bool   `json:"onTarget"` // launched with the target (new) AMI
+	Ready    bool   `json:"ready"`
+	Phase    Phase  `json:"phase"`
+}
+
+// Snapshot is the nodegroup's state at one instant, plus roll aggregates.
+type Snapshot struct {
+	Nodes       []NodeView `json:"nodes"`
+	Total       int        `json:"total"`
+	ReadyTarget int        `json:"readyTarget"` // Ready nodes already on the target AMI
+	Draining    int        `json:"draining"`
+	Joining     int        `json:"joining"`
+}
+
+// Observer yields successive snapshots of a roll. Implementations: a
+// Kubernetes-backed one (below), an ASG-activities fallback, and a scripted
+// one for tests/--simulate.
+type Observer interface {
+	Snapshot(ctx context.Context) (Snapshot, error)
+}
+
+// KubeObserver reads node state from the cluster's Kubernetes API, scoped to a
+// single managed nodegroup. It is read-only and safe to poll.
+type KubeObserver struct {
+	client    kubernetes.Interface
+	nodegroup string
+	targetAMI string
+}
+
+// NewKubeObserver returns an Observer for nodegroup, treating targetAMI as the
+// "new" AMI the roll is moving toward.
+func NewKubeObserver(client kubernetes.Interface, nodegroup, targetAMI string) *KubeObserver {
+	return &KubeObserver{client: client, nodegroup: nodegroup, targetAMI: targetAMI}
+}
+
+// Snapshot lists the nodegroup's nodes and classifies each. Nodes from other
+// nodegroups are excluded by the label selector.
+func (o *KubeObserver) Snapshot(ctx context.Context) (Snapshot, error) {
+	list, err := o.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: LabelNodegroup + "=" + o.nodegroup,
+	})
+	if err != nil {
+		return Snapshot{}, err
+	}
+
+	var snap Snapshot
+	for i := range list.Items {
+		v := classify(&list.Items[i], o.targetAMI)
+		snap.Nodes = append(snap.Nodes, v)
+		snap.Total++
+		switch v.Phase {
+		case PhaseDraining:
+			snap.Draining++
+		case PhaseJoining:
+			snap.Joining++
+		case PhaseReady:
+			if v.OnTarget {
+				snap.ReadyTarget++
+			}
+		}
+	}
+	// Stable order so renders/golden tests are deterministic.
+	sort.Slice(snap.Nodes, func(i, j int) bool { return snap.Nodes[i].Name < snap.Nodes[j].Name })
+	return snap, nil
+}
+
+// classify derives a node's phase: cordoned/tainted-for-removal => Draining;
+// not Ready => Joining; otherwise Ready.
+func classify(n *corev1.Node, targetAMI string) NodeView {
+	ready := nodeReady(n)
+	phase := PhaseReady
+	switch {
+	case n.Spec.Unschedulable || hasDrainTaint(n):
+		phase = PhaseDraining
+	case !ready:
+		phase = PhaseJoining
+	}
+	return NodeView{
+		Name:     n.Name,
+		OnTarget: n.Labels[LabelImage] == targetAMI,
+		Ready:    ready,
+		Phase:    phase,
+	}
+}
+
+func nodeReady(n *corev1.Node) bool {
+	for _, c := range n.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// hasDrainTaint reports whether a node carries a taint indicating it is being
+// removed (cluster-autoscaler / drain markers), in addition to the cordon flag.
+func hasDrainTaint(n *corev1.Node) bool {
+	for _, t := range n.Spec.Taints {
+		if strings.HasPrefix(t.Key, "ToBeDeletedByClusterAutoscaler") ||
+			strings.HasPrefix(t.Key, "DeletionCandidateOfClusterAutoscaler") ||
+			t.Key == "node.kubernetes.io/unschedulable" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/noderoll/observer.go
+++ b/internal/noderoll/observer.go
@@ -76,6 +76,9 @@ type KubeObserver struct {
 	// for live rolls where the target AMI ID isn't known up front. nil → fall
 	// back to the nodegroup-image AMI label.
 	baseline map[string]bool
+	// drainStart remembers the evictable-pod count when a node first appears
+	// Draining, so the panel can show evicted/total as pods leave.
+	drainStart map[string]int
 }
 
 // NewKubeObserver returns an Observer for nodegroup, treating targetAMI as the
@@ -127,9 +130,64 @@ func (o *KubeObserver) Snapshot(ctx context.Context) (Snapshot, error) {
 			}
 		}
 	}
+	// Best-effort pod-eviction progress for draining nodes.
+	if snap.Draining > 0 {
+		o.fillPodEviction(ctx, &snap)
+	}
+
 	// Stable order so renders/golden tests are deterministic.
 	sort.Slice(snap.Nodes, func(i, j int) bool { return snap.Nodes[i].Name < snap.Nodes[j].Name })
 	return snap, nil
+}
+
+// fillPodEviction counts the evictable pods on each draining node and records
+// the count at drain start, so the panel can show evicted/total. Best-effort:
+// a list failure leaves the pod fields zero (the panel just omits the bar).
+func (o *KubeObserver) fillPodEviction(ctx context.Context, snap *Snapshot) {
+	pods, err := o.client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return
+	}
+	counts := make(map[string]int)
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if isEvictablePod(p) {
+			counts[p.Spec.NodeName]++
+		}
+	}
+	if o.drainStart == nil {
+		o.drainStart = make(map[string]int)
+	}
+	for i := range snap.Nodes {
+		n := &snap.Nodes[i]
+		if n.Phase != PhaseDraining {
+			continue
+		}
+		cur := counts[n.Name]
+		if _, seen := o.drainStart[n.Name]; !seen {
+			o.drainStart[n.Name] = cur
+		}
+		n.Pods = cur
+		n.PodsTotal = o.drainStart[n.Name]
+	}
+}
+
+// isEvictablePod reports whether a pod counts toward drain progress: DaemonSet
+// pods and static/mirror pods aren't drained, and terminal pods are already
+// gone.
+func isEvictablePod(p *corev1.Pod) bool {
+	if p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
+		return false
+	}
+	if _, mirror := p.Annotations["kubernetes.io/config.mirror"]; mirror {
+		return false
+	}
+	for _, ref := range p.OwnerReferences {
+		if ref.Kind == "DaemonSet" {
+			return false
+		}
+	}
+	return true
 }
 
 // classify derives a node's phase: cordoned/tainted-for-removal => Draining;

--- a/internal/noderoll/observer.go
+++ b/internal/noderoll/observer.go
@@ -43,6 +43,10 @@ type NodeView struct {
 	OnTarget bool   `json:"onTarget"` // launched with the target (new) AMI
 	Ready    bool   `json:"ready"`
 	Phase    Phase  `json:"phase"`
+	// Pods/PodsTotal track eviction progress while a node is Draining (0 when
+	// not draining or when pod accounting isn't available).
+	Pods      int `json:"pods,omitempty"`
+	PodsTotal int `json:"podsTotal,omitempty"`
 }
 
 // Snapshot is the nodegroup's state at one instant, plus roll aggregates.

--- a/internal/noderoll/observer.go
+++ b/internal/noderoll/observer.go
@@ -71,12 +71,34 @@ type KubeObserver struct {
 	client    kubernetes.Interface
 	nodegroup string
 	targetAMI string
+	// baseline, when set, holds the node names present at roll start; any node
+	// NOT in it is treated as "on target" (new). This makes old-vs-new robust
+	// for live rolls where the target AMI ID isn't known up front. nil → fall
+	// back to the nodegroup-image AMI label.
+	baseline map[string]bool
 }
 
 // NewKubeObserver returns an Observer for nodegroup, treating targetAMI as the
 // "new" AMI the roll is moving toward.
 func NewKubeObserver(client kubernetes.Interface, nodegroup, targetAMI string) *KubeObserver {
 	return &KubeObserver{client: client, nodegroup: nodegroup, targetAMI: targetAMI}
+}
+
+// CaptureBaseline records the nodegroup's current node set as "old" so that
+// nodes appearing afterward count as the new (on-target) nodes — for live rolls
+// where the target AMI ID isn't known in advance.
+func (o *KubeObserver) CaptureBaseline(ctx context.Context) error {
+	list, err := o.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: LabelNodegroup + "=" + o.nodegroup,
+	})
+	if err != nil {
+		return err
+	}
+	o.baseline = make(map[string]bool, len(list.Items))
+	for i := range list.Items {
+		o.baseline[list.Items[i].Name] = true
+	}
+	return nil
 }
 
 // Snapshot lists the nodegroup's nodes and classifies each. Nodes from other
@@ -91,7 +113,7 @@ func (o *KubeObserver) Snapshot(ctx context.Context) (Snapshot, error) {
 
 	var snap Snapshot
 	for i := range list.Items {
-		v := classify(&list.Items[i], o.targetAMI)
+		v := classify(&list.Items[i], o.targetAMI, o.baseline)
 		snap.Nodes = append(snap.Nodes, v)
 		snap.Total++
 		switch v.Phase {
@@ -111,8 +133,10 @@ func (o *KubeObserver) Snapshot(ctx context.Context) (Snapshot, error) {
 }
 
 // classify derives a node's phase: cordoned/tainted-for-removal => Draining;
-// not Ready => Joining; otherwise Ready.
-func classify(n *corev1.Node, targetAMI string) NodeView {
+// not Ready => Joining; otherwise Ready. onTarget comes from the baseline set
+// when present (node appeared after roll start), else the nodegroup-image AMI
+// label.
+func classify(n *corev1.Node, targetAMI string, baseline map[string]bool) NodeView {
 	ready := nodeReady(n)
 	phase := PhaseReady
 	switch {
@@ -121,9 +145,13 @@ func classify(n *corev1.Node, targetAMI string) NodeView {
 	case !ready:
 		phase = PhaseJoining
 	}
+	onTarget := n.Labels[LabelImage] == targetAMI
+	if baseline != nil {
+		onTarget = !baseline[n.Name]
+	}
 	return NodeView{
 		Name:     n.Name,
-		OnTarget: n.Labels[LabelImage] == targetAMI,
+		OnTarget: onTarget,
 		Ready:    ready,
 		Phase:    phase,
 	}

--- a/internal/noderoll/observer_test.go
+++ b/internal/noderoll/observer_test.go
@@ -1,0 +1,143 @@
+package noderoll
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	oldAMI = "ami-0a1b"
+	newAMI = "ami-0f9e"
+	ng     = "spot-burst"
+)
+
+func mkNode(name, ami string, ready, cordoned bool) *corev1.Node {
+	cond := corev1.ConditionFalse
+	if ready {
+		cond = corev1.ConditionTrue
+	}
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				LabelNodegroup: ng,
+				LabelImage:     ami,
+			},
+		},
+		Spec: corev1.NodeSpec{Unschedulable: cordoned},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: cond}},
+		},
+	}
+}
+
+// Drives a fake cluster through a managed-nodegroup AMI roll — no AWS, no live
+// cluster — and asserts the observer reports the per-node transitions
+// (old → draining → gone, joining → ready) the live panel renders.
+func TestKubeObserver_RollTransitions(t *testing.T) {
+	ctx := context.Background()
+
+	// Start: 3 old-AMI nodes serving, plus one node from a DIFFERENT nodegroup
+	// that must be excluded by the label selector.
+	other := mkNode("ip-other", newAMI, true, false)
+	other.Labels[LabelNodegroup] = "general"
+	client := fake.NewClientset(
+		mkNode("ip-1", oldAMI, true, false),
+		mkNode("ip-2", oldAMI, true, false),
+		mkNode("ip-3", oldAMI, true, false),
+		other,
+	)
+	obs := NewKubeObserver(client, ng, newAMI)
+
+	// --- t0: steady state ---------------------------------------------------
+	s, err := obs.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if s.Total != 3 {
+		t.Fatalf("Total = %d, want 3 (ip-other excluded by nodegroup label)", s.Total)
+	}
+	if s.ReadyTarget != 0 {
+		t.Fatalf("ReadyTarget = %d, want 0 (all still on old AMI)", s.ReadyTarget)
+	}
+	for _, n := range s.Nodes {
+		if n.Phase != PhaseReady || n.OnTarget {
+			t.Fatalf("node %s = %+v, want Ready & not OnTarget", n.Name, n)
+		}
+	}
+
+	// --- t1: surge a new node (joining) and cordon an old one (draining) ----
+	if _, err := client.CoreV1().Nodes().Create(ctx, mkNode("ip-4", newAMI, false, false), metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	cordon(ctx, t, client, "ip-1")
+
+	s, _ = obs.Snapshot(ctx)
+	if s.Total != 4 {
+		t.Fatalf("Total = %d, want 4", s.Total)
+	}
+	if s.Draining != 1 || s.Joining != 1 || s.ReadyTarget != 0 {
+		t.Fatalf("counts = draining %d / joining %d / readyTarget %d, want 1 / 1 / 0", s.Draining, s.Joining, s.ReadyTarget)
+	}
+	if got := phaseOf(s, "ip-1"); got != PhaseDraining {
+		t.Fatalf("ip-1 phase = %s, want Draining", got)
+	}
+	if got := phaseOf(s, "ip-4"); got != PhaseJoining {
+		t.Fatalf("ip-4 phase = %s, want Joining", got)
+	}
+
+	// --- t2: new node becomes Ready; drained old node is terminated ---------
+	setReady(ctx, t, client, "ip-4")
+	if err := client.CoreV1().Nodes().Delete(ctx, "ip-1", metav1.DeleteOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	s, _ = obs.Snapshot(ctx)
+	if s.Total != 3 {
+		t.Fatalf("Total = %d, want 3 (ip-1 terminated)", s.Total)
+	}
+	if s.ReadyTarget != 1 || s.Draining != 0 || s.Joining != 0 {
+		t.Fatalf("counts = readyTarget %d / draining %d / joining %d, want 1 / 0 / 0", s.ReadyTarget, s.Draining, s.Joining)
+	}
+	if v := nodeOf(s, "ip-4"); !v.OnTarget || v.Phase != PhaseReady {
+		t.Fatalf("ip-4 = %+v, want OnTarget Ready", v)
+	}
+}
+
+func cordon(ctx context.Context, t *testing.T, c *fake.Clientset, name string) {
+	t.Helper()
+	n, err := c.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	n.Spec.Unschedulable = true
+	if _, err := c.CoreV1().Nodes().Update(ctx, n, metav1.UpdateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setReady(ctx context.Context, t *testing.T, c *fake.Clientset, name string) {
+	t.Helper()
+	n, err := c.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	n.Status.Conditions = []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}
+	if _, err := c.CoreV1().Nodes().Update(ctx, n, metav1.UpdateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func phaseOf(s Snapshot, name string) Phase { return nodeOf(s, name).Phase }
+func nodeOf(s Snapshot, name string) NodeView {
+	for _, n := range s.Nodes {
+		if n.Name == name {
+			return n
+		}
+	}
+	return NodeView{}
+}

--- a/internal/noderoll/podeviction_test.go
+++ b/internal/noderoll/podeviction_test.go
@@ -1,0 +1,66 @@
+package noderoll
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func pod(name, node string, phase corev1.PodPhase, daemonset, mirror bool) *corev1.Pod {
+	p := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: node},
+		Status:     corev1.PodStatus{Phase: phase},
+	}
+	if daemonset {
+		p.OwnerReferences = []metav1.OwnerReference{{Kind: "DaemonSet", Name: "kube-proxy"}}
+	}
+	if mirror {
+		p.Annotations = map[string]string{"kubernetes.io/config.mirror": "abc"}
+	}
+	return p
+}
+
+// Real pod-eviction accounting on a fake cluster (no AWS): a draining node's
+// evictable pods are counted, DaemonSet/mirror/terminal pods excluded, and the
+// drain-start total is remembered as pods leave.
+func TestKubeObserver_PodEviction(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewClientset(
+		mkNode("ip-1", oldAMI, true, true), // cordoned -> draining
+		// On ip-1: 3 evictable workload pods + a DaemonSet pod + a terminal pod.
+		pod("web-1", "ip-1", corev1.PodRunning, false, false),
+		pod("web-2", "ip-1", corev1.PodRunning, false, false),
+		pod("web-3", "ip-1", corev1.PodRunning, false, false),
+		pod("kube-proxy-1", "ip-1", corev1.PodRunning, true, false),   // DaemonSet -> excluded
+		pod("done-1", "ip-1", corev1.PodSucceeded, false, false),      // terminal -> excluded
+		pod("static-1", "ip-1", corev1.PodRunning, false, true),       // mirror -> excluded
+		pod("elsewhere", "ip-other", corev1.PodRunning, false, false), // different node
+	)
+	obs := NewKubeObserver(client, ng, newAMI)
+
+	s, err := obs.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := nodeOf(s, "ip-1")
+	if n.Phase != PhaseDraining {
+		t.Fatalf("ip-1 phase = %s, want Draining", n.Phase)
+	}
+	if n.PodsTotal != 3 || n.Pods != 3 {
+		t.Fatalf("drain start: Pods=%d PodsTotal=%d, want 3/3 (DaemonSet/mirror/terminal/other excluded)", n.Pods, n.PodsTotal)
+	}
+
+	// Evict one workload pod; total stays at the remembered start (3), remaining drops to 2.
+	if err := client.CoreV1().Pods("default").Delete(ctx, "web-1", metav1.DeleteOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	s, _ = obs.Snapshot(ctx)
+	n = nodeOf(s, "ip-1")
+	if n.Pods != 2 || n.PodsTotal != 3 {
+		t.Fatalf("after eviction: Pods=%d PodsTotal=%d, want 2/3", n.Pods, n.PodsTotal)
+	}
+}

--- a/internal/noderoll/scripted.go
+++ b/internal/noderoll/scripted.go
@@ -1,0 +1,90 @@
+package noderoll
+
+import "context"
+
+// ScriptedObserver replays a fixed sequence of snapshots. It backs the
+// `nodegroup update --simulate` dev flag and tests, so the full live roll can
+// be exercised with no AWS and no cluster. After the last frame it keeps
+// returning the final state.
+type ScriptedObserver struct {
+	frames []Snapshot
+	i      int
+}
+
+// NewScriptedObserver replays frames in order.
+func NewScriptedObserver(frames []Snapshot) *ScriptedObserver {
+	return &ScriptedObserver{frames: frames}
+}
+
+// Snapshot returns the next frame, advancing until the last (which then
+// repeats).
+func (o *ScriptedObserver) Snapshot(_ context.Context) (Snapshot, error) {
+	if len(o.frames) == 0 {
+		return Snapshot{}, nil
+	}
+	idx := o.i
+	if idx >= len(o.frames) {
+		idx = len(o.frames) - 1
+	}
+	if o.i < len(o.frames)-1 {
+		o.i++
+	}
+	return o.frames[idx], nil
+}
+
+// AtEnd reports whether the last frame has been reached.
+func (o *ScriptedObserver) AtEnd() bool { return o.i >= len(o.frames)-1 }
+
+func snapOf(nodes ...NodeView) Snapshot {
+	s := Snapshot{Nodes: nodes, Total: len(nodes)}
+	for _, n := range nodes {
+		switch n.Phase {
+		case PhaseDraining:
+			s.Draining++
+		case PhaseJoining:
+			s.Joining++
+		case PhaseReady:
+			if n.OnTarget {
+				s.ReadyTarget++
+			}
+		}
+	}
+	return s
+}
+
+func oldReady(name string) NodeView {
+	return NodeView{Name: name, OnTarget: false, Ready: true, Phase: PhaseReady}
+}
+func newJoining(name string) NodeView {
+	return NodeView{Name: name, OnTarget: true, Ready: false, Phase: PhaseJoining}
+}
+func newReady(name string) NodeView {
+	return NodeView{Name: name, OnTarget: true, Ready: true, Phase: PhaseReady}
+}
+func draining(name string, remaining, total int) NodeView {
+	return NodeView{Name: name, OnTarget: false, Ready: true, Phase: PhaseDraining, Pods: remaining, PodsTotal: total}
+}
+
+// DemoTimeline builds a realistic surge roll of 3 old nodes → 3 new nodes
+// (max-surge 1): each new node joins and goes Ready, then an old node drains
+// its pods and terminates. Used by --simulate.
+func DemoTimeline() []Snapshot {
+	const a, b, c = "ip-10-0-1-12", "ip-10-0-3-21", "ip-10-0-2-08"
+	const d, e, f = "ip-10-0-1-44", "ip-10-0-2-77", "ip-10-0-3-05"
+	return []Snapshot{
+		snapOf(oldReady(a), oldReady(b), oldReady(c)),
+		snapOf(oldReady(a), oldReady(b), oldReady(c), newJoining(d)),
+		snapOf(draining(a, 4, 4), oldReady(b), oldReady(c), newReady(d)),
+		snapOf(draining(a, 2, 4), oldReady(b), oldReady(c), newReady(d)),
+		snapOf(draining(a, 0, 4), oldReady(b), oldReady(c), newReady(d)),
+		snapOf(oldReady(b), oldReady(c), newReady(d)),
+		snapOf(oldReady(b), oldReady(c), newReady(d), newJoining(e)),
+		snapOf(draining(b, 3, 3), oldReady(c), newReady(d), newReady(e)),
+		snapOf(draining(b, 0, 3), oldReady(c), newReady(d), newReady(e)),
+		snapOf(oldReady(c), newReady(d), newReady(e)),
+		snapOf(oldReady(c), newReady(d), newReady(e), newJoining(f)),
+		snapOf(draining(c, 5, 5), newReady(d), newReady(e), newReady(f)),
+		snapOf(draining(c, 0, 5), newReady(d), newReady(e), newReady(f)),
+		snapOf(newReady(d), newReady(e), newReady(f)),
+	}
+}

--- a/internal/noderoll/tracker.go
+++ b/internal/noderoll/tracker.go
@@ -1,0 +1,82 @@
+package noderoll
+
+// EventKind classifies a node lifecycle transition during a roll.
+type EventKind string
+
+const (
+	EvtJoining    EventKind = "joining"    // a new node appeared, not yet Ready
+	EvtOnline     EventKind = "online"     // a node became Ready
+	EvtDraining   EventKind = "draining"   // a node was cordoned / tainted for removal
+	EvtTerminated EventKind = "terminated" // a node left the cluster
+)
+
+// Event is a single observed lifecycle transition.
+type Event struct {
+	Node string    `json:"node"`
+	Kind EventKind `json:"kind"`
+}
+
+// Tracker derives lifecycle events by diffing successive snapshots — turning
+// the observer's point-in-time state into the "node came online / went offline"
+// feed the live panel shows. It is pure: feed it snapshots, read Events.
+type Tracker struct {
+	prev   map[string]Phase
+	seeded bool
+	Events []Event
+}
+
+// NewTracker returns an empty Tracker.
+func NewTracker() *Tracker { return &Tracker{prev: map[string]Phase{}} }
+
+// Observe diffs s against the previous snapshot and appends any transitions.
+// The first snapshot is taken as the baseline (no events), so a roll that is
+// already in flight on attach doesn't replay its whole history.
+func (t *Tracker) Observe(s Snapshot) {
+	cur := make(map[string]Phase, len(s.Nodes))
+	for _, n := range s.Nodes {
+		cur[n.Name] = n.Phase
+	}
+	if !t.seeded {
+		t.prev = cur
+		t.seeded = true
+		return
+	}
+	// Appeared or changed phase (s.Nodes is name-sorted → deterministic order).
+	for _, n := range s.Nodes {
+		old, existed := t.prev[n.Name]
+		if existed && old == n.Phase {
+			continue
+		}
+		if k := eventForPhase(n.Phase); k != "" {
+			t.Events = append(t.Events, Event{Node: n.Name, Kind: k})
+		}
+	}
+	// Disappeared → terminated.
+	for name := range t.prev {
+		if _, ok := cur[name]; !ok {
+			t.Events = append(t.Events, Event{Node: name, Kind: EvtTerminated})
+		}
+	}
+	t.prev = cur
+}
+
+func eventForPhase(p Phase) EventKind {
+	switch p {
+	case PhaseJoining:
+		return EvtJoining
+	case PhaseReady:
+		return EvtOnline
+	case PhaseDraining:
+		return EvtDraining
+	default:
+		return ""
+	}
+}
+
+// Recent returns the last n events (fewer if not enough have accrued).
+func (t *Tracker) Recent(n int) []Event {
+	if n <= 0 || len(t.Events) <= n {
+		return t.Events
+	}
+	return t.Events[len(t.Events)-n:]
+}

--- a/internal/noderoll/tracker_test.go
+++ b/internal/noderoll/tracker_test.go
@@ -1,0 +1,69 @@
+package noderoll
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTracker_DerivesLifecycleEvents(t *testing.T) {
+	tr := NewTracker()
+	// Baseline: 3 old nodes ready — no events.
+	tr.Observe(snapOf(oldReady("a"), oldReady("b"), oldReady("c")))
+	if len(tr.Events) != 0 {
+		t.Fatalf("baseline should emit no events, got %v", tr.Events)
+	}
+	// Surge a new node (joining) + cordon an old one (draining).
+	tr.Observe(snapOf(draining("a", 4, 4), oldReady("b"), oldReady("c"), newJoining("d")))
+	// New node goes Ready; drained node terminates.
+	tr.Observe(snapOf(oldReady("b"), oldReady("c"), newReady("d")))
+
+	want := []Event{
+		{"a", EvtDraining},
+		{"d", EvtJoining},
+		{"d", EvtOnline},
+		{"a", EvtTerminated},
+	}
+	if len(tr.Events) != len(want) {
+		t.Fatalf("events = %v, want %v", tr.Events, want)
+	}
+	for i, w := range want {
+		if tr.Events[i] != w {
+			t.Errorf("event %d = %v, want %v", i, tr.Events[i], w)
+		}
+	}
+}
+
+func TestScriptedObserver_RunsToCompletion(t *testing.T) {
+	obs := NewScriptedObserver(DemoTimeline())
+	ctx := context.Background()
+	// Mirror the driver: pull frames until the snapshot reports the roll done.
+	done := func(s Snapshot) bool {
+		return s.Total > 0 && s.ReadyTarget == 3 && s.Draining == 0 && s.Joining == 0
+	}
+	var last Snapshot
+	finished := false
+	for i := 0; i < 100; i++ {
+		s, err := obs.Snapshot(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		last = s
+		if done(s) {
+			finished = true
+			break
+		}
+	}
+	if !finished {
+		t.Fatalf("scripted roll never completed; last = %+v", last)
+	}
+}
+
+func TestRecent(t *testing.T) {
+	tr := &Tracker{Events: []Event{{"a", EvtJoining}, {"b", EvtOnline}, {"c", EvtDraining}}}
+	if got := tr.Recent(2); len(got) != 2 || got[0].Node != "b" {
+		t.Errorf("Recent(2) = %v, want last two", got)
+	}
+	if got := tr.Recent(10); len(got) != 3 {
+		t.Errorf("Recent(10) = %v, want all 3", got)
+	}
+}

--- a/internal/render/live.go
+++ b/internal/render/live.go
@@ -1,0 +1,72 @@
+package render
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// LiveRegion repaints a multi-line block in place on a TTY (cursor-up +
+// clear-to-end), and degrades to appended snapshots when output isn't a
+// terminal (or color is off) — so logs and pipes never get escape codes or a
+// flicker of half-frames. It is line-oriented: it never uses the alternate
+// screen buffer, so scrollback is preserved and it stays a CLI, not a TUI.
+//
+// The frame model is a pure func() []string; this type only paints it, which
+// keeps the rendering testable without a pseudo-terminal.
+type LiveRegion struct {
+	w        io.Writer
+	tty      bool // repaint in place vs. append
+	prev     int  // lines painted last frame (TTY only)
+	appended bool // whether we've appended at least one snapshot (non-TTY)
+}
+
+// NewLiveRegion returns a LiveRegion for w. It repaints in place only when w is
+// a terminal and the theme has color enabled.
+func (t *Theme) NewLiveRegion(w io.Writer) *LiveRegion {
+	return &LiveRegion{w: w, tty: isTerminal(w) && t.Level != ColorNone}
+}
+
+// Draw paints one frame. On a TTY it overwrites the previous frame in place; off
+// a TTY it appends the frame (callers throttle the cadence so logs stay sane).
+func (lr *LiveRegion) Draw(frame []string) {
+	body := strings.Join(frame, "\n")
+	if lr.tty {
+		if lr.prev > 0 {
+			_, _ = fmt.Fprintf(lr.w, "\x1b[%dA\x1b[0J", lr.prev) // up prev lines, clear to end
+		}
+		_, _ = fmt.Fprint(lr.w, body+"\n")
+		lr.prev = len(frame)
+		return
+	}
+	if lr.appended {
+		_, _ = fmt.Fprintln(lr.w)
+	}
+	_, _ = fmt.Fprint(lr.w, body+"\n")
+	lr.appended = true
+}
+
+// Run draws frames every interval until frame reports done==true or ctx is
+// cancelled. The cursor is hidden during a TTY run and always restored.
+func (lr *LiveRegion) Run(ctx context.Context, interval time.Duration, frame func() (lines []string, done bool)) error {
+	if lr.tty {
+		_, _ = fmt.Fprint(lr.w, "\x1b[?25l")                    // hide cursor
+		defer func() { _, _ = fmt.Fprint(lr.w, "\x1b[?25h") }() // restore on return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		lines, done := frame()
+		lr.Draw(lines)
+		if done {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/render/primitives.go
+++ b/internal/render/primitives.go
@@ -1,0 +1,141 @@
+package render
+
+import (
+	"strings"
+
+	"github.com/dantech2000/refresh/internal/ui"
+)
+
+// colGap separates table columns.
+const colGap = "  "
+
+// Section returns a section header line: "▸ TITLE" in the accent color.
+func (t *Theme) Section(title string) string {
+	return t.Bold(t.Pal.Mauve, t.glyph("▸", ">")+" "+title)
+}
+
+// KV renders aligned key/value detail rows: the keys are dim and padded to a
+// common width, the values are passed through (may already be colored).
+func (t *Theme) KV(pairs [][2]string) []string {
+	keyW := 0
+	for _, p := range pairs {
+		if w := ui.VisibleWidth(p[0]); w > keyW {
+			keyW = w
+		}
+	}
+	out := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		key := ui.PadANSI(t.Paint(t.Pal.Dim, p[0]), keyW, ui.AlignLeft)
+		out = append(out, key+colGap+p[1])
+	}
+	return out
+}
+
+// Table builds an aligned, optionally-colored table that returns its lines
+// (header + rows). Column sizing/alignment reuse the ANSI-width helpers in
+// internal/ui, so colored and glyph cells line up exactly.
+type Table struct {
+	theme *Theme
+	cols  []ui.Column
+	rows  [][]string
+}
+
+// NewTable starts a table with the given columns.
+func (t *Theme) NewTable(cols ...ui.Column) *Table {
+	return &Table{theme: t, cols: cols}
+}
+
+// Row appends a row. Extra cells are ignored; missing cells render empty.
+func (tb *Table) Row(cells ...string) *Table {
+	tb.rows = append(tb.rows, cells)
+	return tb
+}
+
+// Render returns the header line followed by one line per row.
+func (tb *Table) Render() []string {
+	n := len(tb.cols)
+	widths := make([]int, n)
+	for i, c := range tb.cols {
+		widths[i] = max(c.Min, ui.VisibleWidth(c.Title))
+	}
+	for _, row := range tb.rows {
+		for i := 0; i < n && i < len(row); i++ {
+			if w := ui.VisibleWidth(row[i]); w > widths[i] {
+				widths[i] = w
+			}
+		}
+	}
+	for i, c := range tb.cols {
+		if c.Max > 0 && widths[i] > c.Max {
+			widths[i] = c.Max
+		}
+	}
+
+	out := make([]string, 0, len(tb.rows)+1)
+	header := make([]string, n)
+	for i, c := range tb.cols {
+		header[i] = ui.PadANSI(tb.theme.Paint(tb.theme.Pal.Dim, c.Title), widths[i], c.Align)
+	}
+	out = append(out, strings.TrimRight(strings.Join(header, colGap), " "))
+
+	for _, row := range tb.rows {
+		cells := make([]string, n)
+		for i := 0; i < n; i++ {
+			v := ""
+			if i < len(row) {
+				v = row[i]
+			}
+			v = ui.TruncateANSI(v, widths[i])
+			cells[i] = ui.PadANSI(v, widths[i], tb.cols[i].Align)
+		}
+		out = append(out, strings.TrimRight(strings.Join(cells, colGap), " "))
+	}
+	return out
+}
+
+// Callout renders a titled block bounded by top/bottom rules (no side borders,
+// so it is trivially alignment-safe). width is the rule length.
+func (t *Theme) Callout(title string, body []string, width int) []string {
+	if width < 8 {
+		width = 8
+	}
+	hr := t.glyph("━", "=")
+	titleSeg := t.Bold(t.Pal.Mauve, title)
+	used := 3 + ui.VisibleWidth(title) + 1 // "━━ " + title + " "
+	fill := width - used
+	if fill < 0 {
+		fill = 0
+	}
+	top := t.Paint(t.Pal.Rule, strings.Repeat(hr, 2)+" ") + titleSeg + " " + t.Paint(t.Pal.Rule, strings.Repeat(hr, fill))
+	out := make([]string, 0, len(body)+2)
+	out = append(out, top)
+	out = append(out, body...)
+	out = append(out, t.Paint(t.Pal.Rule, strings.Repeat(hr, width)))
+	return out
+}
+
+// Bar renders a block-glyph progress bar of the given width filled to
+// done/total in color c.
+func (t *Theme) Bar(done, total, width int, c Color) string {
+	if total <= 0 {
+		total = 1
+	}
+	f := done * width / total
+	if f > width {
+		f = width
+	}
+	if f < 0 {
+		f = 0
+	}
+	fillCh, emptyCh := t.glyph("█", "#"), t.glyph("░", "-")
+	edgeL, edgeR := t.glyph("▕", "["), t.glyph("▏", "]")
+	return edgeL + t.Paint(c, strings.Repeat(fillCh, f)) + t.Paint(t.Pal.Rule, strings.Repeat(emptyCh, width-f)) + edgeR
+}
+
+// Branch returns the tree connector for a list item ("├─" / "└─" for the last).
+func (t *Theme) Branch(last bool) string {
+	if last {
+		return t.Paint(t.Pal.Dim, t.glyph("└─", "`-"))
+	}
+	return t.Paint(t.Pal.Dim, t.glyph("├─", "|-"))
+}

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -1,0 +1,148 @@
+package render
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/dantech2000/refresh/internal/ui"
+)
+
+func TestPaintLevels(t *testing.T) {
+	// ColorNone is a pass-through.
+	if got := New(ColorNone, true).Paint(Mocha.Green, "ok"); got != "ok" {
+		t.Fatalf("ColorNone Paint = %q, want %q", got, "ok")
+	}
+	// Truecolor emits a 24-bit SGR.
+	if got := New(ColorTrue, true).Paint(Color{1, 2, 3}, "x"); got != "\x1b[38;2;1;2;3mx\x1b[0m" {
+		t.Fatalf("ColorTrue Paint = %q", got)
+	}
+	// 256 emits an indexed SGR; bold prefixes the attribute.
+	if got := New(Color256, true).Bold(Mocha.Red, "x"); !strings.HasPrefix(got, "\x1b[1;38;5;") {
+		t.Fatalf("Color256 Bold = %q, want 1;38;5; prefix", got)
+	}
+}
+
+func TestRGBTo256(t *testing.T) {
+	if got := rgbTo256(Color{0, 0, 0}); got != 16 {
+		t.Errorf("black = %d, want 16", got)
+	}
+	if got := rgbTo256(Color{255, 255, 255}); got != 231 {
+		t.Errorf("white = %d, want 231", got)
+	}
+	if got := rgbTo256(Mocha.Green); got < 16 || got > 255 {
+		t.Errorf("green index %d out of range", got)
+	}
+}
+
+func TestDetectLevelNoColor(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	if lvl := DetectLevel(&bytes.Buffer{}); lvl != ColorNone {
+		t.Fatalf("NO_COLOR set: level = %d, want ColorNone", lvl)
+	}
+}
+
+func TestTokenUnicodeAndASCII(t *testing.T) {
+	if got := New(ColorNone, true).Token(Healthy, "current"); got != "● current" {
+		t.Fatalf("unicode token = %q, want %q", got, "● current")
+	}
+	if got := New(ColorNone, false).Token(Fail, "blocked"); got != "[X] blocked" {
+		t.Fatalf("ascii token = %q, want %q", got, "[X] blocked")
+	}
+	// Color is additive: ColorNone output never contains an escape.
+	if got := New(ColorNone, true).Tokenf(Warn, "2 stale"); strings.Contains(got, "\x1b") {
+		t.Fatalf("ColorNone token contains ANSI: %q", got)
+	}
+}
+
+func TestStatusFromString(t *testing.T) {
+	cases := map[string]Status{
+		"ACTIVE":      Healthy,
+		"UPDATING":    Warn,
+		"FAILED":      Fail,
+		"IN_PROGRESS": Progress,
+		"UNKNOWN":     Unknown,
+	}
+	for in, want := range cases {
+		if got := StatusFromString(in); got != want {
+			t.Errorf("StatusFromString(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestTableAlignment(t *testing.T) {
+	th := New(ColorNone, true)
+	got := th.NewTable(
+		ui.Column{Title: "NAME"},
+		ui.Column{Title: "AGE"},
+	).Row("prod", "2").Row("x", "10").Render()
+
+	want := []string{
+		"NAME  AGE",
+		"prod  2",
+		"x     10",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("rows = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestKVAlignment(t *testing.T) {
+	th := New(ColorNone, true)
+	got := th.KV([][2]string{{"version", "1.32"}, {"status", "ACTIVE"}})
+	want := []string{"version  1.32", "status   ACTIVE"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBar(t *testing.T) {
+	if got := New(ColorNone, true).Bar(2, 3, 9, Mocha.Teal); got != "▕██████░░░▏" {
+		t.Fatalf("unicode bar = %q", got)
+	}
+	if got := New(ColorNone, false).Bar(1, 2, 6, Mocha.Teal); got != "[###---]" {
+		t.Fatalf("ascii bar = %q", got)
+	}
+}
+
+func TestCallout(t *testing.T) {
+	got := New(ColorNone, true).Callout("VERDICT", []string{"  body"}, 20)
+	if !strings.HasPrefix(got[0], "━━ VERDICT ") {
+		t.Errorf("callout top = %q", got[0])
+	}
+	if last := got[len(got)-1]; last != strings.Repeat("━", 20) {
+		t.Errorf("callout bottom = %q", last)
+	}
+}
+
+func TestLiveAppendNonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	lr := New(ColorNone, true).NewLiveRegion(&buf) // buf is not a *os.File -> not a TTY
+	lr.Draw([]string{"a", "b"})
+	lr.Draw([]string{"c"})
+	want := "a\nb\n\nc\n"
+	if buf.String() != want {
+		t.Fatalf("non-TTY append = %q, want %q", buf.String(), want)
+	}
+	if strings.Contains(buf.String(), "\x1b") {
+		t.Fatalf("non-TTY output contains ANSI cursor codes: %q", buf.String())
+	}
+}
+
+func TestLiveRedrawTTY(t *testing.T) {
+	var buf bytes.Buffer
+	lr := &LiveRegion{w: &buf, tty: true} // force the in-place path
+	lr.Draw([]string{"x", "y"})
+	lr.Draw([]string{"z"})
+	// Second frame must rewind over the 2 lines of the first and clear down.
+	if !strings.Contains(buf.String(), "\x1b[2A\x1b[0J") {
+		t.Fatalf("redraw missing cursor-up/clear: %q", buf.String())
+	}
+}

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -23,6 +23,25 @@ func TestPaintLevels(t *testing.T) {
 	}
 }
 
+// Locks the production theming to the exact truecolor (and 256-color) SGR codes
+// the design proof used — so the real CLI emits the same Catppuccin palette,
+// not an approximation.
+func TestThemingMatchesProofPalette(t *testing.T) {
+	tc := New(ColorTrue, true)
+	// Healthy ● is Catppuccin green {166,227,161}; the label stays uncolored.
+	if got, want := tc.Token(Healthy, "current"), "\x1b[38;2;166;227;161m●\x1b[0m current"; got != want {
+		t.Errorf("truecolor Healthy token = %q, want %q", got, want)
+	}
+	// Fail ✗ is red {243,139,168}.
+	if got, want := tc.Glyph(Fail), "\x1b[38;2;243;139;168m✗\x1b[0m"; got != want {
+		t.Errorf("truecolor Fail glyph = %q, want %q", got, want)
+	}
+	// 256-color terminals get an indexed code from the same palette.
+	if got := New(Color256, true).Glyph(Progress); !strings.HasPrefix(got, "\x1b[38;5;") {
+		t.Errorf("256-color Progress glyph = %q, want 38;5; prefix", got)
+	}
+}
+
 func TestRGBTo256(t *testing.T) {
 	if got := rgbTo256(Color{0, 0, 0}); got != 16 {
 		t.Errorf("black = %d, want 16", got)

--- a/internal/render/theme.go
+++ b/internal/render/theme.go
@@ -1,0 +1,177 @@
+// Package render is the human-facing visual system for refresh: a small design
+// language (palette, status tokens, primitives) plus an in-place live-region
+// printer. It is line-oriented CLI output — NOT a TUI (no alternate screen, no
+// input loop). Color is always additive: every status also carries a glyph and
+// a label, so output stays legible with --no-color, when piped, or on a
+// non-UTF-8 terminal.
+//
+// Machine formats (-o json/yaml/plain) do not go through this package; they
+// stay in runner.EncodeStdout. render only styles the human `table`/detail
+// surfaces, reusing the ANSI-width math in internal/ui.
+package render
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+// ColorLevel is the terminal's color capability.
+type ColorLevel int
+
+const (
+	ColorNone ColorLevel = iota // no ANSI color (NO_COLOR, piped, dumb term)
+	Color256                    // 256-color palette
+	ColorTrue                   // 24-bit truecolor
+)
+
+// Color is a 24-bit RGB color.
+type Color struct{ R, G, B uint8 }
+
+// Palette is the named color set the design system draws from.
+type Palette struct {
+	Text, Subtext, Dim, White, Rule                   Color
+	Green, Yellow, Red, Teal, Blue, Mauve, Peach, Sky Color
+}
+
+// Mocha is the default palette (Catppuccin Mocha) — a real, widely-used
+// terminal theme that downgrades cleanly to 256-color.
+var Mocha = Palette{
+	Text:    Color{205, 214, 244},
+	Subtext: Color{166, 173, 200},
+	Dim:     Color{108, 112, 134},
+	White:   Color{235, 239, 252},
+	Rule:    Color{69, 71, 90},
+	Green:   Color{166, 227, 161},
+	Yellow:  Color{249, 226, 175},
+	Red:     Color{243, 139, 168},
+	Teal:    Color{148, 226, 213},
+	Blue:    Color{137, 180, 250},
+	Mauve:   Color{203, 166, 247},
+	Peach:   Color{250, 179, 135},
+	Sky:     Color{137, 220, 235},
+}
+
+// Theme renders strings at a given color level and Unicode capability. It is
+// safe to copy; it holds no state.
+type Theme struct {
+	Level   ColorLevel
+	Unicode bool
+	Pal     Palette
+}
+
+// New builds a Theme with an explicit level/unicode (used in tests for
+// determinism).
+func New(level ColorLevel, unicode bool) *Theme {
+	return &Theme{Level: level, Unicode: unicode, Pal: Mocha}
+}
+
+// Default detects the color level and Unicode support from w and the
+// environment.
+func Default(w io.Writer) *Theme {
+	return &Theme{Level: DetectLevel(w), Unicode: detectUnicode(), Pal: Mocha}
+}
+
+// DetectLevel reports the color capability for w. Honors NO_COLOR, fatih/color's
+// global (set by --no-color), TTY-ness, COLORTERM and TERM.
+func DetectLevel(w io.Writer) ColorLevel {
+	if color.NoColor || os.Getenv("NO_COLOR") != "" {
+		return ColorNone
+	}
+	if !isTerminal(w) {
+		return ColorNone
+	}
+	switch os.Getenv("COLORTERM") {
+	case "truecolor", "24bit":
+		return ColorTrue
+	}
+	term := os.Getenv("TERM")
+	if term == "" || term == "dumb" {
+		return ColorNone
+	}
+	if strings.Contains(term, "256") {
+		return Color256
+	}
+	// Modern terminals that don't advertise COLORTERM still do at least 256.
+	return Color256
+}
+
+func detectUnicode() bool {
+	for _, k := range []string{"LC_ALL", "LC_CTYPE", "LANG"} {
+		if v := strings.ToLower(os.Getenv(k)); v != "" {
+			return strings.Contains(v, "utf-8") || strings.Contains(v, "utf8")
+		}
+	}
+	return true // assume a modern UTF-8 terminal
+}
+
+func isTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	fi, err := f.Stat()
+	return err == nil && (fi.Mode()&os.ModeCharDevice) != 0
+}
+
+// Paint wraps s in the foreground color for the active level (no-op at
+// ColorNone). Bold is the same with the bold attribute.
+func (t *Theme) Paint(c Color, s string) string { return t.paint(c, s, false) }
+func (t *Theme) Bold(c Color, s string) string  { return t.paint(c, s, true) }
+
+func (t *Theme) paint(c Color, s string, bold bool) string {
+	if t.Level == ColorNone {
+		return s
+	}
+	var code string
+	switch t.Level {
+	case ColorTrue:
+		code = fmt.Sprintf("38;2;%d;%d;%d", c.R, c.G, c.B)
+	case Color256:
+		code = fmt.Sprintf("38;5;%d", rgbTo256(c))
+	default:
+		return s
+	}
+	if bold {
+		code = "1;" + code
+	}
+	return "\x1b[" + code + "m" + s + "\x1b[0m"
+}
+
+// glyph returns the Unicode glyph, or its ASCII fallback when the terminal
+// isn't UTF-8 capable.
+func (t *Theme) glyph(unicode, ascii string) string {
+	if t.Unicode {
+		return unicode
+	}
+	return ascii
+}
+
+// rgbTo256 maps a 24-bit color to the nearest xterm-256 index (6x6x6 cube +
+// grayscale ramp) for terminals without truecolor.
+func rgbTo256(c Color) int {
+	r, g, b := int(c.R), int(c.G), int(c.B)
+	if r == g && g == b {
+		if r < 8 {
+			return 16
+		}
+		if r > 248 {
+			return 231
+		}
+		return 232 + (r-8)*24/247
+	}
+	cube := func(v int) int {
+		switch {
+		case v < 48:
+			return 0
+		case v < 115:
+			return 1
+		default:
+			return (v - 35) / 40
+		}
+	}
+	return 16 + 36*cube(r) + 6*cube(g) + cube(b)
+}

--- a/internal/render/tokens.go
+++ b/internal/render/tokens.go
@@ -1,0 +1,77 @@
+package render
+
+import "github.com/dantech2000/refresh/internal/ui"
+
+// Status is a semantic state with a fixed glyph + color, so meaning is carried
+// by the glyph (not color alone).
+type Status int
+
+const (
+	Neutral  Status = iota // •  dim
+	Healthy                // ●  green  — active / current / pass
+	Warn                   // ▲  yellow — stale / warning
+	Fail                   // ✗  red    — failed / blocked
+	Progress               // ◷  teal   — updating / in-progress
+	Unknown                // ○  dim    — unknown / n-a
+)
+
+func (t *Theme) tokenParts(s Status) (glyph, ascii string, col Color) {
+	switch s {
+	case Healthy:
+		return "●", "[OK]", t.Pal.Green
+	case Warn:
+		return "▲", "[!]", t.Pal.Yellow
+	case Fail:
+		return "✗", "[X]", t.Pal.Red
+	case Progress:
+		return "◷", "[~]", t.Pal.Teal
+	case Unknown:
+		return "○", "[?]", t.Pal.Dim
+	default:
+		return "•", "-", t.Pal.Dim
+	}
+}
+
+// Glyph renders just the status glyph, colored.
+func (t *Theme) Glyph(s Status) string {
+	g, a, col := t.tokenParts(s)
+	return t.Paint(col, t.glyph(g, a))
+}
+
+// Token renders "glyph label" — the glyph colored, the label in the caller's
+// default text color. Pass an empty label for the glyph alone.
+func (t *Theme) Token(s Status, label string) string {
+	if label == "" {
+		return t.Glyph(s)
+	}
+	return t.Glyph(s) + " " + label
+}
+
+// Tokenf is Token with the label colored to match the status (used where the
+// whole token should read as one unit, e.g. a verdict).
+func (t *Theme) Tokenf(s Status, label string) string {
+	_, _, col := t.tokenParts(s)
+	if label == "" {
+		return t.Glyph(s)
+	}
+	return t.Glyph(s) + " " + t.Paint(col, label)
+}
+
+// StatusFromString maps a free-form AWS/Kubernetes status to a Status using the
+// single classification table in internal/ui (so the vocabulary never drifts).
+func StatusFromString(s string) Status {
+	switch ui.ClassifyStatus(s) {
+	case ui.StatusGood:
+		return Healthy
+	case ui.StatusWarning:
+		return Warn
+	case ui.StatusBad:
+		return Fail
+	case ui.StatusInProgress:
+		return Progress
+	case ui.StatusUnknown:
+		return Unknown
+	default:
+		return Neutral
+	}
+}


### PR DESCRIPTION
Epic **REF-119**, end-to-end in one PR. Reimagines the human-facing output into one coherent visual system and adds **real-time, per-node observability** to nodegroup rolls — all testable with **zero AWS / zero live cluster**.

Built additively: new packages alongside old, each surface flipped one commit at a time, every commit green (`go build`, `go vet`, `go test -race ./...`, `golangci-lint`, `govulncheck`). Machine formats (`-o json/yaml/plain`) are **byte-for-byte unchanged** throughout.

## Architecture decision: evolve, don't rewrite
New `internal/render` (design system) + `internal/noderoll` (live observer), but the proven plumbing stays: `runner.EncodeStdout` + the json/yaml/plain contract (REF-59), the ANSI-width math in `internal/ui`, the spinner TTY-degrade. Each restyled view branches `if ui.PlainOutput()` so `-o plain` keeps its TSV.

## What landed
- **REF-120/121 — `internal/render`**: Catppuccin palette (truecolor → 256 → none, capability detection); status tokens (`glyph + label + color`, ASCII fallback — color is always *additive*); primitives (section/table/KV/callout/bar); `LiveRegion` (in-place redraw on a TTY, appends when piped). Palette locked to the design-proof byte codes in CI.
- **REF-122 — `refresh status`**: fleet dashboard (header, summary chips, tokenized table, next-step hint).
- **REF-123 — cluster surfaces**: `cluster describe` (sectioned detail + health card), `cluster list` (tokenized, tree kept), and `cluster upgrade-check` (readiness verdict ✗ NOT READY / ▲ REVIEW / ● READY + tokenized insights + skew).
- **REF-124 — `nodegroup list` / `addon list`**: same grammar.
- **REF-125 — observer**: `KubeObserver` (label-scoped Node state → Ready/joining/draining; old-vs-new via the `nodegroup-image` AMI label **or** a roll-start `CaptureBaseline`; **real pod-eviction counting** on draining nodes, excluding DaemonSet/mirror/terminal pods); `Tracker` (snapshot diffs → lifecycle event feed).
- **REF-126/127 — live panel**: pure `rollPanelLines` frame model (golden-tested); `runRoll` driver via `LiveRegion`; **`nodegroup update --simulate`** runs the whole live roll with no AWS.
- **REF-128 — docs**: CLAUDE.md, `docs/concepts/output.md` (design system + live view), README.

## Testing without a live cluster
- **Data**: `client-go/kubernetes/fake` — full roll transitions (`observer_test.go`), pod-eviction counting (`podeviction_test.go`), and a real `KubeObserver` → panel **integration test** (`rollpanel_integration_test.go`).
- **Render**: pure frame models (`[]string`) golden-tested under `NO_COLOR` (fleet, detail, list, upgrade-check, roll panel).
- **Demo**: `refresh nodegroup update --simulate` — the full live roll, no AWS:

```
⠸ rolling spot-burst   ami-0a1b… → ami-0f9e…
▕██████████░░░░░░▏  2/3 replaced · 3 new ready

     NODE            AMI  STATE
  ▲  ip-10-0-2-08    old  draining · evicting ▕█████▏ 5/5 pods
  ●  ip-10-0-1-44    new  Ready
  ●  ip-10-0-3-05    new  Ready
```

## One remaining step (called out, not hidden)
Flipping the **live `nodegroup update` monitor** itself onto this panel during a *real* roll is gated on a real-cluster run — the EKS-update concurrency can't be exercised by the fake harness. Every component it needs (observer, baseline classification, pod-eviction, panel, driver) is complete and tested, and the real observer→panel path is proven with a fake cluster. Also deferred: the ASG-activities fallback for the no-kube-access case.

Closes REF-120, REF-121, REF-122, REF-123, REF-124, REF-125, REF-127, REF-128. Advances REF-126 (real-roll monitor insertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)