### PR TITLE
Live Kubernetes Warning events during a roll (REF-138)

### DIFF
--- a/internal/commands/nodegroup/rollpanel.go
+++ b/internal/commands/nodegroup/rollpanel.go
@@ -113,7 +113,31 @@ func rollPanelLines(th *render.Theme, snap noderoll.Snapshot, events []noderoll.
 		st, text := eventToken(e.Kind)
 		out = append(out, "    "+th.Glyph(st)+" "+th.Paint(pal.White, e.Node)+th.Paint(pal.Dim, "  "+text))
 	}
+
+	// Warning events explain *why* a node is stuck (failed drain/eviction,
+	// sandbox failures) — surfaced beneath the lifecycle feed.
+	if len(snap.Warnings) > 0 {
+		out = append(out, "", th.Paint(pal.Dim, "warnings"))
+		for _, w := range snap.Warnings {
+			line := "    " + th.Token(render.Warn, w.Reason) + " " + th.Paint(pal.White, w.Node)
+			if msg := oneLineWarn(w.Message); msg != "" {
+				line += th.Paint(pal.Dim, "  "+msg)
+			}
+			out = append(out, line)
+		}
+	}
 	return out
+}
+
+// oneLineWarn collapses an event message to a single line and clamps its length
+// so a verbose message can't blow out the panel width.
+func oneLineWarn(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	const max = 80
+	if len(s) > max {
+		return s[:max-1] + "…"
+	}
+	return s
 }
 
 func spin(th *render.Theme, frame int) string {

--- a/internal/commands/nodegroup/rollpanel_test.go
+++ b/internal/commands/nodegroup/rollpanel_test.go
@@ -8,6 +8,30 @@ import (
 	"github.com/dantech2000/refresh/internal/render"
 )
 
+// TestRollPanelLines_Warnings verifies scoped Warning events render in a
+// warnings section with reason + node + (truncated) message.
+func TestRollPanelLines_Warnings(t *testing.T) {
+	th := render.New(render.ColorNone, true)
+	snap := noderoll.Snapshot{
+		Total: 1, Draining: 1,
+		Nodes: []noderoll.NodeView{{Name: "ip-1", OnTarget: false, Ready: true, Phase: noderoll.PhaseDraining}},
+		Warnings: []noderoll.WarnEvent{{
+			Node: "ip-1", Object: "Node/ip-1", Reason: "FailedDraining",
+			Message: "Cannot evict pod as it would violate the pod's disruption budget",
+		}},
+	}
+	m := rollMeta{Nodegroup: "spot-burst", OldAMI: "ami-old", NewAMI: "ami-new", Desired: 1}
+	joined := strings.Join(rollPanelLines(th, snap, nil, m), "\n")
+	if strings.Contains(joined, "\x1b") {
+		t.Fatalf("ColorNone panel contains ANSI escapes:\n%s", joined)
+	}
+	for _, want := range []string{"warnings", "FailedDraining", "ip-1", "violate the pod's disruption budget"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("panel missing %q in:\n%s", want, joined)
+		}
+	}
+}
+
 // TestRollPanelLines_PressureAdvisory verifies a Ready node under pressure still
 // reads "Ready" but carries the pressure advisory in its state cell.
 func TestRollPanelLines_PressureAdvisory(t *testing.T) {

--- a/internal/noderoll/observer.go
+++ b/internal/noderoll/observer.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"sort"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,6 +61,18 @@ type Snapshot struct {
 	ReadyTarget int        `json:"readyTarget"` // Ready nodes already on the target AMI
 	Draining    int        `json:"draining"`
 	Joining     int        `json:"joining"`
+	// Warnings are recent Kubernetes Warning events scoped to this nodegroup's
+	// nodes — the "why is a node stuck" signal (failed drain/eviction, sandbox
+	// failures) that the coarse lifecycle phases can't show.
+	Warnings []WarnEvent `json:"warnings,omitempty"`
+}
+
+// WarnEvent is a Kubernetes Warning event scoped to a nodegroup node.
+type WarnEvent struct {
+	Node    string `json:"node"`    // the nodegroup node it concerns
+	Object  string `json:"object"`  // involved object, "Kind/name"
+	Reason  string `json:"reason"`  // e.g. FailedDraining, FailedCreatePodSandbox
+	Message string `json:"message"` // human detail (truncated for display)
 }
 
 // Observer yields successive snapshots of a roll. Implementations: a
@@ -139,9 +152,34 @@ func (o *KubeObserver) Snapshot(ctx context.Context) (Snapshot, error) {
 		o.fillPodEviction(ctx, &snap)
 	}
 
+	// Best-effort Warning events scoped to this nodegroup's nodes.
+	nodeSet := make(map[string]bool, len(list.Items))
+	for i := range list.Items {
+		nodeSet[list.Items[i].Name] = true
+	}
+	o.fillWarnings(ctx, &snap, nodeSet)
+
 	// Stable order so renders/golden tests are deterministic.
 	sort.Slice(snap.Nodes, func(i, j int) bool { return snap.Nodes[i].Name < snap.Nodes[j].Name })
 	return snap, nil
+}
+
+// warningWindow bounds how recent a Warning event must be to surface, so the
+// panel shows what's happening during the roll, not stale history.
+const warningWindow = 10 * time.Minute
+
+// fillWarnings lists Warning events and keeps those scoped to the nodegroup's
+// nodes. Best-effort: a list failure leaves Warnings empty (the panel omits the
+// section) rather than failing the snapshot.
+func (o *KubeObserver) fillWarnings(ctx context.Context, snap *Snapshot, nodeSet map[string]bool) {
+	evList, err := o.client.CoreV1().Events(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+		FieldSelector: "type=Warning",
+		Limit:         200,
+	})
+	if err != nil {
+		return
+	}
+	snap.Warnings = scopeWarnings(evList.Items, nodeSet, time.Now(), warningWindow)
 }
 
 // fillPodEviction counts the evictable pods on each draining node and records
