### PR TITLE
Control-plane readiness gate from AWS/EKS CloudWatch metrics (REF-140)

### DIFF
--- a/internal/commands/cluster/upgradecheck.go
+++ b/internal/commands/cluster/upgradecheck.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/urfave/cli/v3"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/dantech2000/refresh/internal/commands/factory"
 	"github.com/dantech2000/refresh/internal/commands/runner"
 	appconfig "github.com/dantech2000/refresh/internal/config"
+	"github.com/dantech2000/refresh/internal/health"
 	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
 	"github.com/dantech2000/refresh/internal/services/status"
 )
@@ -96,6 +98,14 @@ func runUpgradeCheck(ctx context.Context, cmd *cli.Command) error {
 	if report != nil && report.Skew.ControlPlaneVersion != "" {
 		posture := status.NewSupportResolver(eks.NewFromConfig(awsCfg)).Resolve(ctx, report.Skew.ControlPlaneVersion)
 		report.Support = &posture
+	}
+
+	// Control-plane health gate from the free AWS/EKS CloudWatch metrics — etcd
+	// usage vs the 8 GiB read-only limit + API-server error rate (REF-140).
+	if report != nil {
+		checker := health.NewChecker(eks.NewFromConfig(awsCfg), nil, cloudwatch.NewFromConfig(awsCfg), nil)
+		cp := checker.CheckControlPlaneMetrics(ctx, clusterName)
+		report.ControlPlane = &cp
 	}
 
 	if handled, encErr := runner.EncodeStdout(cmd.String("format"), report); handled {

--- a/internal/commands/clusterview/insights.go
+++ b/internal/commands/clusterview/insights.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fatih/color"
 
+	"github.com/dantech2000/refresh/internal/health"
 	"github.com/dantech2000/refresh/internal/render"
 	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
 	"github.com/dantech2000/refresh/internal/ui"
@@ -31,8 +32,25 @@ func OutputUpgradeCheck(report *clustersvc.UpgradeReport) error {
 	}
 	outputInsights(report.Insights)
 	fmt.Println()
+	outputControlPlane(report.ControlPlane)
 	outputSkew(report.Skew)
 	return nil
+}
+
+// outputControlPlane renders the control-plane gate for `-o plain`.
+func outputControlPlane(cp *health.HealthResult) {
+	if cp == nil {
+		return
+	}
+	if cp.Skipped {
+		ui.Outf("Control plane: %s\n", cp.Message)
+	} else {
+		ui.Outf("Control plane (%s): %s\n", cp.Status, cp.Message)
+		for _, d := range cp.Details {
+			fmt.Printf("  %s\n", d)
+		}
+	}
+	fmt.Println()
 }
 
 func outputInsights(insights []clustersvc.InsightSummary) {

--- a/internal/commands/clusterview/insights_render.go
+++ b/internal/commands/clusterview/insights_render.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dantech2000/refresh/internal/health"
 	"github.com/dantech2000/refresh/internal/render"
 	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
 	"github.com/dantech2000/refresh/internal/ui"
@@ -22,13 +23,38 @@ func upgradeVerdict(report *clustersvc.UpgradeReport) (render.Status, string) {
 			warnc++
 		}
 	}
+	// The control-plane gate participates in the verdict: a blocking failure
+	// (e.g. etcd near the read-only limit) is NOT READY; a warning is REVIEW.
+	cpFail, cpWarn := false, false
+	if cp := report.ControlPlane; cp != nil && !cp.Skipped {
+		switch cp.Status {
+		case health.StatusFail:
+			cpFail = true
+		case health.StatusWarn:
+			cpWarn = true
+		}
+	}
 	switch {
-	case errc > 0:
+	case errc > 0 || cpFail:
 		return render.Fail, "NOT READY"
-	case warnc > 0 || len(report.Skew.Findings) > 0:
+	case warnc > 0 || cpWarn || len(report.Skew.Findings) > 0:
 		return render.Warn, "REVIEW"
 	default:
 		return render.Healthy, "READY"
+	}
+}
+
+// healthStatusToken maps a health check status to a render status token.
+func healthStatusToken(s health.HealthStatus) render.Status {
+	switch s {
+	case health.StatusPass:
+		return render.Healthy
+	case health.StatusWarn:
+		return render.Warn
+	case health.StatusFail:
+		return render.Fail
+	default:
+		return render.Unknown
 	}
 }
 
