### PR TITLE
chore(deps): bump pymdown-extensions to 11.0.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -384,15 +384,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Supersedes #72 (Dependabot's 10.21.3 → 11.0) by going one patch further to **11.0.1**.

#72 was flagged for manual review because it's a major bump — correctly, since auto-merge only takes patch/minor. This is that review.

## Is the major bump actually breaking?

No. The 11.0 changelog has exactly one `BREAK` entry, and it's scoped to `pymdownx.b64`:

> **BREAK**: B64: Restricts relative links to `base_path` by default. Can be disabled by setting new `restrict_path` option to `False`.

We don't enable `b64`. Comparing tags `10.21.3...11.0`, the only extension sources that changed at all were `b64.py`, `tabbed.py` (+2/-2, empty-title crash fix), `snippets.py` (+1/-1), and `blocks/tab.py` (+1/-1). Everything else was CI and test churn.

All nine extensions we configure keep their options and output: `details`, `highlight` (`anchor_linenums`, `line_spans`, `pygments_lang_class`), `inlinehilite`, `keys`, `snippets` (`base_path`, `check_paths`), `superfences`, `tabbed` (`alternate_style` still exists and still defaults to `False` — not removed, not the new default), `tasklist` (`custom_checkbox`), and `emoji` (`emoji.py` is byte-identical; the Material `twemoji`/`to_svg` integration is untouched).

## Verified, not assumed

Built the site with `--strict` on both versions and diffed the output:

```
10.21.3 → /tmp/site-baseline
11.0.1  → /tmp/site-new

file inventory   identical
differing files  0
```

**Byte-for-byte identical rendered site.** Both builds pass `mkdocs build --strict` with no new warnings.

`task dev:full` also passes (fmt + vet + lint + test + build) — expected, as this is a docs-only dependency with no Go surface.

## Compatibility

- 11.0 drops Python 3.9; `pyproject.toml` already requires `>=3.11`.
- mkdocs-material declares `pymdown-extensions>=10.2` with **no upper bound**, so the `mkdocs-material>=9.5,<10` constraint is unaffected.
- `Markdown>=3.6` requirement is unchanged from 10.21.3.

## Why 11.0.1 rather than Dependabot's 11.0

11.0.1 adds regex-efficiency fixes for BetterEm, Tilde, Caret, and MagicLink at no config cost. Taking it now avoids a follow-up Dependabot PR.

Closes #72.