@@ -174,6 +212,77 @@ func (o *KubeObserver) fillPodEviction(ctx context.Context, snap *Snapshot) {
 		n.Pods = cur
 		n.PodsTotal = o.drainStart[n.Name]
 	}
+}
+
+// scopeWarnings filters cluster Warning events down to those concerning the
+// nodegroup's nodes (involvedObject is one of the nodes, or the event was
+// emitted by a kubelet on one of them) and recent enough to matter, deduped by
+// node+object+reason keeping the latest. Pure for testability.
+func scopeWarnings(events []corev1.Event, nodeSet map[string]bool, now time.Time, window time.Duration) []WarnEvent {
+	type key struct{ node, object, reason string }
+	latest := make(map[key]corev1.Event)
+	order := make([]key, 0)
+
+	for i := range events {
+		e := events[i]
+		if e.Type != "" && e.Type != corev1.EventTypeWarning {
+			continue
+		}
+		node := warningNode(&e, nodeSet)
+		if node == "" {
+			continue // not scoped to this nodegroup
+		}
+		if ts := warningTime(&e); !ts.IsZero() && now.Sub(ts) > window {
+			continue // stale
+		}
+		k := key{node: node, object: e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name, reason: e.Reason}
+		if prev, seen := latest[k]; !seen {
+			order = append(order, k)
+			latest[k] = e
+		} else if warningTime(&e).After(warningTime(&prev)) {
+			latest[k] = e
+		}
+	}
+
+	out := make([]WarnEvent, 0, len(order))
+	for _, k := range order {
+		e := latest[k]
+		out = append(out, WarnEvent{
+			Node:    k.node,
+			Object:  k.object,
+			Reason:  e.Reason,
+			Message: e.Message,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Node != out[j].Node {
+			return out[i].Node < out[j].Node
+		}
+		return out[i].Reason < out[j].Reason
+	})
+	return out
+}
+
+// warningNode returns the nodegroup node an event concerns, or "" if it isn't
+// scoped to one: either the involved object is a Node in the set, or the event
+// was emitted by a kubelet (Source.Host) on a node in the set.
+func warningNode(e *corev1.Event, nodeSet map[string]bool) string {
+	if e.InvolvedObject.Kind == "Node" && nodeSet[e.InvolvedObject.Name] {
+		return e.InvolvedObject.Name
+	}
+	if nodeSet[e.Source.Host] {
+		return e.Source.Host
+	}
+	return ""
+}
+
+// warningTime is the event's most recent occurrence (LastTimestamp, falling
+// back to EventTime).
+func warningTime(e *corev1.Event) time.Time {
+	if !e.LastTimestamp.IsZero() {
+		return e.LastTimestamp.Time
+	}
+	return e.EventTime.Time
 }
 
 // isEvictablePod reports whether a pod counts toward drain progress: DaemonSet

--- a/internal/noderoll/observer_test.go
+++ b/internal/noderoll/observer_test.go
@@ -4,11 +4,64 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+func TestScopeWarnings(t *testing.T) {
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	recent := metav1.NewTime(now.Add(-2 * time.Minute))
+	stale := metav1.NewTime(now.Add(-30 * time.Minute))
+	nodeSet := map[string]bool{"ip-1": true, "ip-2": true}
+
+	events := []corev1.Event{
+		// Node-involved warning on a nodegroup node — kept.
+		{Type: "Warning", Reason: "NodeNotReady", Message: "kubelet stopped posting status",
+			InvolvedObject: corev1.ObjectReference{Kind: "Node", Name: "ip-1"}, LastTimestamp: recent},
+		// Kubelet-emitted (Source.Host) pod warning on a nodegroup node — kept.
+		{Type: "Warning", Reason: "FailedCreatePodSandbox", Message: "network plugin not ready",
+			InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "web-x", Namespace: "default"},
+			Source:         corev1.EventSource{Host: "ip-2"}, LastTimestamp: recent},
+		// Warning on a node NOT in the nodegroup — dropped.
+		{Type: "Warning", Reason: "DiskPressure", InvolvedObject: corev1.ObjectReference{Kind: "Node", Name: "other"}, LastTimestamp: recent},
+		// Normal event — dropped.
+		{Type: "Normal", Reason: "Starting", InvolvedObject: corev1.ObjectReference{Kind: "Node", Name: "ip-1"}, LastTimestamp: recent},
+		// Stale warning — dropped.
+		{Type: "Warning", Reason: "OldNews", InvolvedObject: corev1.ObjectReference{Kind: "Node", Name: "ip-1"}, LastTimestamp: stale},
+	}
+
+	got := scopeWarnings(events, nodeSet, now, 10*time.Minute)
+	if len(got) != 2 {
+		t.Fatalf("got %d scoped warnings, want 2: %+v", len(got), got)
+	}
+	// Sorted by node: ip-1 (NodeNotReady) then ip-2 (FailedCreatePodSandbox).
+	if got[0].Node != "ip-1" || got[0].Reason != "NodeNotReady" {
+		t.Errorf("first = %+v, want ip-1/NodeNotReady", got[0])
+	}
+	if got[1].Node != "ip-2" || got[1].Reason != "FailedCreatePodSandbox" || got[1].Object != "Pod/web-x" {
+		t.Errorf("second = %+v, want ip-2/FailedCreatePodSandbox/Pod/web-x", got[1])
+	}
+}
+
+func TestScopeWarnings_DedupKeepsLatest(t *testing.T) {
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	nodeSet := map[string]bool{"ip-1": true}
+	older := metav1.NewTime(now.Add(-5 * time.Minute))
+	newer := metav1.NewTime(now.Add(-1 * time.Minute))
+	obj := corev1.ObjectReference{Kind: "Node", Name: "ip-1"}
+
+	got := scopeWarnings([]corev1.Event{
+		{Type: "Warning", Reason: "FailedDraining", Message: "older", InvolvedObject: obj, LastTimestamp: older},
+		{Type: "Warning", Reason: "FailedDraining", Message: "newer", InvolvedObject: obj, LastTimestamp: newer},
+	}, nodeSet, now, 10*time.Minute)
+
+	if len(got) != 1 || got[0].Message != "newer" {
+		t.Errorf("dedup should keep the latest message, got %+v", got)
+	}
+}
 
 // TestClassify_PressureAdvisory verifies node-pressure conditions are reported
 // in a stable order, that False conditions are ignored, and that pressure is
