### PR TITLE
fix: CLI/help/status UX bugs (REF-129, REF-131, REF-132, REF-133, REF-134)

### DIFF
--- a/docs/reference/nodegroup.md
+++ b/docs/reference/nodegroup.md
@@ -126,7 +126,7 @@ operation settles.
 
 ### refresh nodegroup update
 
-> Update the AMI for all or a specific node group (rolling by default)
+> Update the AMI for all or a specific nodegroup (rolling by default)
 
 **Aliases:** `update-ami`
 

--- a/docs/reference/status.md
+++ b/docs/reference/status.md
@@ -21,10 +21,8 @@ Exit codes (for CI/cron):
 
 | Flag | Env | Default | Description |
 |---|---|---|---|
-| `--timeout, -t duration` | `REFRESH_TIMEOUT` | `2m0s` | Operation timeout (e.g. 60s, 2m) |
 | `--all-regions, -A` | — | — | Query all EKS-supported regions |
 | `--region, -r string` | — | — | Specific region(s) to query (repeatable) |
-| `--max-concurrency, -C int` | `REFRESH_MAX_CONCURRENCY` | `8` | Max concurrent region/cluster requests |
 | `--format, -o string` | — | `table` | Output format (table, json, yaml, plain) |
 | `--sort string` | — | `cluster` | Sort by field: cluster,region,version,support,stale |
 | `--desc` | — | — | Sort descending |

