### PR TITLE
Itemize per-check health results in cluster describe (REF-146)

### DIFF
--- a/internal/commands/clusterview/detail.go
+++ b/internal/commands/clusterview/detail.go
@@ -115,6 +115,17 @@ func outputClusterDetailsPlain(details *clustersvc.ClusterDetails, elapsed time.
 		addTbl.Render()
 	}
 
+	if details.Health != nil && len(details.Health.Results) > 0 {
+		ui.Outln("\nHealth Checks:")
+		for _, r := range details.Health.Results {
+			status := string(r.Status)
+			if r.Skipped {
+				status = "SKIPPED"
+			}
+			fmt.Printf("  %-22s %-8s %s\n", r.Name, status, r.Message)
+		}
+	}
+
 	if len(details.HealthIssues) > 0 {
 		ui.Outln("\nHealth Issues:")
 		for _, iss := range details.HealthIssues {

--- a/internal/commands/clusterview/detail_render.go
+++ b/internal/commands/clusterview/detail_render.go
@@ -164,7 +164,49 @@ func healthCardLines(th *render.Theme, h *health.HealthSummary) []string {
 		th.Paint(th.Pal.Dim, fmt.Sprintf("  %d/100 · ", h.OverallScore)) +
 		th.Tokenf(st, string(h.Decision))
 	bar := th.Bar(h.OverallScore, 100, 24, col)
-	return []string{head, "  " + bar + "  " + th.Paint(th.Pal.Dim, healthSummaryMsg(h))}
+	out := []string{head, "  " + bar + "  " + th.Paint(th.Pal.Dim, healthSummaryMsg(h))}
+	return append(out, healthCheckRows(th, h.Results)...)
+}
+
+// healthCheckRows itemizes each individual health check beneath the card —
+// glyph + name + message — so the control-plane / utilization / quota / node /
+// PDB gates are all visible, not collapsed into one summary line. Skipped
+// checks (missing prerequisite) render dimmed so a gap reads as "not measured",
+// not "passed".
+func healthCheckRows(th *render.Theme, results []health.HealthResult) []string {
+	if len(results) == 0 {
+		return nil
+	}
+	nameWidth := 0
+	for _, r := range results {
+		if len(r.Name) > nameWidth {
+			nameWidth = len(r.Name)
+		}
+	}
+	out := make([]string, 0, len(results))
+	for _, r := range results {
+		name := r.Name + strings.Repeat(" ", nameWidth-len(r.Name))
+		if r.Skipped {
+			out = append(out, "    "+th.Glyph(render.Neutral)+" "+th.Paint(th.Pal.Dim, name+"  "+r.Message))
+			continue
+		}
+		out = append(out, "    "+th.Glyph(healthCheckStatus(r.Status))+" "+
+			th.Paint(th.Pal.White, name)+th.Paint(th.Pal.Dim, "  "+r.Message))
+	}
+	return out
+}
+
+func healthCheckStatus(s health.HealthStatus) render.Status {
+	switch s {
+	case health.StatusPass:
+		return render.Healthy
+	case health.StatusWarn:
+		return render.Warn
+	case health.StatusFail:
+		return render.Fail
+	default:
+		return render.Unknown
+	}
 }
 
 func decisionStatusColor(th *render.Theme, d health.Decision) (render.Status, render.Color) {

--- a/internal/commands/clusterview/detail_render_test.go
+++ b/internal/commands/clusterview/detail_render_test.go
@@ -61,6 +61,34 @@ func TestClusterDetailLines_HealthIssues(t *testing.T) {
 	}
 }
 
+func TestClusterDetailLines_HealthChecksItemized(t *testing.T) {
+	th := render.New(render.ColorNone, true)
+	d := sampleDetails()
+	d.Health = &health.HealthSummary{
+		OverallScore: 75,
+		Decision:     health.DecisionWarn,
+		Results: []health.HealthResult{
+			{Name: "Node Health", Status: health.StatusPass, Score: 100, Message: "all nodes Ready"},
+			{Name: "Control Plane", Status: health.StatusWarn, Score: 70, Message: "etcd 82% of the 8 GiB limit"},
+			{Name: "Service Quotas", Status: health.StatusPass, Skipped: true, Message: "headroom unavailable (clients not configured)"},
+		},
+	}
+	joined := strings.Join(clusterDetailLines(th, d, 0), "\n")
+	if strings.Contains(joined, "\x1b") {
+		t.Fatalf("ColorNone health card contains ANSI escapes:\n%s", joined)
+	}
+	for _, want := range []string{
+		"▸ HEALTH",
+		"Node Health", "all nodes Ready",
+		"Control Plane", "etcd 82% of the 8 GiB limit",
+		"Service Quotas", "headroom unavailable", // skipped check is still listed
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("itemized health card missing %q in:\n%s", want, joined)
+		}
+	}
+}
+
 func TestClusterDetailLines_Pretty(t *testing.T) {
 	th := render.New(render.ColorNone, true)
 	joined := strings.Join(clusterDetailLines(th, sampleDetails(), 0), "\n")


### PR DESCRIPTION
A small follow-on that makes today's new health gates actually visible.

## Problem
`cluster describe --show-health` collapsed the entire `HealthSummary` to a score + decision + a single summary line. So the individual checks — including the three gates added this session (control-plane REF-140, node-utilization REF-142, service-quota REF-144) plus the existing node/capacity/PDB/balance checks — were invisible here, even though the `nodegroup` path already itemizes them via `ui.DisplayHealthResults`.

## Change
Itemize each `HealthSummary.Results` entry beneath the card (glyph + name + message), in both the themed and `-o plain` describe views. Skipped checks (missing prerequisite — e.g. metrics-server absent, no CloudWatch client) render dimmed (themed) / `SKIPPED` (plain) so a gap reads as *not measured*, not *passed*.

## Tests
Golden test on `clusterDetailLines` asserting pass/warn/skipped checks are each listed with name + message and no ANSI under ColorNone. `go build`, `go vet`, `go test ./... -race`, `golangci-lint` clean; no docs/reference drift (no flag/command change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)