### PR TITLE
EC2 vCPU service-quota headroom pre-flight (REF-144)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.307.0
 	github.com/aws/aws-sdk-go-v2/service/eks v1.86.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.54.5
+	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.7
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.69.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3
 	github.com/aws/smithy-go v1.27.2

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12 h1:ZD2+BS
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12/go.mod h1:Ms4zlcVBbXbiP7EVLhl+lgjvA/a7YphqQ3Ih3174EmI=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.29 h1:DRebniUGZ2MqiiIVmQJ04vIXr918hubdHMnarSLEWyU=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.29/go.mod h1:LfRkPCD8YHDM2E5eTkos2UpwYeZnBcVarTa8L59bJHA=
+github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.7 h1:p63l2xECULZKPzgYzoN7bUiskcPSDa1rZifiFh4VpfI=
+github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.7/go.mod h1:YGEUoireZkWOCYB/aR5O4ajuI6rWd+uxxq8R13EQR70=
 github.com/aws/aws-sdk-go-v2/service/signin v1.2.0 h1:3nXpRcFwRCW8n7HgO2QGy0Dc20eQNfBuUemGQhpF8m8=
 github.com/aws/aws-sdk-go-v2/service/signin v1.2.0/go.mod h1:LxYujSTLPRlp2vTtcUO/+1ilrew8ytt6SvQyOgejzFQ=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.69.3 h1:58LjP8cp8UEHA1LG/JZ4fG9SobHE82kLYe46mogbSI4=

--- a/internal/commands/nodegroup/actions_update.go
+++ b/internal/commands/nodegroup/actions_update.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v3"
@@ -280,6 +281,9 @@ func preflightHealthCheck(ctx context.Context, awsCfg aws.Config, eksClient *eks
 			checker.SetNodeMetrics(m)
 		}
 	}
