### PR TITLE
Document the queryable upgrade-readiness insight checks (REF-150)

### DIFF
--- a/docs/commands/cluster.md
+++ b/docs/commands/cluster.md
@@ -117,6 +117,40 @@ shows) plus a local **version-skew** picture: control-plane version vs. each
 managed nodegroup, and installed add-ons vs. the latest compatible version —
 with ordered, actionable findings.
 
+### Upgrade-readiness checks
+
+EKS computes these insights server-side and **owns the catalog — it adds and
+changes checks over time** — so treat this list as representative, not
+exhaustive. The authoritative, always-current set for *your* cluster comes from
+`--show-passing` (each row prints a short ID you can pass to `--id`):
+
+```bash
+refresh cluster upgrade-check -c prod-east --show-passing
+```
+
+Common `UPGRADE_READINESS` checks:
+
+- **Deprecated APIs** — workloads calling Kubernetes APIs removed in the target
+  version. Conditional (only appears when EKS detects such usage) and named for
+  the version, e.g. *"Deprecated APIs removed in 1.33"*. The detail view (`--id`)
+  names the calling clients (user agent, last-seen, 30-day request count).
+- **Kubelet version skew** / **kube-proxy version skew** — node components too
+  far behind the control plane to upgrade safely.
+- **EKS add-on version compatibility** — installed add-ons vs. the target version.
+- **Amazon Linux 2 compatibility** — nodes on AL2 (end-of-life; no AMIs for newer versions).
+- **Cluster health issues** — control-plane health problems that would block an upgrade.
+
+A second category, `MISCONFIGURATION` (`--category MISCONFIGURATION`), covers
+EKS Hybrid Nodes.
+
+Drill into any insight with `--id` — it accepts the **short ID** from the table,
+the full insight ID, or a **case-insensitive name substring**:
+
+```bash
+refresh cluster upgrade-check -c prod-east --id "deprecated"   # by name
+refresh cluster upgrade-check -c prod-east --id bc8b2f86       # by short ID
+```
+
 ### Flags
 
 | Flag | Description |
@@ -125,7 +159,7 @@ with ordered, actionable findings.
 | `--category` | Insight category: `UPGRADE_READINESS` (default), `MISCONFIGURATION` |
 | `--status` | Filter by insight status: `PASSING`, `WARNING`, `ERROR`, `UNKNOWN` (repeatable) |
 | `--show-passing` | Include `PASSING` insights (hidden by default) |
-| `--id` | Show the detail view (recommendation + resources) for a single insight ID |
+| `--id` | Show the detail view for one insight — accepts its short ID (from the table), full ID, or a case-insensitive name substring |
 | `--format, -o` | `table` (default), `json`, `yaml`, `plain` |
 | `--timeout, -t` | Operation timeout (env `REFRESH_TIMEOUT`) |
 
@@ -138,8 +172,8 @@ refresh cluster upgrade-check -c prod-east
 # Include passing checks, as JSON for a gate
 refresh cluster upgrade-check -c prod-east --show-passing -o json
 
-# Drill into one insight
-refresh cluster upgrade-check -c prod-east --id <insight-id>
+# Drill into one insight (by name, short ID, or full ID)
+refresh cluster upgrade-check -c prod-east --id "deprecated"
 ```
 
 ---

--- a/docs/reference/cluster.md
+++ b/docs/reference/cluster.md
@@ -106,10 +106,15 @@ local version-skew picture: control-plane version vs each managed nodegroup, and
 installed addons vs the latest compatible version — with ordered, actionable
 findings. Nothing is mutated; this is the pre-flight read before 'cluster upgrade'.
 
+Insights are defined and computed by EKS (the same set the console shows), and
+that catalog evolves — so list the live set for your cluster with --show-passing,
+then drill into any with --id, which accepts the short ID shown in the table, the
+full ID, or a case-insensitive name substring (e.g. --id "deprecated").
+
 Examples:
    refresh cluster upgrade-check -c prod-east
    refresh cluster upgrade-check -c prod-east --show-passing -o json
-   refresh cluster upgrade-check -c prod-east --id <insight-id>   # detail view
+   refresh cluster upgrade-check -c prod-east --id "deprecated"   # detail view (by name)
 
 #### Flags
 

--- a/internal/commands/cluster/upgradecheck.go
+++ b/internal/commands/cluster/upgradecheck.go
@@ -28,10 +28,15 @@ local version-skew picture: control-plane version vs each managed nodegroup, and
 installed addons vs the latest compatible version — with ordered, actionable
 findings. Nothing is mutated; this is the pre-flight read before 'cluster upgrade'.
 
+Insights are defined and computed by EKS (the same set the console shows), and
+that catalog evolves — so list the live set for your cluster with --show-passing,
+then drill into any with --id, which accepts the short ID shown in the table, the
+full ID, or a case-insensitive name substring (e.g. --id "deprecated").
+
 Examples:
    refresh cluster upgrade-check -c prod-east
    refresh cluster upgrade-check -c prod-east --show-passing -o json
-   refresh cluster upgrade-check -c prod-east --id <insight-id>   # detail view`,
+   refresh cluster upgrade-check -c prod-east --id "deprecated"   # detail view (by name)`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "cluster", Aliases: []string{"c"}, Usage: "EKS cluster name or pattern"},
 			&cli.DurationFlag{Name: "timeout", Aliases: []string{"t"}, Usage: "Operation timeout (e.g. 60s, 2m)", Value: appconfig.DefaultTimeout, Sources: cli.EnvVars("REFRESH_TIMEOUT")},


### PR DESCRIPTION
Follow-up to REF-149 — answers "how does a user know what can be passed to `--id`?", weighted toward the live list so nothing goes stale.

## Help (`cluster upgrade-check -h`)
Description now explains: insights are EKS-defined and the catalog evolves → list the live set for your cluster with `--show-passing`, then drill in with `--id` (short ID / full ID / **name substring**). Example updated to `--id "deprecated"`.

## Docs (`docs/commands/cluster.md`)
New **"Upgrade-readiness checks"** section:
- `--show-passing` is called out as the **authoritative, always-current** source (each row shows a short ID).
- A **representative** list of the common checks — Deprecated APIs (conditional, version-named), kubelet / kube-proxy version skew, add-on compatibility, Amazon Linux 2 compatibility, cluster health — with an explicit **caveat that AWS owns and evolves the catalog**, so it's illustrative, not exhaustive.
- Notes the second `MISCONFIGURATION` category.
- `--id` flag row + examples updated to show name/short-ID drilling.

## Why pointer-weighted
The UUIDs are per-cluster and the catalog changes, so the durable answer is the live `--show-passing` list + name matching; the enumerated names are a newcomer aid, clearly marked as such.

Reference docs regenerated for the new Description; `build`/`vet`/`test`/`lint`/docs-drift clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)