--- a/internal/commands/nodegroup/actions_describe.go
+++ b/internal/commands/nodegroup/actions_describe.go
@@ -16,6 +16,16 @@ func runDescribe(ctx context.Context, cmd *cli.Command) error {
 	if err := runner.ValidateFormat(cmd.String("format"), runner.FormatsStandard); err != nil {
 		return err
 	}
+
+	// Validate the nodegroup name before any AWS work: PositionalSlot reads only
+	// flags/positionals, so a missing name should fail fast — not after loading
+	// AWS config, resolving the cluster, and printing a misleading "Cluster name
+	// resolved!" success message. (REF-131)
+	ngName := runner.PositionalSlot(cmd, "nodegroup", "cluster")
+	if ngName == "" {
+		return fmt.Errorf("missing nodegroup name; pass as second argument or --nodegroup <name>")
+	}
+
 	ctx, cancel, awsCfg, err := runner.SetupAWS(ctx, cmd)
 	if err != nil {
 		return err
@@ -25,11 +35,6 @@ func runDescribe(ctx context.Context, cmd *cli.Command) error {
 	clusterName, listed, err := runner.ResolveClusterOrList(ctx, awsCfg, cmd)
 	if err != nil || listed {
 		return err
-	}
-
-	ngName := runner.PositionalSlot(cmd, "nodegroup", "cluster")
-	if ngName == "" {
-		return fmt.Errorf("missing nodegroup name; pass as second argument or --nodegroup <name>")
 	}
 
 	logger := factory.NewDefaultLogger(nil)

--- a/internal/commands/nodegroup/command.go
+++ b/internal/commands/nodegroup/command.go
@@ -121,7 +121,7 @@ func updateAMICommand() *cli.Command {
 	return &cli.Command{
 		Name:      "update",
 		Aliases:   []string{"update-ami"},
-		Usage:     "Update the AMI for all or a specific node group (rolling by default)",
+		Usage:     "Update the AMI for all or a specific nodegroup (rolling by default)",
 		ArgsUsage: "[cluster] [nodegroup]",
 		Description: `Roll managed nodegroups to the latest recommended AMI, with pre-flight
 health gates and live monitoring.

--- a/internal/commands/statuscmd/actions.go
+++ b/internal/commands/statuscmd/actions.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v3"
 
+	"github.com/dantech2000/refresh/internal/commands/factory"
 	"github.com/dantech2000/refresh/internal/commands/runner"
 	"github.com/dantech2000/refresh/internal/commands/statusview"
 	appconfig "github.com/dantech2000/refresh/internal/config"
@@ -96,6 +97,10 @@ func gatherFleet(ctx context.Context, baseCfg aws.Config, regions []string, opts
 	if maxConc <= 0 {
 		maxConc = appconfig.DefaultMaxConcurrency
 	}
+	// Build the shared logger once through the factory so service logs honor the
+	// global --log-level/--verbose (quiet by default) instead of leaking at
+	// Info level into the TUI. (REF-129)
+	logger := factory.NewDefaultLogger(nil)
 	var (
 		mu   sync.Mutex
 		all  []statussvc.ClusterStatus
@@ -112,7 +117,7 @@ func gatherFleet(ctx context.Context, baseCfg aws.Config, regions []string, opts
 
 			cfg := baseCfg.Copy()
 			cfg.Region = r
-			svc := statussvc.NewService(cfg, nil)
+			svc := statussvc.NewService(cfg, logger)
 			statuses, err := svc.ListClusterStatuses(ctx, opts)
 
 			mu.Lock()

--- a/internal/commands/statuscmd/command.go
+++ b/internal/commands/statuscmd/command.go
@@ -4,11 +4,8 @@ package statuscmd
 
 import (
 	"context"
-	"time"
 
 	"github.com/urfave/cli/v3"
-
-	appconfig "github.com/dantech2000/refresh/internal/config"
 )
 
 // Command returns the `refresh status` top-level command.
@@ -26,10 +23,15 @@ Exit codes (for CI/cron):
   2  something stale (nodegroup AMI or addon behind latest)
   3  a cluster is on extended support or unsupported`,
 		Flags: []cli.Flag{
-			&cli.DurationFlag{Name: "timeout", Aliases: []string{"t"}, Usage: "Operation timeout (e.g. 60s, 2m)", Value: 2 * time.Minute, Sources: cli.EnvVars("REFRESH_TIMEOUT")},
+			// --timeout and --max-concurrency come from the global/persistent
+			// flags (see main.go); status reads them via cmd.Duration/cmd.Int and
+			// does not re-declare them, so help lists each once. (REF-134)
+			//
+			// --region is intentionally local: a repeatable slice for "scan these
+			// regions", which deliberately shadows the global single-string AWS
+			// region override. (REF-47)
 			&cli.BoolFlag{Name: "all-regions", Aliases: []string{"A"}, Usage: "Query all EKS-supported regions"},
 			&cli.StringSliceFlag{Name: "region", Aliases: []string{"r"}, Usage: "Specific region(s) to query (repeatable)"},
-			&cli.IntFlag{Name: "max-concurrency", Aliases: []string{"C"}, Usage: "Max concurrent region/cluster requests", Value: appconfig.DefaultMaxConcurrency, Sources: cli.EnvVars("REFRESH_MAX_CONCURRENCY")},
 			&cli.StringFlag{Name: "format", Aliases: []string{"o"}, Usage: "Output format (table, json, yaml, plain)", Value: "table"},
 			&cli.StringFlag{Name: "sort", Usage: "Sort by field: cluster,region,version,support,stale", Value: "cluster"},
 			&cli.BoolFlag{Name: "desc", Usage: "Sort descending"},

--- a/internal/health/capacity.go
+++ b/internal/health/capacity.go
@@ -54,7 +54,7 @@ func (hc *HealthChecker) checkClusterCapacityWith(ctx context.Context, snap *cpu
 		result.Status = StatusWarn
 		result.Score = 70 // Default score when metrics unavailable
 		result.Message = fmt.Sprintf("Unable to fetch CPU metrics: %v", err)
-		result.Details = append(result.Details, "EC2 CPU metrics unavailable - check EKS node group status")
+		result.Details = append(result.Details, "EC2 CPU metrics unavailable - check EKS nodegroup status")
 		return result
 	}
 

--- a/internal/services/status/service.go
+++ b/internal/services/status/service.go
@@ -3,6 +3,7 @@ package status
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"strings"
 	"sync"
@@ -72,7 +73,11 @@ type ListOptions struct {
 // the concrete cluster/nodegroup/addons/ec2 clients.
 func NewService(awsCfg aws.Config, logger *slog.Logger) *Service {
 	if logger == nil {
-		logger = slog.Default()
+		// Defense-in-depth: callers should pass factory.NewDefaultLogger(nil)
+		// (quiet by default, honoring --log-level/--verbose). If a caller still
+		// passes nil, discard service logs rather than falling back to
+		// slog.Default(), which is Info-level and would leak into the TUI. (REF-129)
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	}
 	eksClient := eks.NewFromConfig(awsCfg)
 	return &Service{

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
+	"strings"
 	"syscall"
 
 	"github.com/fatih/color"
@@ -36,32 +37,40 @@ func coloredHelpPrinter(w io.Writer, templ string, data interface{}) {
 	// First, render the template using the default printer to a buffer
 	var buf bytes.Buffer
 	cli.HelpPrinterCustom(&buf, templ, data, nil)
+	_, _ = fmt.Fprint(w, colorizeHelp(buf.String()))
+}
 
-	// Get the rendered help text
-	helpText := buf.String()
-
-	// Define colors
+// colorizeHelp applies section-header and command-name coloring to already
+// rendered help text. Command-name coloring is scoped to the COMMANDS section
+// only: applied globally, commandRegex matches the leading word of any indented
+// line — including wrapped DESCRIPTION prose — and colors it as if it were a
+// command. Section headers are colored wherever they appear. (REF-132)
+func colorizeHelp(text string) string {
 	cyan := color.New(color.FgCyan, color.Bold)
 	yellow := color.New(color.FgYellow)
 
-	// Apply colors to section headers
-	helpText = sectionRegex.ReplaceAllStringFunc(helpText, func(match string) string {
-		return cyan.Sprint(match)
-	})
-
-	// Color command names (looking for lines with command format)
-	helpText = commandRegex.ReplaceAllStringFunc(helpText, func(match string) string {
-		parts := commandRegex.FindStringSubmatch(match)
-		return fmt.Sprintf("%s%s%s", parts[1], yellow.Sprint(parts[2]), parts[3])
-	})
-
-	_, _ = fmt.Fprint(w, helpText)
+	lines := strings.Split(text, "\n")
+	inCommands := false
+	for i, line := range lines {
+		if m := sectionRegex.FindStringSubmatch(line); m != nil {
+			inCommands = m[1] == "COMMANDS"
+			lines[i] = cyan.Sprint(line)
+			continue
+		}
+		if inCommands {
+			lines[i] = commandRegex.ReplaceAllStringFunc(line, func(match string) string {
+				parts := commandRegex.FindStringSubmatch(match)
+				return fmt.Sprintf("%s%s%s", parts[1], yellow.Sprint(parts[2]), parts[3])
+			})
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func newApp() *cli.Command {
 	return &cli.Command{
 		Name:                  "refresh",
-		Usage:                 "Manage and monitor AWS EKS clusters and node groups",
+		Usage:                 "Manage and monitor AWS EKS clusters and nodegroups",
 		Version:               commands.VersionInfo.Version,
 		EnableShellCompletion: true,
 		Flags: []cli.Flag{

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/fatih/color"
 	docs "github.com/urfave/cli-docs/v3"
 
 	awsClient "github.com/dantech2000/refresh/internal/aws"
@@ -204,6 +205,44 @@ COMMANDS:
 	// Section header should be present.
 	if !strings.Contains(got, "NAME") || !strings.Contains(got, "COMMANDS") {
 		t.Fatalf("coloredHelpPrinter: missing section headers in output: %q", got)
+	}
+}
+
+// REF-132: command-name coloring must be confined to the COMMANDS section.
+// Words that happen to match command names inside DESCRIPTION prose (or any
+// other indented block) must NOT be colorized.
+func TestColorizeHelpScopesCommandColoringToCommandsSection(t *testing.T) {
+	// Force color on regardless of TTY so the ANSI assertions are meaningful.
+	prev := color.NoColor
+	color.NoColor = false
+	t.Cleanup(func() { color.NoColor = prev })
+
+	help := strings.Join([]string{
+		"NAME:",
+		"   refresh nodegroup - manage nodegroups",
+		"",
+		"DESCRIPTION:",
+		"   Inspect and operate: list them, describe one, scale and update.",
+		"",
+		"COMMANDS:",
+		"   list      List nodegroups",
+		"   describe  Describe a nodegroup",
+		"",
+	}, "\n")
+
+	for _, line := range strings.Split(colorizeHelp(help), "\n") {
+		switch {
+		case strings.Contains(line, "Inspect and operate"):
+			// Prose words (list/describe/scale/update) must stay uncolored.
+			if strings.Contains(line, "\x1b[") {
+				t.Errorf("DESCRIPTION prose was colorized: %q", line)
+			}
+		case strings.Contains(line, "List nodegroups"):
+			// Real command rows must be colorized (yellow command name).
+			if !strings.Contains(line, "\x1b[33m") {
+				t.Errorf("COMMANDS row was not colorized: %q", line)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Batch of small correctness/polish fixes found during manual testing. Each maps to a tracked Linear issue.

## Fixes

### REF-129 — `refresh status` leaked Info logs into the TUI
The status service fell back to `slog.Default()` (Info-level, ignores `--log-level`/`--verbose`) when passed a `nil` logger, so service logs like `… INFO listing nodegroups …` stomped on the spinner. Now `gatherFleet` builds the shared logger once via `factory.NewDefaultLogger(nil)` (quiet by default), and the service's `nil` fallback discards rather than using `slog.Default()`.

### REF-131 — `nodegroup describe/get` SUCCESS-then-error on missing name
`refresh nodegroup get develop` printed `SUCCESS Cluster name resolved!` and burned an AWS round-trip before erroring on the missing nodegroup name. The name is resolvable from flags/positionals with no AWS, so it's now validated **before** `SetupAWS`/cluster resolution — clean fast-fail, no misleading success. (`scale` is already covered by `--nodegroup Required: true`.)

### REF-132 — help colorizer highlighted prose as commands
`coloredHelpPrinter` ran the command-name regex over the whole help buffer, coloring the leading word of wrapped `DESCRIPTION` lines as if they were commands. Colorization is now scoped to the `COMMANDS` section via a section-aware line-by-line pass, extracted as `colorizeHelp` with a regression test asserting prose stays uncolored.

### REF-133 — "node group" → "nodegroup"
Normalized three user-facing strings (update usage, top-level app usage, capacity health detail) to the canonical one-word term.

### REF-134 — status re-declared global flags
`status` re-declared `--timeout` (default 2m vs global 1m) and `--max-concurrency`, producing duplicate, conflicting help entries. Dropped the local flags to rely on the globals (single source of truth, accurate help). `--region` stays local intentionally (REF-47). Note: this changes `status`'s default timeout from 2m to the global 1m; `--timeout`/`REFRESH_TIMEOUT` still override.

## Verification
- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), full `go test ./...` + `-race` on touched packages — all green.
- Runtime-checked: `nodegroup describe`/`describe develop` fast-fail with no SUCCESS; `status --help` lists `--timeout`/`--max-concurrency` once; new unit test covers the help-colorization scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)