### PR TITLE
Real-time data, tier-1/3 small batch: REF-137/139/141/145

### DIFF
--- a/internal/commands/cluster/actions.go
+++ b/internal/commands/cluster/actions.go
@@ -7,12 +7,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/urfave/cli/v3"
 
 	"github.com/dantech2000/refresh/internal/commands/clusterview"
 	"github.com/dantech2000/refresh/internal/commands/factory"
 	"github.com/dantech2000/refresh/internal/commands/runner"
 	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
+	"github.com/dantech2000/refresh/internal/services/status"
 	"github.com/dantech2000/refresh/internal/ui"
 )
 
@@ -143,6 +145,13 @@ func runDescribe(ctx context.Context, cmd *cli.Command) error {
 		return derr
 	}); err != nil {
 		return err
+	}
+
+	// Support posture for the cluster's version, via the same resolver behind
+	// `refresh status` (REF-145).
+	if details != nil && details.Version != "" {
+		posture := status.NewSupportResolver(eks.NewFromConfig(awsCfg)).Resolve(ctx, details.Version)
+		details.Support = &posture
 	}
 
 	if handled, err := runner.EncodeStdout(cmd.String("format"), details); handled {

--- a/internal/commands/cluster/upgradecheck.go
+++ b/internal/commands/cluster/upgradecheck.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/urfave/cli/v3"
 
 	"github.com/dantech2000/refresh/internal/commands/clusterview"
@@ -10,6 +11,7 @@ import (
 	"github.com/dantech2000/refresh/internal/commands/runner"
 	appconfig "github.com/dantech2000/refresh/internal/config"
 	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
+	"github.com/dantech2000/refresh/internal/services/status"
 )
 
 func upgradeCheckCommand() *cli.Command {
@@ -87,6 +89,13 @@ func runUpgradeCheck(ctx context.Context, cmd *cli.Command) error {
 		return rerr
 	}); werr != nil {
 		return werr
+	}
+
+	// Support posture for the control-plane version, via the same resolver
+	// behind `refresh status` (REF-145).
+	if report != nil && report.Skew.ControlPlaneVersion != "" {
+		posture := status.NewSupportResolver(eks.NewFromConfig(awsCfg)).Resolve(ctx, report.Skew.ControlPlaneVersion)
+		report.Support = &posture
 	}
 
 	if handled, encErr := runner.EncodeStdout(cmd.String("format"), report); handled {

--- a/internal/commands/clusterview/detail.go
+++ b/internal/commands/clusterview/detail.go
@@ -110,5 +110,19 @@ func outputClusterDetailsPlain(details *clustersvc.ClusterDetails, elapsed time.
 		}
 		addTbl.Render()
 	}
+
+	if len(details.HealthIssues) > 0 {
+		ui.Outln("\nHealth Issues:")
+		for _, iss := range details.HealthIssues {
+			line := iss.Code
+			if iss.Message != "" {
+				line += ": " + iss.Message
+			}
+			if len(iss.ResourceIds) > 0 {
+				line += " [" + strings.Join(iss.ResourceIds, ", ") + "]"
+			}
+			fmt.Printf("  - %s\n", line)
+		}
+	}
 	return nil
 }

--- a/internal/commands/clusterview/detail.go
+++ b/internal/commands/clusterview/detail.go
@@ -39,6 +39,10 @@ func outputClusterDetailsPlain(details *clustersvc.ClusterDetails, elapsed time.
 		Add("Platform", details.PlatformVersion).
 		Add("Endpoint", truncateEndpoint(details.Endpoint))
 
+	if details.Support != nil {
+		tbl.Add("Support", supportPlain(details.Support))
+	}
+
 	if details.Health != nil {
 		tbl.Add("Health", formatHealth(details.Health))
 	}

--- a/internal/commands/clusterview/detail_render.go
+++ b/internal/commands/clusterview/detail_render.go
@@ -115,9 +115,32 @@ func clusterDetailLines(th *render.Theme, d *clustersvc.ClusterDetails, elapsed 
 		}
 	}
 
+	if len(d.HealthIssues) > 0 {
+		out = append(out, "")
+		out = append(out, healthIssueLines(th, d.HealthIssues)...)
+	}
+
 	if d.Health != nil {
 		out = append(out, "")
 		out = append(out, healthCardLines(th, d.Health)...)
+	}
+	return out
+}
+
+// healthIssueLines renders the HEALTH ISSUES section: AWS-reported control-plane
+// problems (DescribeCluster Health.Issues) as failing tokens with affected
+// resource IDs. Shared shape with nodegroup/addon issues.
+func healthIssueLines(th *render.Theme, issues []clustersvc.HealthIssue) []string {
+	out := []string{th.Section("HEALTH ISSUES") + th.Paint(th.Pal.Dim, fmt.Sprintf("  %d", len(issues)))}
+	for _, iss := range issues {
+		label := iss.Code
+		if iss.Message != "" {
+			label += ": " + iss.Message
+		}
+		out = append(out, "  "+th.Token(render.Fail, label))
+		if len(iss.ResourceIds) > 0 {
+			out = append(out, "    "+th.Paint(th.Pal.Dim, strings.Join(iss.ResourceIds, ", ")))
+		}
 	}
 	return out
 }

--- a/internal/commands/clusterview/detail_render.go
+++ b/internal/commands/clusterview/detail_render.go
@@ -31,6 +31,9 @@ func clusterDetailLines(th *render.Theme, d *clustersvc.ClusterDetails, elapsed 
 		{"version", version},
 		{"status", statusToken(th, d.Status)},
 	}
+	if d.Support != nil {
+		kv = append(kv, [2]string{"support", supportToken(th, d.Support)})
+	}
 	if d.Endpoint != "" {
 		kv = append(kv, [2]string{"endpoint", th.Paint(pal.Sky, truncateEndpoint(d.Endpoint))})
 	}

--- a/internal/commands/clusterview/detail_render_test.go
+++ b/internal/commands/clusterview/detail_render_test.go
@@ -35,6 +35,32 @@ func sampleDetails() *clustersvc.ClusterDetails {
 	}
 }
 
+func TestClusterDetailLines_HealthIssues(t *testing.T) {
+	th := render.New(render.ColorNone, true)
+	d := sampleDetails()
+	d.HealthIssues = []clustersvc.HealthIssue{{
+		Code:        "InternalFailure",
+		Message:     "control plane could not assume the cluster IAM role",
+		ResourceIds: []string{"arn:aws:iam::123456789012:role/eksClusterRole"},
+	}}
+	joined := strings.Join(clusterDetailLines(th, d, 0), "\n")
+	for _, want := range []string{
+		"▸ HEALTH ISSUES  1",
+		"InternalFailure: control plane could not assume the cluster IAM role",
+		"arn:aws:iam::123456789012:role/eksClusterRole",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("describe view missing %q in:\n%s", want, joined)
+		}
+	}
+
+	// No issues → no HEALTH ISSUES section.
+	clean := strings.Join(clusterDetailLines(th, sampleDetails(), 0), "\n")
+	if strings.Contains(clean, "HEALTH ISSUES") {
+		t.Errorf("clean cluster should not render a HEALTH ISSUES section:\n%s", clean)
+	}
+}
+
 func TestClusterDetailLines_Pretty(t *testing.T) {
 	th := render.New(render.ColorNone, true)
 	joined := strings.Join(clusterDetailLines(th, sampleDetails(), 0), "\n")

--- a/internal/commands/clusterview/insights.go
+++ b/internal/commands/clusterview/insights.go
@@ -113,7 +113,43 @@ func OutputInsightDetail(detail *clustersvc.InsightDetail) error {
 			fmt.Printf("    - %s\n", r)
 		}
 	}