@@ -98,6 +124,18 @@ func upgradeCheckLines(th *render.Theme, report *clustersvc.UpgradeReport) []str
 			out = append(out, "  "+l)
 		}
 		out = append(out, "  "+insightCountChips(th, errc, warnc, passc))
+	}
+
+	if cp := report.ControlPlane; cp != nil {
+		out = append(out, "", th.Section("CONTROL PLANE"))
+		if cp.Skipped {
+			out = append(out, "  "+th.Paint(pal.Dim, cp.Message))
+		} else {
+			out = append(out, "  "+th.Tokenf(healthStatusToken(cp.Status), cp.Message))
+			for _, d := range cp.Details {
+				out = append(out, "    "+th.Paint(pal.Dim, d))
+			}
+		}
 	}
 
 	out = append(out, "", th.Section("VERSION SKEW")+th.Paint(pal.Dim, "  control plane "+valueOrDash(report.Skew.ControlPlaneVersion)))

--- a/internal/commands/clusterview/insights_render_test.go
+++ b/internal/commands/clusterview/insights_render_test.go
@@ -5,9 +5,51 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dantech2000/refresh/internal/health"
 	"github.com/dantech2000/refresh/internal/render"
 	clustersvc "github.com/dantech2000/refresh/internal/services/cluster"
 )