+	// EC2 vCPU quota headroom — a roll surges new nodes against the account
+	// quota; the check skips cleanly if it can't read the limit/usage. (REF-144)
+	checker.SetServiceQuotas(servicequotas.NewFromConfig(awsCfg))
 
 	spinner := ui.NewFunSpinnerForCategory("health")
 	if humanOutput {

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -58,6 +58,7 @@ type HealthChecker struct {
 	cwClient    *cloudwatch.Client
 	asgClient   *autoscaling.Client
 	nodeMetrics NodeMetricsLister // optional; enables the live utilization check
+	sqClient    serviceQuotaAPI   // optional; enables the vCPU quota headroom check
 }
 
 // NewChecker creates a new health checker instance
@@ -80,6 +81,7 @@ func (hc *HealthChecker) RunAllChecks(ctx context.Context, clusterName string) H
 		func() HealthResult { return hc.checkClusterCapacityWith(ctx, snap) },
 		func() HealthResult { return hc.CheckNodeUtilization(ctx, clusterName) },
 		func() HealthResult { return hc.CheckControlPlaneMetrics(ctx, clusterName) },
+		func() HealthResult { return hc.CheckServiceQuotas(ctx, clusterName) },
 		func() HealthResult { return hc.CheckCriticalWorkloads(ctx) },
 		func() HealthResult { return hc.CheckPodDisruptionBudgets(ctx) },
 		func() HealthResult { return hc.checkResourceBalanceWith(ctx, snap) },

--- a/internal/health/quotas.go
+++ b/internal/health/quotas.go
@@ -1,0 +1,134 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
+)
+
+// EC2 On-Demand Standard (A, C, D, H, I, M, R, T, Z) vCPU quota — the limit a
+// nodegroup scale-up or AMI roll (which surges new nodes) consumes against.
+const (
+	ec2ServiceCode      = "ec2"
+	onDemandVCPUQuota   = "L-1216C47A"
+	quotaWarnPercent    = 85.0
+	quotaHighPercent    = 95.0
+	quotaUsageWindow    = 10 * time.Minute
+	quotaUsageNamespace = "AWS/Usage"
+)
+
+// serviceQuotaAPI is the slice of Service Quotas the headroom check needs.
+type serviceQuotaAPI interface {
+	GetServiceQuota(ctx context.Context, in *servicequotas.GetServiceQuotaInput, optFns ...func(*servicequotas.Options)) (*servicequotas.GetServiceQuotaOutput, error)
+}
+
+// SetServiceQuotas attaches a Service Quotas client, enabling the vCPU quota
+// headroom check. Without it (and a CloudWatch client), the check is skipped.
+func (hc *HealthChecker) SetServiceQuotas(sq serviceQuotaAPI) { hc.sqClient = sq }
+
+// CheckServiceQuotas reports EC2 On-Demand vCPU usage against the account quota
+// — the headroom for adding nodes during a scale-up or roll. The limit comes
+// from Service Quotas; current usage from the AWS/Usage CloudWatch metric (the
+// quota API returns only the limit, not usage). Advisory (non-blocking); skips
+// when either client is missing or the limit/usage can't be read.
+func (hc *HealthChecker) CheckServiceQuotas(ctx context.Context, _ string) HealthResult {
+	if hc.sqClient == nil || hc.cwClient == nil {
+		return HealthResult{Name: "Service Quotas", Status: StatusPass, Skipped: true,
+			Message: "service-quota headroom unavailable (clients not configured)"}
+	}
+	return checkServiceQuotas(ctx, hc.sqClient, hc.cwClient)
+}
+
+// checkServiceQuotas is CheckServiceQuotas against injectable clients (testable).
+func checkServiceQuotas(ctx context.Context, sq serviceQuotaAPI, md metricDataAPI) HealthResult {
+	limit, err := onDemandVCPULimit(ctx, sq)
+	if err != nil {
+		return HealthResult{Name: "Service Quotas", Status: StatusPass, Skipped: true,
+			Message: fmt.Sprintf("service-quota headroom unavailable: %v", err)}
+	}
+	usage, ok, err := onDemandVCPUUsage(ctx, md)
+	if err != nil || !ok {
+		return HealthResult{Name: "Service Quotas", Status: StatusPass, Skipped: true,
+			Message: "service-quota usage unavailable (AWS/Usage metric not reported)"}
+	}
+	return evaluateQuota(usage, limit)
+}
+
+func onDemandVCPULimit(ctx context.Context, sq serviceQuotaAPI) (float64, error) {
+	out, err := sq.GetServiceQuota(ctx, &servicequotas.GetServiceQuotaInput{
+		ServiceCode: aws.String(ec2ServiceCode),
+		QuotaCode:   aws.String(onDemandVCPUQuota),
+	})
+	if err != nil {
+		return 0, err
+	}
+	if out == nil || out.Quota == nil || out.Quota.Value == nil {
+		return 0, fmt.Errorf("no quota value returned")
+	}
+	return *out.Quota.Value, nil
+}
+
+func onDemandVCPUUsage(ctx context.Context, md metricDataAPI) (usage float64, ok bool, err error) {
+	end := time.Now()
+	start := end.Add(-quotaUsageWindow)
+	out, err := md.GetMetricData(ctx, &cloudwatch.GetMetricDataInput{
+		StartTime: aws.Time(start),
+		EndTime:   aws.Time(end),
+		MetricDataQueries: []cwtypes.MetricDataQuery{{
+			Id: aws.String("vcpu"),
+			MetricStat: &cwtypes.MetricStat{
+				Metric: &cwtypes.Metric{
+					Namespace:  aws.String(quotaUsageNamespace),
+					MetricName: aws.String("ResourceCount"),
+					Dimensions: []cwtypes.Dimension{
+						{Name: aws.String("Service"), Value: aws.String("EC2")},
+						{Name: aws.String("Type"), Value: aws.String("Resource")},
+						{Name: aws.String("Resource"), Value: aws.String("vCPU")},
+						{Name: aws.String("Class"), Value: aws.String("Standard/OnDemand")},
+					},
+				},
+				Period: aws.Int32(int32(quotaUsageWindow.Seconds())),
+				Stat:   aws.String("Maximum"),
+			},
+		}},
+	})
+	if err != nil {
+		return 0, false, err
+	}
+	for _, r := range out.MetricDataResults {
+		if aws.ToString(r.Id) == "vcpu" && len(r.Values) > 0 {
+			return maxFloat(r.Values), true, nil
+		}
+	}
+	return 0, false, nil
+}
+
+// evaluateQuota turns usage vs limit into an advisory verdict (pure, testable).
+func evaluateQuota(usage, limit float64) HealthResult {
+	r := HealthResult{Name: "Service Quotas", IsBlocking: false, Status: StatusPass, Score: 100}
+	if limit <= 0 {
+		r.Skipped = true
+		r.Message = "service-quota limit unavailable"
+		return r
+	}
+	pct := usage / limit * 100
+	r.Details = append(r.Details, fmt.Sprintf("EC2 On-Demand Standard vCPUs: %.0f of %.0f used (%.1f%%, %.0f free)", usage, limit, pct, limit-usage))
+	switch {
+	case pct >= quotaHighPercent:
+		r.Status = StatusFail
+		r.Score = 40
+		r.Message = fmt.Sprintf("EC2 vCPU quota nearly exhausted (%.1f%%) — a scale-up or roll may fail to launch nodes", pct)
+	case pct >= quotaWarnPercent:
+		r.Status = StatusWarn
+		r.Score = 70
+		r.Message = fmt.Sprintf("EC2 vCPU quota usage high (%.1f%%) — limited headroom for new nodes", pct)
+	default:
+		r.Message = fmt.Sprintf("EC2 vCPU quota headroom healthy (%.1f%% used)", pct)
+	}
+	return r
+}