+	for _, line := range deprecationLines(detail.Deprecations) {
+		fmt.Println(line)
+	}
 	return nil
+}
+
+// deprecationLines renders the deprecated-API breakdown: for each deprecated
+// resource, the replacement and the clients still calling it (most-active
+// first), so you know exactly which workload to fix before the upgrade.
+func deprecationLines(deps []clustersvc.DeprecationDetail) []string {
+	if len(deps) == 0 {
+		return nil
+	}
+	out := []string{"", "  Deprecated APIs still in use:"}
+	for _, d := range deps {
+		head := "    - " + valueOrDash(d.Usage)
+		if d.ReplacedWith != "" {
+			head += " → " + d.ReplacedWith
+		}
+		if d.StopServingVersion != "" {
+			head += fmt.Sprintf(" (removed in %s)", d.StopServingVersion)
+		}
+		out = append(out, head)
+		if len(d.ClientStats) == 0 {
+			continue
+		}
+		for _, c := range d.ClientStats {
+			last := "-"
+			if c.LastRequestTime != nil {
+				last = c.LastRequestTime.Format(insightTimeLayout)
+			}
+			out = append(out, fmt.Sprintf("        %s — %d req/30d, last seen %s",
+				valueOrDash(c.UserAgent), c.NumberOfRequestsLast30Days, last))
+		}
+	}
+	out = append(out, "    note: EKS reads audit logs on a 30-day window — a check stays ERROR until the last call ages out.")
+	return out
 }
 
 func valueOrDash(s string) string {

--- a/internal/commands/clusterview/insights.go
+++ b/internal/commands/clusterview/insights.go
@@ -26,6 +26,9 @@ func OutputUpgradeCheck(report *clustersvc.UpgradeReport) error {
 		return nil
 	}
 	ui.Outf("Upgrade readiness for %s\n", report.Cluster)
+	if report.Support != nil {
+		ui.Outf("Support: %s\n", supportPlain(report.Support))
+	}
 	outputInsights(report.Insights)
 	fmt.Println()
 	outputSkew(report.Skew)

--- a/internal/commands/clusterview/insights_render.go
+++ b/internal/commands/clusterview/insights_render.go
@@ -53,9 +53,14 @@ func upgradeCheckLines(th *render.Theme, report *clustersvc.UpgradeReport) []str
 	st, verdict := upgradeVerdict(report)
 	out := []string{
 		th.Bold(pal.White, "UPGRADE READINESS") + th.Paint(pal.Dim, "  "+report.Cluster) + "   " + th.Tokenf(st, verdict),
-		"",
-		th.Section("INSIGHTS") + th.Paint(pal.Dim, fmt.Sprintf("  %d", len(report.Insights))),
 	}
+	if report.Support != nil {
+		out = append(out, th.Paint(pal.Dim, "support  ")+supportToken(th, report.Support))
+	}
+	out = append(out,
+		"",
+		th.Section("INSIGHTS")+th.Paint(pal.Dim, fmt.Sprintf("  %d", len(report.Insights))),
+	)
 
 	if len(report.Insights) == 0 {
 		out = append(out, "  "+th.Token(render.Healthy, "no upgrade insights to address"))

--- a/internal/commands/clusterview/insights_render_test.go
+++ b/internal/commands/clusterview/insights_render_test.go
@@ -3,10 +3,39 @@ package clusterview
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dantech2000/refresh/internal/render"
 	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
 )
+
+func TestDeprecationLines(t *testing.T) {
+	// Empty input renders nothing.
+	if got := deprecationLines(nil); got != nil {
+		t.Errorf("nil deprecations should render nothing, got %v", got)
+	}
+
+	last := time.Date(2026, 6, 14, 9, 30, 0, 0, time.UTC)
+	deps := []clustersvc.DeprecationDetail{{
+		Usage:              "policy/v1beta1 PodDisruptionBudget",
+		ReplacedWith:       "policy/v1 PodDisruptionBudget",
+		StopServingVersion: "1.25",
+		ClientStats: []clustersvc.ClientStat{
+			{UserAgent: "newrelic-kube-state-metric/v2", LastRequestTime: &last, NumberOfRequestsLast30Days: 412},
+		},
+	}}
+	joined := strings.Join(deprecationLines(deps), "\n")
+	for _, want := range []string{
+		"Deprecated APIs still in use:",
+		"policy/v1beta1 PodDisruptionBudget → policy/v1 PodDisruptionBudget (removed in 1.25)",
+		"newrelic-kube-state-metric/v2 — 412 req/30d, last seen 2026-06-14 09:30",
+		"30-day window",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("deprecation render missing %q in:\n%s", want, joined)
+		}
+	}
+}
 
 func TestUpgradeCheckLines_Verdicts(t *testing.T) {
 	th := render.New(render.ColorNone, true)

--- a/internal/commands/clusterview/support.go
+++ b/internal/commands/clusterview/support.go
@@ -1,0 +1,61 @@
+package clusterview
+
+import (
+	"fmt"
+
+	"github.com/dantech2000/refresh/internal/render"
+	"github.com/dantech2000/refresh/internal/services/status"
+)
+
+// supportToken renders an EKS support posture (tier + days remaining, and the
+// extended-support premium when in extended) as a colored token: green for
+// standard, a warning for extended, a failure for unsupported. Reuses the
+// posture resolved by the shared status resolver (REF-145).
+func supportToken(th *render.Theme, p *status.SupportPosture) string {
+	if p == nil {
+		return th.Paint(th.Pal.Dim, "unknown")
+	}
+	days := ""
+	if p.DaysRemaining != nil {
+		days = fmt.Sprintf(" (%dd)", *p.DaysRemaining)
+	}
+	switch p.Tier {
+	case status.SupportStandard:
+		return th.Paint(th.Pal.Green, "standard"+days)
+	case status.SupportExtended:
+		txt := "extended" + days
+		if p.ExtraCostUSDPerHour > 0 {
+			txt += fmt.Sprintf(" · +$%.2f/hr", p.ExtraCostUSDPerHour)
+		}
+		return th.Token(render.Warn, txt)
+	case status.SupportUnsupported:
+		return th.Token(render.Fail, "unsupported")
+	default:
+		return th.Paint(th.Pal.Dim, "unknown")
+	}
+}
+
+// supportPlain is the uncolored form of a support posture for `-o plain`.
+func supportPlain(p *status.SupportPosture) string {
+	if p == nil {
+		return "unknown"
+	}
+	days := ""
+	if p.DaysRemaining != nil {
+		days = fmt.Sprintf(" (%dd)", *p.DaysRemaining)
+	}
+	switch p.Tier {
+	case status.SupportStandard:
+		return "standard" + days
+	case status.SupportExtended:
+		s := "extended" + days
+		if p.ExtraCostUSDPerHour > 0 {
+			s += fmt.Sprintf(", +$%.2f/hr", p.ExtraCostUSDPerHour)
+		}
+		return s
+	case status.SupportUnsupported:
+		return "unsupported"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/commands/clusterview/support_test.go
+++ b/internal/commands/clusterview/support_test.go
@@ -1,0 +1,68 @@
+package clusterview
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dantech2000/refresh/internal/render"
+	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
+	"github.com/dantech2000/refresh/internal/services/status"
+)
+
+func intp(i int) *int { return &i }
+
+func TestSupportFormatters(t *testing.T) {
+	th := render.New(render.ColorNone, true)
+
+	std := &status.SupportPosture{Tier: status.SupportStandard, DaysRemaining: intp(200)}
+	if got := supportPlain(std); got != "standard (200d)" {
+		t.Errorf("standard plain = %q, want %q", got, "standard (200d)")
+	}
+	if got := supportToken(th, std); !strings.Contains(got, "standard (200d)") {
+		t.Errorf("standard token = %q", got)
+	}
+
+	ext := &status.SupportPosture{Tier: status.SupportExtended, DaysRemaining: intp(90), ExtraCostUSDPerHour: 0.50}
+	if got := supportPlain(ext); got != "extended (90d), +$0.50/hr" {
+		t.Errorf("extended plain = %q", got)
+	}
+	if got := supportToken(th, ext); !strings.Contains(got, "extended (90d)") || !strings.Contains(got, "+$0.50/hr") {
+		t.Errorf("extended token = %q", got)
+	}
+
+	if got := supportPlain(&status.SupportPosture{Tier: status.SupportUnsupported}); got != "unsupported" {
+		t.Errorf("unsupported plain = %q", got)
+	}
+	if got := supportPlain(nil); got != "unknown" {
+		t.Errorf("nil plain = %q, want unknown", got)
+	}
+}
+
+func TestUpgradeCheckLines_Support(t *testing.T) {
+	th := render.New(render.ColorNone, true)
+	rpt := &clustersvc.UpgradeReport{
+		Cluster: "prod",
+		Support: &status.SupportPosture{Tier: status.SupportStandard, DaysRemaining: intp(200)},
+		Skew:    clustersvc.SkewReport{ControlPlaneVersion: "1.32"},
+	}
+	joined := strings.Join(upgradeCheckLines(th, rpt), "\n")
+	if !strings.Contains(joined, "support  standard (200d)") {
+		t.Errorf("upgrade-check missing support line in:\n%s", joined)
+	}
+
+	// Nil support → no support line (back-compat with existing reports).
+	noSup := &clustersvc.UpgradeReport{Cluster: "prod", Skew: clustersvc.SkewReport{ControlPlaneVersion: "1.32"}}
+	if got := strings.Join(upgradeCheckLines(th, noSup), "\n"); strings.Contains(got, "support  ") {
+		t.Errorf("nil support should render no support line:\n%s", got)
+	}
+}
+
+func TestClusterDetailLines_Support(t *testing.T) {
+	th := render.New(render.ColorNone, true)
+	d := sampleDetails()
+	d.Support = &status.SupportPosture{Tier: status.SupportExtended, DaysRemaining: intp(45), ExtraCostUSDPerHour: 0.50}
+	joined := strings.Join(clusterDetailLines(th, d, 0), "\n")
+	if !strings.Contains(joined, "support") || !strings.Contains(joined, "extended (45d)") {
+		t.Errorf("describe missing support KV in:\n%s", joined)
+	}
+}

--- a/internal/commands/nodegroup/rollpanel.go
+++ b/internal/commands/nodegroup/rollpanel.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"k8s.io/client-go/kubernetes"
@@ -130,13 +131,14 @@ func amiWord(th *render.Theme, onTarget bool) string {
 }
 
 func nodeStateCell(th *render.Theme, n noderoll.NodeView) string {
+	var s string
 	switch n.Phase {
 	case noderoll.PhaseReady:
-		return th.Paint(th.Pal.Green, "Ready")
+		s = th.Paint(th.Pal.Green, "Ready")
 	case noderoll.PhaseJoining:
-		return th.Paint(th.Pal.Dim, "joining (NotReady)")
+		s = th.Paint(th.Pal.Dim, "joining (NotReady)")
 	case noderoll.PhaseDraining:
-		s := th.Paint(th.Pal.Yellow, "draining")
+		s = th.Paint(th.Pal.Yellow, "draining")
 		if n.PodsTotal > 0 {
 			evicted := n.PodsTotal - n.Pods
 			if evicted < 0 {
@@ -145,10 +147,14 @@ func nodeStateCell(th *render.Theme, n noderoll.NodeView) string {
 			s += th.Paint(th.Pal.Dim, " · evicting ") + th.Bar(evicted, n.PodsTotal, 5, th.Pal.Yellow) +
 				th.Paint(th.Pal.Dim, fmt.Sprintf(" %d/%d pods", evicted, n.PodsTotal))
 		}
-		return s
 	default:
-		return th.Paint(th.Pal.Dim, "unknown")
+		s = th.Paint(th.Pal.Dim, "unknown")
 	}
+	// Advisory: a node can be Ready yet under pressure (undersized replacement).
+	if len(n.Pressure) > 0 {
+		s += th.Paint(th.Pal.Dim, " · ") + th.Token(render.Warn, strings.Join(n.Pressure, "+"))
+	}
+	return s
 }
 
 // runRoll drives the live panel from obs until done(snapshot) is true or ctx is

--- a/internal/commands/nodegroup/rollpanel_test.go
+++ b/internal/commands/nodegroup/rollpanel_test.go
@@ -8,6 +8,28 @@ import (
 	"github.com/dantech2000/refresh/internal/render"
 )
 
+// TestRollPanelLines_PressureAdvisory verifies a Ready node under pressure still
+// reads "Ready" but carries the pressure advisory in its state cell.
+func TestRollPanelLines_PressureAdvisory(t *testing.T) {
+	th := render.New(render.ColorNone, true)
+	snap := noderoll.Snapshot{
+		Total: 1, ReadyTarget: 1,
+		Nodes: []noderoll.NodeView{
+			{Name: "ip-hot", OnTarget: true, Ready: true, Phase: noderoll.PhaseReady, Pressure: []string{"MemoryPressure", "DiskPressure"}},
+		},
+	}
+	m := rollMeta{Nodegroup: "spot-burst", OldAMI: "ami-old", NewAMI: "ami-new", Desired: 1}
+	joined := strings.Join(rollPanelLines(th, snap, nil, m), "\n")
+	if strings.Contains(joined, "\x1b") {
+		t.Fatalf("ColorNone panel contains ANSI escapes:\n%s", joined)
+	}
+	for _, want := range []string{"Ready", "MemoryPressure+DiskPressure"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("panel missing %q in:\n%s", want, joined)
+		}
+	}
+}
+
 func TestRollPanelLines_MidRoll(t *testing.T) {
 	th := render.New(render.ColorNone, true)
 	snap := noderoll.Snapshot{

--- a/internal/commands/statusview/fleet_render.go
+++ b/internal/commands/statusview/fleet_render.go
@@ -218,6 +218,8 @@ func hintLine(th *render.Theme, statuses []statussvc.ClusterStatus) string {
 	switch {
 	case st == render.Fail:
 		reason = "is on unsupported EKS"
+	case worst.HealthIssues > 0:
+		reason = fmt.Sprintf("has %d control-plane health issue(s)", worst.HealthIssues)
 	case worst.NeedsAttention():
 		reason = "has stale AMIs/addons"
 	}

--- a/internal/commands/statusview/fleet_render_test.go
+++ b/internal/commands/statusview/fleet_render_test.go
@@ -36,6 +36,20 @@ func sampleFleet() []statussvc.ClusterStatus {
 	}
 }
 
+func TestFleetLines_HealthIssueHint(t *testing.T) {
+	th := render.New(render.ColorNone, true)
+	fleet := []statussvc.ClusterStatus{{
+		Name: "prod-east", Region: "us-east-1", Version: "1.32",
+		Support:      statussvc.SupportPosture{Tier: statussvc.SupportStandard, DaysRemaining: iptr(200)},
+		Compute:      statussvc.ComputeManaged,
+		HealthIssues: 2,
+	}}
+	joined := strings.Join(fleetLines(th, fleet, 0), "\n")
+	// A health-issue cluster is flagged "need attention" and the hint names the cause.
+	mustContain(t, joined, "▲  prod-east")
+	mustContain(t, joined, "has 2 control-plane health issue(s)")
+}
+
 func TestFleetLines_Pretty(t *testing.T) {
 	th := render.New(render.ColorNone, true) // deterministic: glyphs, no ANSI
 	lines := fleetLines(th, sampleFleet(), 0)

--- a/internal/noderoll/observer.go
+++ b/internal/noderoll/observer.go
@@ -47,6 +47,10 @@ type NodeView struct {
 	// not draining or when pod accounting isn't available).
 	Pods      int `json:"pods,omitempty"`
 	PodsTotal int `json:"podsTotal,omitempty"`
+	// Pressure lists active node-pressure conditions (MemoryPressure, etc.) — an
+	// advisory layered over Phase. A node can be Ready yet under pressure when the
+	// replacement instance is undersized; the roll looks healthy while it isn't.
+	Pressure []string `json:"pressure,omitempty"`
 }
 
 // Snapshot is the nodegroup's state at one instant, plus roll aggregates.
@@ -212,7 +216,36 @@ func classify(n *corev1.Node, targetAMI string, baseline map[string]bool) NodeVi
 		OnTarget: onTarget,
 		Ready:    ready,
 		Phase:    phase,
+		Pressure: pressureConditions(n),
 	}
+}
+
+// pressureNodeConditions are the conditions signalling a node is unhealthy under
+// load. Advisory during a roll: a node can be Ready yet under one of these when
+// the replacement AMI/instance is undersized.
+var pressureNodeConditions = []corev1.NodeConditionType{
+	corev1.NodeMemoryPressure,
+	corev1.NodeDiskPressure,
+	corev1.NodePIDPressure,
+	corev1.NodeNetworkUnavailable,
+}
+
+// pressureConditions returns the names of active (Status=True) pressure
+// conditions on a node, in a stable order. Empty when the node is unstressed.
+func pressureConditions(n *corev1.Node) []string {
+	active := make(map[corev1.NodeConditionType]bool, len(n.Status.Conditions))
+	for _, c := range n.Status.Conditions {
+		if c.Status == corev1.ConditionTrue {
+			active[c.Type] = true
+		}
+	}
+	var out []string
+	for _, t := range pressureNodeConditions {
+		if active[t] {
+			out = append(out, string(t))
+		}
+	}
+	return out
 }
 
 func nodeReady(n *corev1.Node) bool {

--- a/internal/noderoll/observer_test.go
+++ b/internal/noderoll/observer_test.go
@@ -2,12 +2,39 @@ package noderoll
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+// TestClassify_PressureAdvisory verifies node-pressure conditions are reported
+// in a stable order, that False conditions are ignored, and that pressure is
+// advisory — it never changes a Ready node's phase.
+func TestClassify_PressureAdvisory(t *testing.T) {
+	n := mkNode("ip-hot", newAMI, true, false)
+	// Out-of-order + a False condition that must be ignored.
+	n.Status.Conditions = append(n.Status.Conditions,
+		corev1.NodeCondition{Type: corev1.NodeDiskPressure, Status: corev1.ConditionTrue},
+		corev1.NodeCondition{Type: corev1.NodePIDPressure, Status: corev1.ConditionFalse},
+		corev1.NodeCondition{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionTrue},
+	)
+	v := classify(n, newAMI, nil)
+	if v.Phase != PhaseReady || !v.Ready {
+		t.Fatalf("pressure must not change phase: got phase=%s ready=%v", v.Phase, v.Ready)
+	}
+	// Canonical order (Memory, Disk, PID, Network); the False PIDPressure is dropped.
+	want := []string{"MemoryPressure", "DiskPressure"}
+	if !reflect.DeepEqual(v.Pressure, want) {
+		t.Errorf("pressure = %v, want %v", v.Pressure, want)
+	}
+	// Unstressed node reports no pressure.
+	if got := classify(mkNode("ip-cool", newAMI, true, false), newAMI, nil).Pressure; got != nil {
+		t.Errorf("healthy node should report no pressure, got %v", got)
+	}
+}
 
 const (
 	oldAMI = "ami-0a1b"

--- a/internal/services/cluster/insights.go
+++ b/internal/services/cluster/insights.go
@@ -15,6 +15,7 @@ import (
 	awsinternal "github.com/dantech2000/refresh/internal/aws"
 	"github.com/dantech2000/refresh/internal/services/addons"
 	"github.com/dantech2000/refresh/internal/services/common"
+	"github.com/dantech2000/refresh/internal/services/status"
 )
 
 // Insight status values (the flattened InsightStatus.Status enum).
@@ -113,9 +114,10 @@ type SkewReport struct {
 // UpgradeReport combines AWS Cluster Insights with the local version-skew view —
 // the full `cluster upgrade-check` result.
 type UpgradeReport struct {
-	Cluster  string           `json:"cluster" yaml:"cluster"`
-	Insights []InsightSummary `json:"insights" yaml:"insights"`
-	Skew     SkewReport       `json:"skew" yaml:"skew"`
+	Cluster  string                 `json:"cluster" yaml:"cluster"`
+	Support  *status.SupportPosture `json:"support,omitempty" yaml:"support,omitempty"`
+	Insights []InsightSummary       `json:"insights" yaml:"insights"`
+	Skew     SkewReport             `json:"skew" yaml:"skew"`
 }
 
 // ListInsights returns the cluster's EKS Cluster Insights filtered per opts.

--- a/internal/services/cluster/insights.go
+++ b/internal/services/cluster/insights.go
@@ -47,9 +47,33 @@ type InsightSummary struct {
 // InsightDetail is the DescribeInsight detail view (recommendation + resources).
 type InsightDetail struct {
 	InsightSummary
-	Recommendation string            `json:"recommendation,omitempty" yaml:"recommendation,omitempty"`
-	Resources      []string          `json:"resources,omitempty" yaml:"resources,omitempty"`
-	AdditionalInfo map[string]string `json:"additionalInfo,omitempty" yaml:"additionalInfo,omitempty"`
+	Recommendation string              `json:"recommendation,omitempty" yaml:"recommendation,omitempty"`
+	Resources      []string            `json:"resources,omitempty" yaml:"resources,omitempty"`
+	AdditionalInfo map[string]string   `json:"additionalInfo,omitempty" yaml:"additionalInfo,omitempty"`
+	Deprecations   []DeprecationDetail `json:"deprecations,omitempty" yaml:"deprecations,omitempty"`
+}
+
+// DeprecationDetail describes one deprecated Kubernetes API surfaced by an
+// UPGRADE_READINESS insight, plus the clients still calling it. EKS derives this
+// from the control-plane audit log on a 30-day rolling window.
+type DeprecationDetail struct {
+	// Usage is the deprecated resource/API path (e.g. policy/v1beta1 PodDisruptionBudget).
+	Usage string `json:"usage,omitempty" yaml:"usage,omitempty"`
+	// ReplacedWith is the API to migrate to, if applicable.
+	ReplacedWith string `json:"replacedWith,omitempty" yaml:"replacedWith,omitempty"`
+	// StopServingVersion is the Kubernetes version that removes the deprecated API.
+	StopServingVersion string `json:"stopServingVersion,omitempty" yaml:"stopServingVersion,omitempty"`
+	// StartServingReplacementVersion is the version where the replacement became available.
+	StartServingReplacementVersion string `json:"startServingReplacementVersion,omitempty" yaml:"startServingReplacementVersion,omitempty"`
+	// ClientStats are the callers (most-active first) still hitting the deprecated API.
+	ClientStats []ClientStat `json:"clientStats,omitempty" yaml:"clientStats,omitempty"`
+}
+
+// ClientStat identifies one Kubernetes client still calling a deprecated API.
+type ClientStat struct {
+	UserAgent                  string     `json:"userAgent,omitempty" yaml:"userAgent,omitempty"`
+	LastRequestTime            *time.Time `json:"lastRequestTime,omitempty" yaml:"lastRequestTime,omitempty"`
+	NumberOfRequestsLast30Days int32      `json:"numberOfRequestsLast30Days" yaml:"numberOfRequestsLast30Days"`
 }
 
 // UpgradeCheckOptions filters an upgrade-check query.
@@ -184,6 +208,28 @@ func (s *ServiceImpl) DescribeInsight(ctx context.Context, clusterName, id strin
 			detail.Resources = append(detail.Resources, aws.ToString(r.Arn))
 		case r.KubernetesResourceUri != nil:
 			detail.Resources = append(detail.Resources, aws.ToString(r.KubernetesResourceUri))
+		}
+	}
+	if css := ins.CategorySpecificSummary; css != nil {
+		for _, d := range css.DeprecationDetails {
+			dd := DeprecationDetail{
+				Usage:                          aws.ToString(d.Usage),
+				ReplacedWith:                   aws.ToString(d.ReplacedWith),
+				StopServingVersion:             aws.ToString(d.StopServingVersion),
+				StartServingReplacementVersion: aws.ToString(d.StartServingReplacementVersion),
+			}
+			for _, c := range d.ClientStats {
+				dd.ClientStats = append(dd.ClientStats, ClientStat{
+					UserAgent:                  aws.ToString(c.UserAgent),
+					LastRequestTime:            c.LastRequestTime,
+					NumberOfRequestsLast30Days: c.NumberOfRequestsLast30Days,
+				})
+			}
+			// Most-active callers first — that's who to chase down.
+			sort.SliceStable(dd.ClientStats, func(i, j int) bool {
+				return dd.ClientStats[i].NumberOfRequestsLast30Days > dd.ClientStats[j].NumberOfRequestsLast30Days
+			})
+			detail.Deprecations = append(detail.Deprecations, dd)
 		}
 	}
 	return detail, nil

--- a/internal/services/cluster/insights_test.go
+++ b/internal/services/cluster/insights_test.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
@@ -69,6 +70,76 @@ func TestListInsights_MappingFilterPagination(t *testing.T) {
 	}
 	if len(all) != 2 {
 		t.Fatalf("ShowPassing returned %d, want 2 (pagination + passing)", len(all))
+	}
+}
+
+func TestDescribeInsight_Deprecations(t *testing.T) {
+	lastNewRelic := time.Date(2026, 6, 14, 9, 30, 0, 0, time.UTC)
+	lastKubectl := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	var gotCluster, gotID string
+	mock := &mocks.EKSAPI{
+		DescribeInsightFn: func(_ context.Context, in *eks.DescribeInsightInput, _ ...func(*eks.Options)) (*eks.DescribeInsightOutput, error) {
+			gotCluster = aws.ToString(in.ClusterName)
+			gotID = aws.ToString(in.Id)
+			return &eks.DescribeInsightOutput{Insight: &ekstypes.Insight{
+				Id:                aws.String("dep-1"),
+				Name:              aws.String("Deprecated APIs removed in 1.32"),
+				Category:          ekstypes.CategoryUpgradeReadiness,
+				KubernetesVersion: aws.String("1.32"),
+				InsightStatus:     &ekstypes.InsightStatus{Status: ekstypes.InsightStatusValueError, Reason: aws.String("1 deprecated API in use")},
+				Recommendation:    aws.String("Migrate clients off policy/v1beta1 PodDisruptionBudget."),
+				CategorySpecificSummary: &ekstypes.InsightCategorySpecificSummary{
+					DeprecationDetails: []ekstypes.DeprecationDetail{{
+						Usage:              aws.String("policy/v1beta1 PodDisruptionBudget"),
+						ReplacedWith:       aws.String("policy/v1 PodDisruptionBudget"),
+						StopServingVersion: aws.String("1.25"),
+						// Intentionally out of order — service must sort most-active first.
+						ClientStats: []ekstypes.ClientStat{
+							{UserAgent: aws.String("kubectl/v1.29.0"), LastRequestTime: aws.Time(lastKubectl), NumberOfRequestsLast30Days: 12},
+							{UserAgent: aws.String("newrelic-kube-state-metric/v2"), LastRequestTime: aws.Time(lastNewRelic), NumberOfRequestsLast30Days: 412},
+						},
+					}},
+				},
+			}}, nil
+		},
+	}
+
+	svc := &ServiceImpl{eksClient: mock}
+	detail, err := svc.DescribeInsight(context.Background(), "prod", "dep-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Request passthrough.
+	if gotCluster != "prod" || gotID != "dep-1" {
+		t.Errorf("DescribeInsight called with cluster=%q id=%q, want prod/dep-1", gotCluster, gotID)
+	}
+
+	// Summary fields still map.
+	if detail.Status != InsightStatusError || detail.Recommendation == "" {
+		t.Errorf("summary mapping lost: status=%q recommendation=%q", detail.Status, detail.Recommendation)
+	}
+
+	if len(detail.Deprecations) != 1 {
+		t.Fatalf("got %d deprecations, want 1", len(detail.Deprecations))
+	}
+	d := detail.Deprecations[0]
+	if d.Usage != "policy/v1beta1 PodDisruptionBudget" || d.ReplacedWith != "policy/v1 PodDisruptionBudget" || d.StopServingVersion != "1.25" {
+		t.Errorf("deprecation fields = %+v", d)
+	}
+	if len(d.ClientStats) != 2 {
+		t.Fatalf("got %d client stats, want 2", len(d.ClientStats))
+	}
+	// Most-active caller first (412 > 12).
+	if d.ClientStats[0].UserAgent != "newrelic-kube-state-metric/v2" || d.ClientStats[0].NumberOfRequestsLast30Days != 412 {
+		t.Errorf("client stats not sorted most-active-first: %+v", d.ClientStats)
+	}
+	if d.ClientStats[0].LastRequestTime == nil || !d.ClientStats[0].LastRequestTime.Equal(lastNewRelic) {
+		t.Errorf("LastRequestTime not preserved: %v", d.ClientStats[0].LastRequestTime)
+	}
+	if d.ClientStats[1].UserAgent != "kubectl/v1.29.0" || d.ClientStats[1].NumberOfRequestsLast30Days != 12 {
+		t.Errorf("second client stat = %+v", d.ClientStats[1])
 	}
 }
 

--- a/internal/services/cluster/service.go
+++ b/internal/services/cluster/service.go
@@ -145,6 +145,18 @@ func (s *ServiceImpl) Describe(ctx context.Context, name string, options Describ
 		Tags:            cluster.Tags,
 	}
 
+	// AWS-reported control-plane health issues (always surfaced — no extra API
+	// call, no ShowHealth gate; these are real problems the user must see).
+	if cluster.Health != nil {
+		for _, issue := range cluster.Health.Issues {
+			details.HealthIssues = append(details.HealthIssues, HealthIssue{
+				Code:        string(issue.Code),
+				Message:     aws.ToString(issue.Message),
+				ResourceIds: issue.ResourceIds,
+			})
+		}
+	}
+
 	// Add networking information
 	if cluster.ResourcesVpcConfig != nil {
 		endpointAccess := EndpointAccessInfo{

--- a/internal/services/cluster/service_test.go
+++ b/internal/services/cluster/service_test.go
@@ -257,6 +257,49 @@ func TestDescribe_EmptyClusterResponseErrors(t *testing.T) {
 	}
 }
 
+// TestDescribe_MapsHealthIssues verifies AWS-reported control-plane Health.Issues
+// are surfaced on ClusterDetails — with no ShowHealth gate and no extra API call.
+func TestDescribe_MapsHealthIssues(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mock := &mocks.EKSAPI{
+		DescribeClusterFn: func(_ context.Context, in *eks.DescribeClusterInput, _ ...func(*eks.Options)) (*eks.DescribeClusterOutput, error) {
+			return &eks.DescribeClusterOutput{Cluster: &ekstypes.Cluster{
+				Name:    in.Name,
+				Version: aws.String("1.32"),
+				Status:  ekstypes.ClusterStatusActive,
+				Health: &ekstypes.ClusterHealth{Issues: []ekstypes.ClusterIssue{{
+					Code:        ekstypes.ClusterIssueCodeInternalFailure,
+					Message:     aws.String("control plane could not assume the cluster IAM role"),
+					ResourceIds: []string{"arn:aws:iam::123456789012:role/eksClusterRole"},
+				}}},
+			}}, nil
+		},
+		ListNodegroupsFn: func(_ context.Context, _ *eks.ListNodegroupsInput, _ ...func(*eks.Options)) (*eks.ListNodegroupsOutput, error) {
+			return &eks.ListNodegroupsOutput{}, nil
+		},
+	}
+	svc := &ServiceImpl{eksClient: mock, cache: NewCache(time.Minute), logger: logger}
+
+	// No ShowHealth — issues must still surface.
+	details, err := svc.Describe(context.Background(), "prod", DescribeOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(details.HealthIssues) != 1 {
+		t.Fatalf("got %d health issues, want 1", len(details.HealthIssues))
+	}
+	got := details.HealthIssues[0]
+	if got.Code != string(ekstypes.ClusterIssueCodeInternalFailure) {
+		t.Errorf("issue code = %q, want %q", got.Code, ekstypes.ClusterIssueCodeInternalFailure)
+	}
+	if got.Message != "control plane could not assume the cluster IAM role" {
+		t.Errorf("issue message = %q", got.Message)
+	}
+	if len(got.ResourceIds) != 1 || got.ResourceIds[0] != "arn:aws:iam::123456789012:role/eksClusterRole" {
+		t.Errorf("resource ids = %v", got.ResourceIds)
+	}
+}
+
 func TestDescribe_CachesResultOnSecondCall(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	callCount := 0

--- a/internal/services/cluster/types.go
+++ b/internal/services/cluster/types.go
@@ -20,6 +20,12 @@ type ClusterDetails struct {
 	// Health information (integration with existing health framework)
 	Health *health.HealthSummary `json:"health,omitempty"`
 
+	// HealthIssues are AWS-reported control-plane health issues (DescribeCluster's
+	// Health.Issues) — degraded resources, IAM/permission failures, etc. Distinct
+	// from the computed Health summary above. Always populated when present, even
+	// without ShowHealth.
+	HealthIssues []HealthIssue `json:"healthIssues,omitempty"`
+
 	// Networking details
 	Networking NetworkingInfo `json:"networking"`
 
@@ -44,6 +50,14 @@ type ClusterSummary struct {
 	NodeCount NodeCountInfo         `json:"nodeCount"`
 	CreatedAt time.Time             `json:"createdAt"`
 	Tags      map[string]string     `json:"tags,omitempty"`
+}
+
+// HealthIssue is one AWS-reported health issue on a cluster/nodegroup/addon —
+// the common shape behind EKS's ClusterIssue / NodegroupIssue / AddonIssue.
+type HealthIssue struct {
+	Code        string   `json:"code"`
+	Message     string   `json:"message"`
+	ResourceIds []string `json:"resourceIds,omitempty"`
 }
 
 // NetworkingInfo contains VPC and networking details

--- a/internal/services/cluster/types.go
+++ b/internal/services/cluster/types.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/dantech2000/refresh/internal/health"
+	"github.com/dantech2000/refresh/internal/services/status"
 )
 
 // ClusterDetails contains comprehensive cluster information
@@ -16,6 +17,10 @@ type ClusterDetails struct {
 	Endpoint        string    `json:"endpoint"`
 	CreatedAt       time.Time `json:"createdAt"`
 	Region          string    `json:"region"`
+
+	// Support is the EKS version support posture (tier + days remaining),
+	// resolved via the shared status resolver. Populated by the command layer.
+	Support *status.SupportPosture `json:"support,omitempty"`
 
 	// Health information (integration with existing health framework)
 	Health *health.HealthSummary `json:"health,omitempty"`

--- a/internal/services/status/service.go
+++ b/internal/services/status/service.go
@@ -162,6 +162,9 @@ func (s *Service) assembleCluster(ctx context.Context, name string) ClusterStatu
 	cluster := desc.Cluster
 	cs.Version = aws.ToString(cluster.Version)
 	cs.Support = s.resolveSupport(ctx, cs.Version)
+	if cluster.Health != nil {
+		cs.HealthIssues = len(cluster.Health.Issues)
+	}
 
 	ngs, ngErr := s.nodegroups.List(ctx, name, nodegroup.ListOptions{})
 	if ngErr != nil {

--- a/internal/services/status/service_test.go
+++ b/internal/services/status/service_test.go
@@ -149,6 +149,47 @@ func TestAssembleCluster_DescribeErrorIsNonFatal(t *testing.T) {
 	}
 }
 
+// TestAssembleCluster_HealthIssues verifies AWS-reported control-plane health
+// issues are counted onto the row and flip NeedsAttention, even when AMIs and
+// addons are current.
+func TestAssembleCluster_HealthIssues(t *testing.T) {
+	api := &fakeClusterAPI{
+		clusters: []string{"prod"},
+		describe: map[string]*ekstypes.Cluster{
+			"prod": {
+				Name:    aws.String("prod"),
+				Version: aws.String("1.32"),
+				Health: &ekstypes.ClusterHealth{Issues: []ekstypes.ClusterIssue{
+					{Code: ekstypes.ClusterIssueCodeInternalFailure, Message: aws.String("IAM role failure")},
+					{Code: ekstypes.ClusterIssueCodeResourceLimitExceeded, Message: aws.String("ENI limit")},
+				}},
+			},
+		},
+		versions: map[string]ekstypes.ClusterVersionInformation{
+			"1.32": {ClusterVersion: aws.String("1.32"), EndOfStandardSupportDate: timePtr(date(2027, 3, 23))},
+		},
+	}
+	svc := newTestService(api, &fakeNodegroups{}, &fakeAddons{})
+	statuses, err := svc.ListClusterStatuses(context.Background(), ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(statuses) != 1 {
+		t.Fatalf("got %d statuses, want 1", len(statuses))
+	}
+	c := statuses[0]
+	if c.HealthIssues != 2 {
+		t.Errorf("health issues = %d, want 2", c.HealthIssues)
+	}
+	// No stale AMIs/addons, but health issues alone must flag attention.
+	if c.StaleAMI.Behind != 0 || c.AddonsBehind.Behind != 0 {
+		t.Fatalf("test precondition: expected no stale AMIs/addons, got %+v / %+v", c.StaleAMI, c.AddonsBehind)
+	}
+	if !c.NeedsAttention() {
+		t.Error("a cluster with control-plane health issues should need attention")
+	}
+}
+
 func TestListClusterStatuses_NameFilter(t *testing.T) {
 	api := &fakeClusterAPI{
 		clusters: []string{"prod-east", "staging", "prod-west"},

--- a/internal/services/status/support.go
+++ b/internal/services/status/support.go
@@ -34,9 +34,36 @@ func date(y int, m time.Month, d int) time.Time {
 	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
 }
 
+// supportVersionsAPI is the slice of EKS needed to resolve support windows —
+// just DescribeClusterVersions. Both the fleet Service and the standalone
+// SupportResolver depend on this, so the resolution logic has one home.
+type supportVersionsAPI interface {
+	DescribeClusterVersions(ctx context.Context, in *eks.DescribeClusterVersionsInput, optFns ...func(*eks.Options)) (*eks.DescribeClusterVersionsOutput, error)
+}
+
+// resolveSupportPosture is the shared support-resolution core: prefer
+// DescribeClusterVersions, fall back to the compiled-in calendar, then classify
+// relative to now. Pure given (api, version, now) — used by both the fleet
+// Service and the exported SupportResolver.
+func resolveSupportPosture(ctx context.Context, api supportVersionsAPI, version string, now time.Time) SupportPosture {
+	if version == "" {
+		return SupportPosture{Tier: SupportUnknown}
+	}
+	std, ext, ok := supportDatesFromAPI(ctx, api, version)
+	fallback := false
+	if !ok {
+		cal, found := fallbackCalendar[version]
+		if !found {
+			return SupportPosture{Tier: SupportUnknown}
+		}
+		std, ext = cal.standardEnd, cal.extendedEnd
+		fallback = true
+	}
+	return classifySupport(std, ext, now, fallback)
+}
+
 // resolveSupport returns the support posture for a Kubernetes version, caching
-// per version so `status -A` resolves each version at most once. It prefers
-// DescribeClusterVersions and falls back to the compiled-in calendar.
+// per version so `status -A` resolves each version at most once.
 func (s *Service) resolveSupport(ctx context.Context, version string) SupportPosture {
 	if version == "" {
 		return SupportPosture{Tier: SupportUnknown}
@@ -52,7 +79,7 @@ func (s *Service) resolveSupport(ctx context.Context, version string) SupportPos
 	}
 	s.supportMu.Unlock()
 
-	posture := s.lookupSupport(ctx, version)
+	posture := resolveSupportPosture(ctx, s.clusterAPI, version, s.clock())
 
 	s.supportMu.Lock()
 	s.supportCache[version] = posture
@@ -60,28 +87,39 @@ func (s *Service) resolveSupport(ctx context.Context, version string) SupportPos
 	return posture
 }
 
-func (s *Service) lookupSupport(ctx context.Context, version string) SupportPosture {
-	std, ext, ok := s.supportDatesFromAPI(ctx, version)
-	fallback := false
-	if !ok {
-		cal, found := fallbackCalendar[version]
-		if !found {
-			return SupportPosture{Tier: SupportUnknown}
-		}
-		std, ext = cal.standardEnd, cal.extendedEnd
-		fallback = true
+// SupportResolver resolves EKS version support posture — the same logic behind
+// `refresh status` — for reuse by `cluster upgrade-check` and `cluster
+// describe`. Stateless apart from the EKS client; safe to construct per command.
+type SupportResolver struct {
+	api supportVersionsAPI
+	now func() time.Time
+}
+
+// NewSupportResolver builds a resolver over an EKS client (anything exposing
+// DescribeClusterVersions).
+func NewSupportResolver(api supportVersionsAPI) *SupportResolver {
+	return &SupportResolver{api: api, now: time.Now}
+}
+
+// Resolve returns the support posture for a Kubernetes version (e.g. "1.32"),
+// falling back to the compiled-in calendar when DescribeClusterVersions is
+// unavailable.
+func (r *SupportResolver) Resolve(ctx context.Context, version string) SupportPosture {
+	now := time.Now()
+	if r.now != nil {
+		now = r.now()
 	}
-	return classifySupport(std, ext, s.clock(), fallback)
+	return resolveSupportPosture(ctx, r.api, version, now)
 }
 
 // supportDatesFromAPI fetches the standard/extended end dates for a version via
 // DescribeClusterVersions. ok is false when the API errors or the dates are
 // absent, so the caller falls back to the compiled-in calendar.
-func (s *Service) supportDatesFromAPI(ctx context.Context, version string) (std, ext time.Time, ok bool) {
-	if s.clusterAPI == nil {
+func supportDatesFromAPI(ctx context.Context, api supportVersionsAPI, version string) (std, ext time.Time, ok bool) {
+	if api == nil {
 		return time.Time{}, time.Time{}, false
 	}
-	out, err := s.clusterAPI.DescribeClusterVersions(ctx, &eks.DescribeClusterVersionsInput{
+	out, err := api.DescribeClusterVersions(ctx, &eks.DescribeClusterVersionsInput{
 		ClusterVersions: []string{version},
 	})
 	if err != nil || out == nil {

--- a/internal/services/status/support_test.go
+++ b/internal/services/status/support_test.go
@@ -98,6 +98,44 @@ func TestResolveSupport_FromAPI(t *testing.T) {
 	}
 }
 
+// TestSupportResolver_Reuse verifies the exported resolver (used by
+// cluster upgrade-check / describe) resolves the same posture as the fleet
+// Service, from the API and from the fallback calendar. (REF-145)
+func TestSupportResolver_Reuse(t *testing.T) {
+	api := &fakeClusterAPI{
+		versions: map[string]ekstypes.ClusterVersionInformation{
+			"1.32": {
+				ClusterVersion:           aws.String("1.32"),
+				EndOfStandardSupportDate: timePtr(date(2027, 3, 23)),
+				EndOfExtendedSupportDate: timePtr(date(2028, 3, 23)),
+			},
+		},
+	}
+	r := NewSupportResolver(api)
+	r.now = func() time.Time { return date(2026, 6, 11) }
+
+	p := r.Resolve(context.Background(), "1.32")
+	if p.Tier != SupportStandard || p.Fallback {
+		t.Errorf("API posture = %s (fallback=%v), want standard/non-fallback", p.Tier, p.Fallback)
+	}
+	if p.DaysRemaining == nil || *p.DaysRemaining <= 0 {
+		t.Errorf("expected positive days remaining, got %v", p.DaysRemaining)
+	}
+
+	// Empty version → unknown, no API call.
+	if got := r.Resolve(context.Background(), ""); got.Tier != SupportUnknown {
+		t.Errorf("empty version tier = %s, want unknown", got.Tier)
+	}
+
+	// API failure → compiled-in fallback calendar.
+	rf := NewSupportResolver(&fakeClusterAPI{versionsErr: errors.New("access denied")})
+	rf.now = func() time.Time { return date(2026, 6, 11) }
+	pf := rf.Resolve(context.Background(), "1.31")
+	if !pf.Fallback || pf.Tier != SupportExtended {
+		t.Errorf("fallback posture = %s (fallback=%v), want extended/fallback", pf.Tier, pf.Fallback)
+	}
+}
+
 func timePtr(t time.Time) *time.Time { return &t }
 
 // fakeClusterAPI implements ClusterAPI for tests.

--- a/internal/services/status/types.go
+++ b/internal/services/status/types.go
@@ -73,6 +73,9 @@ type ClusterStatus struct {
 	NodegroupCount int                 `json:"nodegroupCount" yaml:"nodegroupCount"`
 	StaleAMI       StaleAMISummary     `json:"staleAmi" yaml:"staleAmi"`
 	AddonsBehind   AddonsBehindSummary `json:"addonsBehind" yaml:"addonsBehind"`
+	// HealthIssues is the count of AWS-reported control-plane health issues
+	// (DescribeCluster Health.Issues) — degraded resources, IAM failures, etc.
+	HealthIssues int `json:"healthIssues,omitempty" yaml:"healthIssues,omitempty"`
 	// Errors holds non-fatal, per-cluster failures so a partial row still
 	// renders instead of dropping the cluster entirely.
 	Errors []string `json:"errors,omitempty" yaml:"errors,omitempty"`
@@ -81,7 +84,7 @@ type ClusterStatus struct {
 // NeedsAttention reports whether the cluster has any stale AMIs or addons
 // behind latest (drives the exit-code "something stale" signal).
 func (c ClusterStatus) NeedsAttention() bool {
-	return c.StaleAMI.Behind > 0 || c.AddonsBehind.Behind > 0
+	return c.StaleAMI.Behind > 0 || c.AddonsBehind.Behind > 0 || c.HealthIssues > 0
 }
 
 // SupportRisk reports whether the cluster is on extended or unsupported EKS


### PR DESCRIPTION
Ships the four small, high-value real-time-data features from the vetting pass (REF-137, REF-139, REF-141, REF-145). Each is fully tested with correctly-typed mocked API data and validated locally: `go build`, `go vet`, `go test ./... -race`, and `golangci-lint` all clean.

## What's in here

**REF-137 — Deprecated-API `clientStats` drill-down** (Tier 1)
`DescribeInsight` now maps `CategorySpecificSummary.DeprecationDetails` into `InsightDetail.Deprecations`: the deprecated API, its replacement, removal version, and the calling clients (`userAgent`, last-seen, 30-day request count), sorted most-active-first. The detail view names *who* to fix and prints the 30-day audit-window caveat. json/yaml flow through `EncodeStdout` unchanged. Follow-up to the already-shipped REF-28.

**REF-139 — Surface AWS-reported `Health.Issues`** (Tier 1)
`DescribeCluster.Health.Issues` was fetched and discarded. Now mapped onto `ClusterDetails.HealthIssues` (code/message/resourceIds, no `ShowHealth` gate, no extra API call) and rendered as a HEALTH ISSUES block in `cluster describe` (themed + plain). `refresh status` counts issues per cluster, flips `NeedsAttention`, and the fleet hint names the cause. Unifies the issue shape already read for nodegroups/addons behind one `HealthIssue` type.

**REF-141 — Node pressure during a roll** (Tier 2)
`noderoll` read only Ready + drain taints, so a node that joined Ready but went under MemoryPressure (undersized replacement) looked healthy. `classify()` now reports active pressure conditions (Memory/Disk/PID/Network) on `NodeView.Pressure` in stable order — advisory, never changes Phase — and the live roll panel appends it to the node's state cell.

**REF-145 — Reuse the support-window resolver** (Tier 3)
Support posture (tier + days remaining + extended premium) lived only on `refresh status`. Extracted the resolver core into a reusable `status.SupportResolver` (no logic re-implementation — the fleet `Service` now delegates to the same `resolveSupportPosture` core) and surfaced posture on `cluster upgrade-check` and `cluster describe` (themed + plain + json/yaml), resolved at the command layer so the cluster service stays decoupled.

## Tests (mocked API data, no live AWS)
- `insights_test.go` — DeprecationDetail mapping + most-active-first sort + request passthrough
- `service_test.go` (cluster) — `Health.Issues` mapped with no `ShowHealth` gate
- `service_test.go` (status) — health-issue count flips `NeedsAttention`
- `observer_test.go` — pressure ordering, False-condition exclusion, phase unchanged
- render tests across `clusterview` / `statusview` / `nodegroup` for each new surface
- `support_test.go` (status) — `SupportResolver` from API and fallback calendar

## Notes
- The medium-tier items (REF-138 live K8s events, REF-140 control-plane CloudWatch gate, REF-142 metrics-server) and pre-flight gates (REF-143, REF-144) are intentionally left for separate passes.
- REF-140's framing as a *gate* (not utilization-browse, per REF-78/REF-52) is captured in the Linear issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)