### PR TITLE
Pre-flight instance-type availability per AZ on scale/update (REF-143)

### DIFF
--- a/internal/commands/nodegroup/actions.go
+++ b/internal/commands/nodegroup/actions.go
@@ -2,11 +2,13 @@ package nodegroup
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/fatih/color"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/dantech2000/refresh/internal/health"
+	nodegroupsvc "github.com/dantech2000/refresh/internal/services/nodegroup"
 )
 
 // resolveHealthKubeClient builds the Kubernetes client for the pre-flight
@@ -31,4 +33,20 @@ func resolveHealthKubeClient(ctx context.Context, kubeconfig string, humanOutput
 		return nil
 	}
 	return client
+}
+
+// warnInstanceTypeAvailability runs the EC2 instance-type-availability pre-flight
+// and prints a non-blocking warning for any (type, AZ) the nodegroup spans where
+// the type isn't offered — nodes would fail to launch there. Best-effort: any
+// error is swallowed so it never blocks a scale or roll. (REF-143)
+func warnInstanceTypeAvailability(ctx context.Context, svc *nodegroupsvc.ServiceImpl, clusterName, nodegroupName string) {
+	unavailable, err := svc.CheckInstanceTypeAvailability(ctx, clusterName, nodegroupName)
+	if err != nil || len(unavailable) == 0 {
+		return
+	}
+	color.Yellow("Pre-flight: instance type(s) not offered in some of the nodegroup's AZs — new nodes may fail to launch there:")
+	for _, u := range unavailable {
+		fmt.Printf("  - %s not offered in %s\n", u.InstanceType, u.AvailabilityZone)
+	}
+	color.Yellow("  Note: this checks availability, not live capacity (only a launch reveals InsufficientInstanceCapacity).")
 }

--- a/internal/commands/nodegroup/actions_scale.go
+++ b/internal/commands/nodegroup/actions_scale.go
@@ -78,6 +78,10 @@ func runScale(ctx context.Context, cmd *cli.Command) error {
 		return printScaleDryRun(ctx, eks.NewFromConfig(awsCfg), clusterName, cmd.String("nodegroup"), desired, minSize, maxSize, pdbs)
 	}
 
+	// Pre-flight: warn if the nodegroup's instance type isn't offered in one of
+	// its AZs — a scale-up would fail to place nodes there. (REF-143)
+	warnInstanceTypeAvailability(ctx, svc, clusterName, cmd.String("nodegroup"))
+
 	return runner.WithSpinner("nodegroup", "Scaling request submitted", func() error {
 		return svc.Scale(ctx, clusterName, cmd.String("nodegroup"), desired, minSize, maxSize, opts)
 	})

--- a/internal/commands/nodegroup/actions_update.go
+++ b/internal/commands/nodegroup/actions_update.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	awsinternal "github.com/dantech2000/refresh/internal/aws"
+	"github.com/dantech2000/refresh/internal/commands/factory"
 	"github.com/dantech2000/refresh/internal/commands/runner"
 	"github.com/dantech2000/refresh/internal/dryrun"
 	"github.com/dantech2000/refresh/internal/health"