+
+func TestUpgradeCheckLines_ControlPlaneGate(t *testing.T) {
+	th := render.New(render.ColorNone, true)
+
+	// A blocking control-plane failure (etcd near read-only) drives NOT READY
+	// even with no insight errors, and renders the CONTROL PLANE section.
+	rpt := &clustersvc.UpgradeReport{
+		Cluster: "prod",
+		ControlPlane: &health.HealthResult{
+			Name:       "Control Plane",
+			Status:     health.StatusFail,
+			IsBlocking: true,
+			Message:    "etcd database near the 8 GiB read-only limit (96.2%) — compact before upgrading",
+			Details:    []string{"etcd database 96.2% of the 8 GiB limit (7.70 GiB in use)"},
+		},
+		Skew: clustersvc.SkewReport{ControlPlaneVersion: "1.32"},
+	}
+	joined := strings.Join(upgradeCheckLines(th, rpt), "\n")
+	for _, want := range []string{
+		"✗ NOT READY",
+		"▸ CONTROL PLANE",
+		"near the 8 GiB read-only limit",
+		"7.70 GiB in use",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("control-plane gate missing %q in:\n%s", want, joined)
+		}
+	}
+
+	// A skipped gate (pre-1.28) shows the unavailable note and does not fail the
+	// verdict on its own.
+	skipped := &clustersvc.UpgradeReport{
+		Cluster:      "prod",
+		ControlPlane: &health.HealthResult{Name: "Control Plane", Status: health.StatusPass, Skipped: true, Message: "control-plane metrics unavailable (requires EKS 1.28+ on a supported platform version)"},
+		Skew:         clustersvc.SkewReport{ControlPlaneVersion: "1.27"},
+	}
+	got := strings.Join(upgradeCheckLines(th, skipped), "\n")
+	if !strings.Contains(got, "● READY") || !strings.Contains(got, "metrics unavailable") {
+		t.Errorf("skipped gate should be READY + unavailable note:\n%s", got)
+	}
+}
 
 func TestDeprecationLines(t *testing.T) {
 	// Empty input renders nothing.

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -77,6 +77,7 @@ func (hc *HealthChecker) RunAllChecks(ctx context.Context, clusterName string) H
 	checks := []func() HealthResult{
 		func() HealthResult { return hc.CheckNodeHealth(ctx, clusterName) },
 		func() HealthResult { return hc.checkClusterCapacityWith(ctx, snap) },
+		func() HealthResult { return hc.CheckControlPlaneMetrics(ctx, clusterName) },
 		func() HealthResult { return hc.CheckCriticalWorkloads(ctx) },
 		func() HealthResult { return hc.CheckPodDisruptionBudgets(ctx) },
 		func() HealthResult { return hc.checkResourceBalanceWith(ctx, snap) },

--- a/internal/health/controlplane.go
+++ b/internal/health/controlplane.go
@@ -1,0 +1,235 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+)
+
+// EKS standard control-plane etcd limit. At 8 GiB etcd raises a no-space alarm
+// and the API server goes read-only (writes rejected) — so a cluster near this
+// line is unsafe to upgrade until the database is compacted/trimmed.
+// https://docs.aws.amazon.com/eks/latest/best-practices/known_limits_and_service_quotas.html
+const etcdQuotaBytes = 8 * 1024 * 1024 * 1024
+
+// Control-plane gate thresholds (percent). etcd usage is the blocking signal;
+// the API-server error rate is advisory (warn-only) so noisy request metrics
+// never wrongly block an upgrade.
+const (
+	etcdFailPercent = 95.0 // near read-only — block
+	etcdWarnPercent = 80.0 // getting tight — warn
+
+	apiserver5xxWarnPercent = 2.0    // server-error ratio over the window
+	apiserverMinReqsForRate = 1000.0 // ignore the ratio below this volume (too noisy)
+
+	// controlPlaneWindow is how far back to aggregate. The AWS/EKS metrics are
+	// emitted per-minute; a 15-minute window smooths a single blip.
+	controlPlaneWindow = 15 * time.Minute
+)
+
+// metricDataAPI is the slice of CloudWatch the control-plane gate needs. The
+// concrete *cloudwatch.Client satisfies it; tests pass a fake.
+type metricDataAPI interface {
+	GetMetricData(ctx context.Context, in *cloudwatch.GetMetricDataInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error)
+}
+
+// controlPlaneMetrics holds the control-plane signals aggregated over the
+// window. The *Known flags distinguish "measured zero" from "not emitted".
+type controlPlaneMetrics struct {
+	etcdInUseBytes float64
+	etcdKnown      bool
+	reqTotal       float64
+	req5xx         float64
+	req429         float64
+	pendingPods    float64
+	pendingKnown   bool
+	// hasData is true when CloudWatch returned at least one datapoint, i.e. the
+	// AWS/EKS control-plane metrics are being emitted (cluster is ≥1.28 on a
+	// supported platform version). When false, the gate is Skipped.
+	hasData bool
+}
+
+// CheckControlPlaneMetrics gates upgrade readiness on the EKS control plane:
+// etcd database usage vs the 8 GiB read-only limit, plus the API-server error
+// rate. It reads the free AWS/EKS CloudWatch metrics (no Container Insights /
+// agent). Clusters below 1.28 don't emit these — the check is then Skipped, not
+// failed. This is a readiness GATE, not a utilization-browse surface (REF-78).
+func (hc *HealthChecker) CheckControlPlaneMetrics(ctx context.Context, clusterName string) HealthResult {
+	if hc.cwClient == nil {
+		return HealthResult{
+			Name:    "Control Plane",
+			Status:  StatusPass,
+			Skipped: true,
+			Message: "control-plane metrics unavailable (no CloudWatch client)",
+		}
+	}
+	return checkControlPlaneMetrics(ctx, hc.cwClient, clusterName)
+}
+
+// checkControlPlaneMetrics is CheckControlPlaneMetrics against any
+// GetMetricData-capable client, so it is testable with a fake.
+func checkControlPlaneMetrics(ctx context.Context, api metricDataAPI, clusterName string) HealthResult {
+	m, err := fetchControlPlaneMetrics(ctx, api, clusterName)
+	if err != nil {
+		return HealthResult{
+			Name:    "Control Plane",
+			Status:  StatusWarn,
+			Score:   70,
+			Message: fmt.Sprintf("Unable to fetch control-plane metrics: %v", err),
+			Skipped: true,
+		}
+	}
+	return evaluateControlPlane(m)
+}
+
+// controlPlaneQuery pairs a CloudWatch query id with its AWS/EKS metric name and
+// statistic. Sum for counters (request totals), Maximum for gauges (etcd size,
+// pending pods).
+var controlPlaneQueries = []struct {
+	id, metric, stat string
+}{
+	{"etcd", "etcd_mvcc_db_total_size_in_use_in_bytes", "Maximum"},
+	{"req_total", "apiserver_request_total", "Sum"},
+	{"req_5xx", "apiserver_request_total_5XX", "Sum"},
+	{"req_429", "apiserver_request_total_429", "Sum"},
+	{"pending", "scheduler_pending_pods", "Maximum"},
+}
+
+// fetchControlPlaneMetrics pulls the AWS/EKS control-plane metrics for one
+// cluster in a single GetMetricData call, aggregating each over the window.
+func fetchControlPlaneMetrics(ctx context.Context, api metricDataAPI, clusterName string) (controlPlaneMetrics, error) {
+	end := time.Now()
+	start := end.Add(-controlPlaneWindow)
+	period := int32(controlPlaneWindow.Seconds())
+
+	queries := make([]cwtypes.MetricDataQuery, 0, len(controlPlaneQueries))
+	for _, q := range controlPlaneQueries {
+		queries = append(queries, cwtypes.MetricDataQuery{
+			Id: aws.String(q.id),
+			MetricStat: &cwtypes.MetricStat{
+				Metric: &cwtypes.Metric{
+					Namespace:  aws.String("AWS/EKS"),
+					MetricName: aws.String(q.metric),
+					Dimensions: []cwtypes.Dimension{{Name: aws.String("ClusterName"), Value: aws.String(clusterName)}},
+				},
+				Period: aws.Int32(period),
+				Stat:   aws.String(q.stat),
+			},
+		})
+	}
+
+	out, err := api.GetMetricData(ctx, &cloudwatch.GetMetricDataInput{
+		StartTime:         aws.Time(start),
+		EndTime:           aws.Time(end),
+		MetricDataQueries: queries,
+	})
+	if err != nil {
+		return controlPlaneMetrics{}, err
+	}
+
+	var m controlPlaneMetrics
+	for _, r := range out.MetricDataResults {
+		if r.Id == nil || len(r.Values) == 0 {
+			continue
+		}
+		m.hasData = true
+		v := aggregateValues(*r.Id, r.Values)
+		switch *r.Id {
+		case "etcd":
+			m.etcdInUseBytes, m.etcdKnown = v, true
+		case "req_total":
+			m.reqTotal = v
+		case "req_5xx":
+			m.req5xx = v
+		case "req_429":
+			m.req429 = v
+		case "pending":
+			m.pendingPods, m.pendingKnown = v, true
+		}
+	}
+	return m, nil
+}
+
+// aggregateValues collapses a result's datapoints to one number: the max for
+// gauges, the sum for counters. With a single window-length period there is
+// usually one value, but a metric can return a few; reduce defensively.
+func aggregateValues(id string, values []float64) float64 {
+	sumStat := id == "req_total" || id == "req_5xx" || id == "req_429"
+	if sumStat {
+		total := 0.0
+		for _, v := range values {
+			total += v
+		}
+		return total
+	}
+	return maxFloat(values)
+}
+
+// evaluateControlPlane turns the aggregated metrics into a gate verdict (pure,
+// table-testable). etcd usage drives Warn/Fail; the API-server error rate is
+// advisory; the scheduler backlog is informational.
+func evaluateControlPlane(m controlPlaneMetrics) HealthResult {
+	result := HealthResult{Name: "Control Plane", IsBlocking: true}
+
+	if !m.hasData {
+		result.Status = StatusPass
+		result.Skipped = true
+		result.Message = "control-plane metrics unavailable (requires EKS 1.28+ on a supported platform version)"
+		return result
+	}
+
+	result.Status = StatusPass
+	result.Score = 100
+	result.Message = "Control plane healthy"
+
+	// etcd usage vs the 8 GiB read-only limit — the blocking signal.
+	if m.etcdKnown {
+		pct := m.etcdInUseBytes / float64(etcdQuotaBytes) * 100
+		result.Details = append(result.Details,
+			fmt.Sprintf("etcd database %.1f%% of the 8 GiB limit (%.2f GiB in use)", pct, m.etcdInUseBytes/(1024*1024*1024)))
+		switch {
+		case pct >= etcdFailPercent:
+			result.Status = StatusFail
+			result.Score = 30
+			result.Message = fmt.Sprintf("etcd database near the 8 GiB read-only limit (%.1f%%) — compact before upgrading", pct)
+		case pct >= etcdWarnPercent:
+			result.Status = StatusWarn
+			result.Score = 70
+			result.Message = fmt.Sprintf("etcd database growing toward the 8 GiB limit (%.1f%%)", pct)
+		}
+	} else {
+		result.Details = append(result.Details, "etcd size metric not reported")
+	}
+
+	// API-server error rate — advisory (warn-only), and only above a volume
+	// floor so a handful of errors on an idle cluster doesn't trip it.
+	if m.reqTotal >= apiserverMinReqsForRate {
+		errPct := m.req5xx / m.reqTotal * 100
+		result.Details = append(result.Details,
+			fmt.Sprintf("API-server 5xx rate %.2f%% (%d of %d requests)", errPct, int(m.req5xx), int(m.reqTotal)))
+		if errPct >= apiserver5xxWarnPercent && result.Status == StatusPass {
+			result.Status = StatusWarn
+			result.Score = 70
+			result.Message = fmt.Sprintf("Elevated API-server error rate (%.2f%% 5xx)", errPct)
+		}
+	}
+	if m.req429 > 0 {
+		result.Details = append(result.Details, fmt.Sprintf("API-server throttled %d requests (429) in the window", int(m.req429)))
+		if result.Status == StatusPass {
+			result.Status = StatusWarn
+			result.Score = 70
+			result.Message = "API-server is throttling requests (429)"
+		}
+	}
+
+	// Scheduler backlog — informational only.
+	if m.pendingKnown && m.pendingPods > 0 {
+		result.Details = append(result.Details, fmt.Sprintf("Scheduler pending pods: %d", int(m.pendingPods)))
+	}
+
+	return result
+}

--- a/internal/health/controlplane_test.go
+++ b/internal/health/controlplane_test.go
@@ -1,0 +1,151 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+)
+
+// fakeMetricsAPI is a GetMetricData stub that records the request and returns a
+// canned response.
+type fakeMetricsAPI struct {
+	in  *cloudwatch.GetMetricDataInput
+	out *cloudwatch.GetMetricDataOutput
+	err error
+}
+
+func (f *fakeMetricsAPI) GetMetricData(_ context.Context, in *cloudwatch.GetMetricDataInput, _ ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error) {
+	f.in = in
+	return f.out, f.err
+}
+
+func gib(f float64) float64 { return f * 1024 * 1024 * 1024 }
+
+// TestFetchControlPlaneMetrics_ParsesAndScopes verifies the AWS/EKS query is
+// scoped by the ClusterName dimension and that counters are summed while gauges
+// take the max.
+func TestFetchControlPlaneMetrics_ParsesAndScopes(t *testing.T) {
+	fake := &fakeMetricsAPI{out: &cloudwatch.GetMetricDataOutput{
+		MetricDataResults: []cwtypes.MetricDataResult{
+			{Id: aws.String("etcd"), Values: []float64{gib(4.2)}},
+			{Id: aws.String("req_total"), Values: []float64{3000, 2000}}, // summed → 5000
+			{Id: aws.String("req_5xx"), Values: []float64{100, 50}},      // summed → 150
+			{Id: aws.String("req_429"), Values: []float64{0}},
+			{Id: aws.String("pending"), Values: []float64{2, 7, 3}}, // max → 7
+		},
+	}}
+
+	m, err := fetchControlPlaneMetrics(context.Background(), fake, "prod")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !m.hasData || !m.etcdKnown || !m.pendingKnown {
+		t.Fatalf("expected data/known flags set: %+v", m)
+	}
+	if m.etcdInUseBytes != gib(4.2) {
+		t.Errorf("etcd = %v, want %v", m.etcdInUseBytes, gib(4.2))
+	}
+	if m.reqTotal != 5000 || m.req5xx != 150 {
+		t.Errorf("counters summed wrong: total=%v 5xx=%v", m.reqTotal, m.req5xx)
+	}
+	if m.pendingPods != 7 {
+		t.Errorf("pending pods (max) = %v, want 7", m.pendingPods)
+	}
+
+	// Request scoping: AWS/EKS namespace + ClusterName dimension, one query each.
+	if fake.in == nil || len(fake.in.MetricDataQueries) != len(controlPlaneQueries) {
+		t.Fatalf("expected %d queries, got %v", len(controlPlaneQueries), fake.in)
+	}
+	q0 := fake.in.MetricDataQueries[0].MetricStat.Metric
+	if aws.ToString(q0.Namespace) != "AWS/EKS" {
+		t.Errorf("namespace = %q, want AWS/EKS", aws.ToString(q0.Namespace))
+	}
+	if len(q0.Dimensions) != 1 || aws.ToString(q0.Dimensions[0].Name) != "ClusterName" || aws.ToString(q0.Dimensions[0].Value) != "prod" {
+		t.Errorf("dimension = %+v, want ClusterName=prod", q0.Dimensions)
+	}
+}
+
+// TestCheckControlPlaneMetrics_NoData verifies a cluster not emitting the
+// AWS/EKS metrics (e.g. <1.28) is Skipped, not failed.
+func TestCheckControlPlaneMetrics_NoData(t *testing.T) {
+	fake := &fakeMetricsAPI{out: &cloudwatch.GetMetricDataOutput{}}
+	r := checkControlPlaneMetrics(context.Background(), fake, "prod")
+	if !r.Skipped || r.Status == StatusFail {
+		t.Errorf("no-data check should be skipped/non-fail, got %+v", r)
+	}
+}
+
+// TestCheckControlPlaneMetrics_FetchError degrades to Skipped (never blocks an
+// upgrade because CloudWatch hiccuped).
+func TestCheckControlPlaneMetrics_FetchError(t *testing.T) {
+	fake := &fakeMetricsAPI{err: errors.New("throttled")}
+	r := checkControlPlaneMetrics(context.Background(), fake, "prod")
+	if !r.Skipped || r.Status == StatusFail {
+		t.Errorf("fetch error should be skipped/non-fail, got %+v", r)
+	}
+}
+
+func TestEvaluateControlPlane(t *testing.T) {
+	tests := []struct {
+		name        string
+		m           controlPlaneMetrics
+		wantStatus  HealthStatus
+		wantSkipped bool
+	}{
+		{
+			name:       "healthy",
+			m:          controlPlaneMetrics{hasData: true, etcdKnown: true, etcdInUseBytes: gib(4), reqTotal: 5000, req5xx: 0},
+			wantStatus: StatusPass,
+		},
+		{
+			name:       "etcd warn",
+			m:          controlPlaneMetrics{hasData: true, etcdKnown: true, etcdInUseBytes: gib(6.6)}, // 82.5%
+			wantStatus: StatusWarn,
+		},
+		{
+			name:       "etcd fail near read-only",
+			m:          controlPlaneMetrics{hasData: true, etcdKnown: true, etcdInUseBytes: gib(7.7)}, // 96.25%
+			wantStatus: StatusFail,
+		},
+		{
+			name:       "elevated 5xx warns",
+			m:          controlPlaneMetrics{hasData: true, etcdKnown: true, etcdInUseBytes: gib(2), reqTotal: 5000, req5xx: 150}, // 3%
+			wantStatus: StatusWarn,
+		},
+		{
+			name:       "5xx below volume floor ignored",
+			m:          controlPlaneMetrics{hasData: true, etcdKnown: true, etcdInUseBytes: gib(2), reqTotal: 500, req5xx: 100}, // 20% but < floor
+			wantStatus: StatusPass,
+		},
+		{
+			name:       "throttling warns",
+			m:          controlPlaneMetrics{hasData: true, etcdKnown: true, etcdInUseBytes: gib(2), req429: 12},
+			wantStatus: StatusWarn,
+		},
+		{
+			name:        "no data skipped",
+			m:           controlPlaneMetrics{hasData: false},
+			wantStatus:  StatusPass,
+			wantSkipped: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := evaluateControlPlane(tc.m)
+			if r.Status != tc.wantStatus {
+				t.Errorf("status = %s, want %s (%+v)", r.Status, tc.wantStatus, r)
+			}
+			if r.Skipped != tc.wantSkipped {
+				t.Errorf("skipped = %v, want %v", r.Skipped, tc.wantSkipped)
+			}
+			// The etcd-critical case must be blocking so the gate actually holds.
+			if tc.name == "etcd fail near read-only" && !r.IsBlocking {
+				t.Error("etcd-near-limit failure must be blocking")
+			}
+		})
+	}
+}

