### PR TITLE
ci: pin actions to SHAs, add job timeouts + concurrency guards (REF-136)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    # Above the two 900s (15m) check-waits below so they can resolve first.
+    timeout-minutes: 20
     if: github.actor == 'dependabot[bot]'
 
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,11 @@ on:
   pull_request_review:
     types: [submitted]
 
+# One Claude run per issue/PR at a time; a newer @claude mention supersedes.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude:
     if: |
@@ -18,6 +23,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: read
@@ -32,7 +38,9 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        # Pinned to a SHA (the action only publishes a mutable @beta branch).
+        # Dependabot (github-actions) keeps this current.
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,7 @@ jobs:
   build:
     name: Build site
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read # no id-token / pages / secrets — untrusted deps run here
     steps:
@@ -87,6 +88,7 @@ jobs:
     # Only deploy from main; PRs build-and-validate only.
     if: github.event_name == 'push'
     needs: build
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     permissions:
       pages: write # mint the Pages deployment

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
   golangci-lint:
     name: Run golangci-lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,11 +9,17 @@ permissions:
   contents: write
   pull-requests: write
 
+# Serialize release-please so rapid merges to main don't race on the release PR.
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
           token: ${{ secrets.GH_PAT }}
           config-file: release-please-config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,27 +15,28 @@ jobs:
   goreleaser:
     name: Run GoReleaser
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
 
       # SBOM generation (syft) and signing (cosign) used by .goreleaser.yml. (REF-74)
       - name: Install syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
   test:
     name: Run go test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -64,6 +65,7 @@ jobs:
   govulncheck:
     name: Run govulncheck
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
Hardening from a full CI/CD audit (REF-136).

## Audit outcome: parallelism is already good
A PR runs **test + lint + govulncheck as 3 parallel jobs** (critical path = test, ~3m27s after REF-135). `docs.yml` splits **build** (untrusted deps, `contents: read`) from **deploy** (`needs: build`, `pages: write`). Concurrency cancellation is on the hot paths. There's no wasteful serialization to fix — combining jobs would only hurt wall time. So this PR is safety/supply-chain, not restructuring.

## Changes
1. **Pin every remaining action to a full commit SHA**, matching the repo's existing policy. Covers all 5 actions in `release.yml` (the release pipeline — `id-token`/`packages: write`), `release-please.yml`, and `claude.yml`'s `@beta` **branch** ref (mutable + `id-token: write` — the riskiest). Dependabot (`github-actions`) keeps these current.
2. **`timeout-minutes` on every job** so a hung run can't burn the 6h default (test 20, govulncheck/lint/docs-build 15, deploy/release-please 10, release 30, claude/auto-merge 20 — auto-merge above its 900s check-wait).
3. **`concurrency`** on `release-please` (serialize on rapid main merges) and `claude` (one run per issue/PR).

All 7 workflows validated as well-formed YAML; no behavior change to the test/lint/docs jobs.

## Deferred for your decision (not in this PR)
- **No branch protection / required checks on `main`** — failing CI doesn't block merge today. Recommend requiring `Run go test` + `Run golangci-lint`.
- **`test`/`lint` run on docs-only PRs** (no path filter) — wasted ~3.5min; coupled to the required-checks decision above (path-filtering + required checks deadlocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)