@@ -109,6 +110,15 @@ func runUpdateAMI(ctx context.Context, cmd *cli.Command) error {
 	selectedNodegroups, err := selectNodegroupsForUpdate(ctx, eksClient, clusterName, nodegroupPattern, flags.yes)
 	if err != nil {
 		return err
+	}
+
+	// Pre-flight: a roll launches replacement nodes, so warn if an instance type
+	// isn't offered in one of a nodegroup's AZs. Best-effort, non-blocking. (REF-143)
+	if !flags.quiet {
+		ngSvc := factory.NewNodegroupService(awsCfg, false, nil)
+		for _, ng := range selectedNodegroups {
+			warnInstanceTypeAvailability(ctx, ngSvc, clusterName, ng)
+		}
 	}
 
 	if flags.dryRun {

--- a/internal/services/nodegroup/availability.go
+++ b/internal/services/nodegroup/availability.go
@@ -1,0 +1,107 @@
+package nodegroup
+
+import (
+	"context"
+	"sort"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+
+	awsinternal "github.com/dantech2000/refresh/internal/aws"
+)
+
+// instanceOfferingsAPI is the slice of EC2 the availability pre-flight needs.
+// The concrete *ec2.Client satisfies it; tests pass a fake.
+type instanceOfferingsAPI interface {
+	DescribeSubnets(ctx context.Context, in *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error)
+	DescribeInstanceTypeOfferings(ctx context.Context, in *ec2.DescribeInstanceTypeOfferingsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypeOfferingsOutput, error)
+}
+
+// UnavailableOffering is an (instance type, AZ) pair the nodegroup spans but
+// where EC2 doesn't offer that instance type.
+type UnavailableOffering struct {
+	InstanceType     string `json:"instanceType" yaml:"instanceType"`
+	AvailabilityZone string `json:"availabilityZone" yaml:"availabilityZone"`
+}
+
+// CheckInstanceTypeAvailability reports (instance type, AZ) combinations the
+// nodegroup spans where EC2 doesn't offer the type — a pre-flight that catches
+// "the ASG can't launch nodes in AZ X" before a scale-up or roll silently
+// stalls. NOTE: this checks whether a type is *offered* in an AZ, not whether
+// there is spare *capacity* right now — only a launch attempt reveals
+// InsufficientInstanceCapacity.
+func (s *ServiceImpl) CheckInstanceTypeAvailability(ctx context.Context, clusterName, nodegroupName string) ([]UnavailableOffering, error) {
+	desc, err := s.eksClient.DescribeNodegroup(ctx, &eks.DescribeNodegroupInput{
+		ClusterName:   aws.String(clusterName),
+		NodegroupName: aws.String(nodegroupName),
+	})
+	if err != nil {
+		return nil, awsinternal.FormatAWSError(err, "describing nodegroup")
+	}
+	if desc == nil || desc.Nodegroup == nil {
+		return nil, nil
+	}
+	return checkInstanceTypeAvailability(ctx, s.ec2Client, desc.Nodegroup.InstanceTypes, desc.Nodegroup.Subnets)
+}
+
+func checkInstanceTypeAvailability(ctx context.Context, api instanceOfferingsAPI, instanceTypes, subnetIDs []string) ([]UnavailableOffering, error) {
+	// Custom-launch-template nodegroups report no InstanceTypes; nothing to check.
+	if len(instanceTypes) == 0 || len(subnetIDs) == 0 {
+		return nil, nil
+	}
+
+	// Resolve the nodegroup's AZs from its subnets.
+	subs, err := api.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{SubnetIds: subnetIDs})
+	if err != nil {
+		return nil, awsinternal.FormatAWSError(err, "describing subnets")
+	}
+	azSet := make(map[string]bool, len(subs.Subnets))
+	for _, sn := range subs.Subnets {
+		if sn.AvailabilityZone != nil {
+			azSet[*sn.AvailabilityZone] = true
+		}
+	}
+	if len(azSet) == 0 {
+		return nil, nil
+	}
+
+	var unavailable []UnavailableOffering
+	for _, it := range instanceTypes {
+		offerings, oerr := awsinternal.ListAllPages(ctx, "describing instance type offerings",
+			func(rc context.Context, token *string) (*ec2.DescribeInstanceTypeOfferingsOutput, error) {
+				return api.DescribeInstanceTypeOfferings(rc, &ec2.DescribeInstanceTypeOfferingsInput{
+					LocationType: ec2types.LocationTypeAvailabilityZone,
+					Filters:      []ec2types.Filter{{Name: aws.String("instance-type"), Values: []string{it}}},
+					NextToken:    token,
+				})
+			},
+			func(o *ec2.DescribeInstanceTypeOfferingsOutput) ([]ec2types.InstanceTypeOffering, *string) {
+				return o.InstanceTypeOfferings, o.NextToken
+			},
+		)
+		if oerr != nil {
+			return nil, oerr
+		}
+		offered := make(map[string]bool, len(offerings))
+		for _, off := range offerings {
+			if off.Location != nil {
+				offered[*off.Location] = true
+			}
+		}
+		for az := range azSet {
+			if !offered[az] {
+				unavailable = append(unavailable, UnavailableOffering{InstanceType: it, AvailabilityZone: az})
+			}
+		}
+	}
+
+	sort.Slice(unavailable, func(i, j int) bool {
+		if unavailable[i].InstanceType != unavailable[j].InstanceType {
+			return unavailable[i].InstanceType < unavailable[j].InstanceType
+		}
+		return unavailable[i].AvailabilityZone < unavailable[j].AvailabilityZone
+	})
+	return unavailable, nil
+}

--- a/internal/services/nodegroup/availability_test.go
+++ b/internal/services/nodegroup/availability_test.go
@@ -1,0 +1,90 @@
+package nodegroup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// fakeOfferingsAPI serves subnet→AZ mappings and per-instance-type offered AZs.
+type fakeOfferingsAPI struct {
+	subnetAZ map[string]string   // subnetID → AZ
+	offered  map[string][]string // instanceType → AZs offering it
+}
+
+func (f *fakeOfferingsAPI) DescribeSubnets(_ context.Context, in *ec2.DescribeSubnetsInput, _ ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
+	out := &ec2.DescribeSubnetsOutput{}
+	for _, id := range in.SubnetIds {
+		if az, ok := f.subnetAZ[id]; ok {
+			out.Subnets = append(out.Subnets, ec2types.Subnet{SubnetId: aws.String(id), AvailabilityZone: aws.String(az)})
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeOfferingsAPI) DescribeInstanceTypeOfferings(_ context.Context, in *ec2.DescribeInstanceTypeOfferingsInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstanceTypeOfferingsOutput, error) {
+	// The pre-flight filters by instance-type; echo back that type's offered AZs.
+	var it string
+	for _, fl := range in.Filters {
+		if aws.ToString(fl.Name) == "instance-type" && len(fl.Values) > 0 {
+			it = fl.Values[0]
+		}
+	}
+	out := &ec2.DescribeInstanceTypeOfferingsOutput{}
+	for _, az := range f.offered[it] {
+		out.InstanceTypeOfferings = append(out.InstanceTypeOfferings, ec2types.InstanceTypeOffering{
+			InstanceType: ec2types.InstanceType(it),
+			Location:     aws.String(az),
+			LocationType: ec2types.LocationTypeAvailabilityZone,
+		})
+	}
+	return out, nil
+}
+
+func TestCheckInstanceTypeAvailability(t *testing.T) {
+	api := &fakeOfferingsAPI{
+		subnetAZ: map[string]string{"subnet-a": "us-east-1a", "subnet-b": "us-east-1b"},
+		offered: map[string][]string{
+			"m6i.large": {"us-east-1a", "us-east-1b"}, // available everywhere
+			"m7g.large": {"us-east-1a"},               // not offered in 1b
+		},
+	}
+
+	got, err := checkInstanceTypeAvailability(context.Background(), api,
+		[]string{"m6i.large", "m7g.large"}, []string{"subnet-a", "subnet-b"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d unavailable, want 1: %+v", len(got), got)
+	}
+	if got[0].InstanceType != "m7g.large" || got[0].AvailabilityZone != "us-east-1b" {
+		t.Errorf("unavailable = %+v, want m7g.large/us-east-1b", got[0])
+	}
+}
+
+func TestCheckInstanceTypeAvailability_AllAvailable(t *testing.T) {
+	api := &fakeOfferingsAPI{
+		subnetAZ: map[string]string{"subnet-a": "us-east-1a"},
+		offered:  map[string][]string{"m6i.large": {"us-east-1a"}},
+	}
+	got, err := checkInstanceTypeAvailability(context.Background(), api, []string{"m6i.large"}, []string{"subnet-a"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no unavailable offerings, got %+v", got)
+	}
+}
+
+func TestCheckInstanceTypeAvailability_NoInstanceTypes(t *testing.T) {
+	// Custom-launch-template nodegroups report no InstanceTypes — nothing to check.
+	api := &fakeOfferingsAPI{}
+	got, err := checkInstanceTypeAvailability(context.Background(), api, nil, []string{"subnet-a"})
+	if err != nil || got != nil {
+		t.Errorf("custom-LT nodegroup should be a no-op, got %v / %v", got, err)
+	}
+}


### PR DESCRIPTION
First Tier-3 pre-flight gate (REF-143). Catches "the ASG can't launch nodes in AZ X" *before* a scale-up or AMI roll silently stalls.

## What it does
`nodegroup.CheckInstanceTypeAvailability` (service layer):
1. `DescribeNodegroup` → instance types + subnets
2. `DescribeSubnets` → the nodegroup's AZ set
3. per instance type, `DescribeInstanceTypeOfferings` (`location-type=availability-zone`, filter `instance-type`) → the AZs EC2 offers it in
4. returns the `(instanceType, AZ)` gaps

Wired as a **best-effort, non-blocking warning** into `nodegroup scale` and the `nodegroup update` (AMI roll) pre-flight. Custom-launch-template nodegroups (no reported instance types) are a no-op.

## Honest scope (stated in the warning + doc comment)
This checks whether a type is **offered** in an AZ — **not** whether there's spare **capacity** right now. Only an actual launch reveals `InsufficientInstanceCapacity`. So it catches misconfig/unsupported-type-in-AZ, not live shortages.

## Validated against current docs
Filter names (`instance-type`, `location`) and `LocationType=availability-zone`: [DescribeInstanceTypeOfferings API ref](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypeOfferings.html).

## Tests (mocked EC2 API, no live AWS)
- gap detection: a type offered in only some of the nodegroup's AZs → reports the missing `(type, AZ)`
- all-available → no warnings
- custom-LT (no instance types) → no-op

`go build`, `go vet`, `go test ./... -race`, `golangci-lint` all clean.

Last item in the vetted real-time backlog: REF-144 (service-quota surge headroom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)