@@ -59,6 +112,42 @@ func mkNode(name, ami string, ready, cordoned bool) *corev1.Node {
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: cond}},
 		},
+	}
+}
+
+// TestKubeObserver_ScopesWarningEvents drives the observer against a fake
+// cluster with Warning events and asserts only the ones concerning the
+// nodegroup's nodes surface on the snapshot.
+func TestKubeObserver_ScopesWarningEvents(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+	client := fake.NewClientset(
+		mkNode("ip-1", oldAMI, true, false),
+		&corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Name: "e1", Namespace: "default"},
+			Type:           "Warning",
+			Reason:         "FailedDraining",
+			Message:        "Cannot evict pod as it would violate the pod's disruption budget",
+			InvolvedObject: corev1.ObjectReference{Kind: "Node", Name: "ip-1"},
+			LastTimestamp:  now,
+		},
+		&corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Name: "e2", Namespace: "default"},
+			Type:           "Warning",
+			Reason:         "DiskPressure",
+			InvolvedObject: corev1.ObjectReference{Kind: "Node", Name: "ip-elsewhere"},
+			LastTimestamp:  now,
+		},
+	)
+	obs := NewKubeObserver(client, ng, newAMI)
+	s, err := obs.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if len(s.Warnings) != 1 {
+		t.Fatalf("got %d warnings, want 1 (only the nodegroup node): %+v", len(s.Warnings), s.Warnings)
+	}
+	if s.Warnings[0].Node != "ip-1" || s.Warnings[0].Reason != "FailedDraining" {
+		t.Errorf("warning = %+v, want ip-1/FailedDraining", s.Warnings[0])
 	}
 }
 