--- a/internal/services/cluster/insights.go
+++ b/internal/services/cluster/insights.go
@@ -13,6 +13,7 @@ import (
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 
 	awsinternal "github.com/dantech2000/refresh/internal/aws"
+	"github.com/dantech2000/refresh/internal/health"
 	"github.com/dantech2000/refresh/internal/services/addons"
 	"github.com/dantech2000/refresh/internal/services/common"
 	"github.com/dantech2000/refresh/internal/services/status"
@@ -114,10 +115,11 @@ type SkewReport struct {
 // UpgradeReport combines AWS Cluster Insights with the local version-skew view —
 // the full `cluster upgrade-check` result.
 type UpgradeReport struct {
-	Cluster  string                 `json:"cluster" yaml:"cluster"`
-	Support  *status.SupportPosture `json:"support,omitempty" yaml:"support,omitempty"`
-	Insights []InsightSummary       `json:"insights" yaml:"insights"`
-	Skew     SkewReport             `json:"skew" yaml:"skew"`
+	Cluster      string                 `json:"cluster" yaml:"cluster"`
+	Support      *status.SupportPosture `json:"support,omitempty" yaml:"support,omitempty"`
+	ControlPlane *health.HealthResult   `json:"controlPlane,omitempty" yaml:"controlPlane,omitempty"`
+	Insights     []InsightSummary       `json:"insights" yaml:"insights"`
+	Skew         SkewReport             `json:"skew" yaml:"skew"`
 }
 
 // ListInsights returns the cluster's EKS Cluster Insights filtered per opts.


### PR DESCRIPTION
First of the medium-tier real-time features (REF-140). Adds a control-plane health gate sourced from the **free AWS/EKS CloudWatch metrics** (EKS 1.28+, no Container Insights / agent).

## What it does
`health.CheckControlPlaneMetrics` reads the `AWS/EKS` namespace scoped by the `ClusterName` dimension and evaluates:
- **etcd database usage vs the 8 GiB read-only limit** (`etcd_mvcc_db_total_size_in_use_in_bytes`) — the blocking signal: **Fail ≥95%**, **Warn ≥80%**. At 8 GiB etcd goes read-only and rejects writes, so a cluster near the line is genuinely unsafe to upgrade.
- **API-server error rate** (`apiserver_request_total_5XX` / `_429` over `apiserver_request_total`) — advisory **warn-only**, gated by a request-volume floor so an idle cluster's stray errors don't trip it.
- **scheduler backlog** (`scheduler_pending_pods`) — informational detail.

Clusters below 1.28 don't emit these metrics → the check is **Skipped** (excluded from the score), never failed. CloudWatch errors also degrade to Skipped so a hiccup never blocks an upgrade.

## Wiring
- **`RunAllChecks`** — so it strengthens the existing pre-flight gates that already back `nodegroup update` (`preflightHealthCheck`) and the `cluster upgrade` orchestrator. A near-read-only etcd now actually holds a roll.
- **`cluster upgrade-check`** — explicit `CONTROL PLANE` section (themed + plain + json/yaml) that participates in the READY / REVIEW / NOT READY verdict.

## Validated against current docs
- Metric names + statistics (Max for etcd, Sum for request counters): [EKS CloudWatch metrics doc](https://docs.aws.amazon.com/eks/latest/userguide/cloudwatch.html)
- Dimension = By Cluster Name (`ClusterName`), free/automatic, no agent: [EKS control-plane observability blog](https://aws.amazon.com/blogs/containers/amazon-eks-enhances-kubernetes-control-plane-observability/)
- 8 GiB etcd → read-only behavior: [EKS known limits & quotas](https://docs.aws.amazon.com/eks/latest/best-practices/known_limits_and_service_quotas.html)

## Tests (mocked CloudWatch data, no live AWS)
- `fetchControlPlaneMetrics` — Sum vs Max aggregation + `AWS/EKS`/`ClusterName` request scoping
- `evaluateControlPlane` — pure threshold table (healthy / etcd warn / etcd fail-blocking / 5xx warn / below-floor ignored / 429 warn / no-data skipped)
- no-data and fetch-error both degrade to Skipped
- render test: blocking gate → NOT READY + CONTROL PLANE section; skipped gate → READY + unavailable note

`go build`, `go vet`, `go test ./... -race`, and `golangci-lint` all clean.

## Design note (REF-78)
This is a **readiness gate**, not a utilization-browse surface — it reports a pass/warn/fail verdict, not metric tables, so it does not reintroduce the trimmed `--show-utilization` behavior.

Next mediums queued: REF-142 (metrics-server) and REF-138 (live K8s events), each as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)