--- a/internal/health/quotas_test.go
+++ b/internal/health/quotas_test.go
@@ -1,0 +1,95 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
+	sqtypes "github.com/aws/aws-sdk-go-v2/service/servicequotas/types"
+)
+
+type fakeServiceQuotas struct {
+	value *float64
+	err   error
+}
+
+func (f *fakeServiceQuotas) GetServiceQuota(_ context.Context, _ *servicequotas.GetServiceQuotaInput, _ ...func(*servicequotas.Options)) (*servicequotas.GetServiceQuotaOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &servicequotas.GetServiceQuotaOutput{Quota: &sqtypes.ServiceQuota{Value: f.value}}, nil
+}
+
+// usageMetrics is a metricDataAPI stub returning a fixed vCPU usage value.
+type usageMetrics struct {
+	value   float64
+	hasData bool
+	err     error
+}
+
+func (u *usageMetrics) GetMetricData(_ context.Context, _ *cloudwatch.GetMetricDataInput, _ ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error) {
+	if u.err != nil {
+		return nil, u.err
+	}
+	res := cwtypes.MetricDataResult{Id: aws.String("vcpu")}
+	if u.hasData {
+		res.Values = []float64{u.value}
+	}
+	return &cloudwatch.GetMetricDataOutput{MetricDataResults: []cwtypes.MetricDataResult{res}}, nil
+}
+
+func TestEvaluateQuota(t *testing.T) {
+	tests := []struct {
+		name         string
+		usage, limit float64
+		wantStatus   HealthStatus
+		wantSkipped  bool
+	}{
+		{"healthy", 100, 1000, StatusPass, false},
+		{"high warns", 880, 1000, StatusWarn, false}, // 88%
+		{"near-exhausted fails", 970, 1000, StatusFail, false},
+		{"no limit skipped", 10, 0, StatusPass, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := evaluateQuota(tc.usage, tc.limit)
+			if r.Status != tc.wantStatus || r.Skipped != tc.wantSkipped {
+				t.Errorf("got status=%s skipped=%v, want status=%s skipped=%v (%+v)", r.Status, r.Skipped, tc.wantStatus, tc.wantSkipped, r)
+			}
+			if r.IsBlocking {
+				t.Error("quota check should be advisory (non-blocking)")
+			}
+		})
+	}
+}
+
+func TestCheckServiceQuotas_FetchAndEvaluate(t *testing.T) {
+	sq := &fakeServiceQuotas{value: aws.Float64(1000)}
+	md := &usageMetrics{value: 970, hasData: true} // 97% → near-exhausted → fail (advisory)
+
+	r := checkServiceQuotas(context.Background(), sq, md)
+	if r.Skipped {
+		t.Fatalf("expected a measured result, got skipped: %+v", r)
+	}
+	if r.Status != StatusFail {
+		t.Errorf("status = %s, want FAIL at 97%% (%+v)", r.Status, r)
+	}
+	if len(r.Details) == 0 {
+		t.Error("expected usage detail line")
+	}
+}
+
+func TestCheckServiceQuotas_SkipsGracefully(t *testing.T) {
+	// Quota fetch error → skip.
+	if r := checkServiceQuotas(context.Background(), &fakeServiceQuotas{err: errors.New("AccessDenied")}, &usageMetrics{value: 1, hasData: true}); !r.Skipped {
+		t.Errorf("quota error should skip, got %+v", r)
+	}
+	// Usage metric absent (AWS/Usage not reported) → skip, not fail.
+	if r := checkServiceQuotas(context.Background(), &fakeServiceQuotas{value: aws.Float64(1000)}, &usageMetrics{hasData: false}); !r.Skipped || r.Status == StatusFail {
+		t.Errorf("missing usage should skip (not fail), got %+v", r)
+	}
+}