### PR DESCRIPTION
Last of the medium real-time features (REF-138). Turns the live roll panel from "node X is draining" into "node X is draining **because** an eviction is blocked by a PDB."

## What it does
`internal/noderoll`'s `KubeObserver` already polls Node state; it now also lists **Warning events** each poll and scopes them to the rolling nodegroup's nodes:
- involvedObject is one of the nodegroup's nodes, **or** the event was emitted by a kubelet on one (`Source.Host`)
- recent only (within a 10-minute window, so stale history doesn't replay)
- deduped by node + object + reason, keeping the latest message

`Snapshot.Warnings` carries them; the live panel renders a **warnings** section beneath the lifecycle feed — `FailedDraining`, eviction blocked by a PDB, `FailedCreatePodSandbox`, etc. Messages are collapsed to one line and length-clamped so a verbose event can't blow out the panel.

**Best-effort:** an events-list failure leaves the section empty rather than failing the snapshot (the panel and the authoritative EKS `DescribeUpdate` monitor are unaffected).

## Scoping rationale
Cluster events are noisy, so the scope is deliberately tight (Warning-only via field selector + node-set membership + recency + dedup). Pod scheduling failures that never land on a node aren't shown — they aren't reliably attributable to a nodegroup node — keeping the panel signal-dense.

## Tests (fake clientset, no AWS / no cluster)
- `scopeWarnings` — node-involved + kubelet `Source.Host` kept; out-of-nodegroup, Normal-type, and stale events dropped; deterministic ordering
- dedup keeps the latest message for a repeated node+object+reason
- observer integration: only the nodegroup node's warning surfaces on the snapshot
- panel render: warnings section with reason + node + truncated message

`go build`, `go vet`, `go test ./... -race`, `golangci-lint` all clean.

That completes the medium tier (REF-140, REF-142, REF-138). Remaining real-time backlog is the Tier-3 pre-flight gates (REF-143 instance-type availability, REF-144 service quotas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)