### PR DESCRIPTION
Final item in the vetted real-time backlog (REF-144). Catches "you're near your EC2 vCPU quota" before a scale-up or roll fails to launch nodes.

## What it does
`health.CheckServiceQuotas` reports EC2 **On-Demand Standard vCPU** usage against the account quota:
- **limit** from Service Quotas (`ec2` / `L-1216C47A`)
- **usage** from the `AWS/Usage` CloudWatch metric (`ResourceCount`, `Service=EC2/Type=Resource/Resource=vCPU/Class=Standard/OnDemand`, `Maximum`) — because the quota API returns only the limit, not usage
- headroom verdict: warn at ≥85%, fail (advisory, **non-blocking**) at ≥95%

Skips cleanly (excluded from the health score, never fails) when the Service Quotas or CloudWatch clients aren't wired, or the limit/usage can't be read.

## Honest scope
This reports **vCPU headroom against the On-Demand Standard quota** — the one a roll/scale-up consumes. It doesn't model exact per-nodegroup surge (EKS controls surge by `maxUnavailable`, usually a node or two); it answers "do you have room to add nodes at all." That's the accurate, defensible signal without guessing surge math. Spot/other quota families aren't covered.

## Wiring
- `RunAllChecks` — surfaces wherever health runs.
- nodegroup-update **pre-flight** — `SetServiceQuotas(servicequotas.NewFromConfig(...))` attached alongside the metrics-server client.

## Dependency
Adds `github.com/aws/aws-sdk-go-v2/service/servicequotas`.

## Validated against current docs
Quota code `L-1216C47A` and the `AWS/Usage` `ResourceCount` vCPU dimensions/statistic: [CloudWatch usage metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Usage-Metrics.html), [Service Quotas GetServiceQuota](https://docs.aws.amazon.com/cli/latest/reference/service-quotas/get-service-quota.html).

## Tests (mocked Service Quotas + CloudWatch, no live AWS)
- `evaluateQuota` threshold table (healthy / warn / fail / no-limit-skipped, all non-blocking)
- fetch + evaluate at 97% → fail with a usage detail line
- graceful skips: quota fetch error, and AWS/Usage metric not reported

Rebased on `main` after REF-143 merged (both touch `actions_update.go`) — merged cleanly. `go build`, `go vet`, `go test ./... -race`, `golangci-lint` all clean.

This completes all 9 vetted real-time features (REF-137/138/139/140/141/142/143/144/145).

🤖 Generated with [Claude Code](https://claude.com/claude-code)