### PR TITLE
ci: make Go module bumps cut a patch release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,14 @@ updates:
       - "dantech2000"
     assignees:
       - "dantech2000"
+    # `fix` on purpose: Go modules are compiled into the shipped binary, so a
+    # bump IS user-facing. `include: scope` appends a literal "(deps)", giving
+    # `fix(deps): bump ...` — the only prefix here that release-please treats as
+    # releasable, so dependency merges cut a patch release. (Dropped the old
+    # `deps` prefix: it produced `deps(deps):`, which release-please ignores,
+    # and `prefix-development`, which gomod does not support at all.)
     commit-message:
-      prefix: "deps"
-      prefix-development: "deps(dev)"
+      prefix: "fix"
       include: "scope"
     labels:
       - "dependencies"
@@ -44,6 +49,9 @@ updates:
       - "dantech2000"
     assignees:
       - "dantech2000"
+    # Deliberately NOT `fix`: action bumps only touch CI, never the released
+    # binary, so they must not cut a release. `ci` is absent from
+    # release-please-config.json's changelog-sections, so these are inert.
     commit-message:
       prefix: "ci"
       include: "scope"
@@ -53,7 +61,12 @@ updates:
 
   # Docs site Python deps (Material for MkDocs) — keep the hash-locked tree
   # reviewed rather than silently floating. (REF-107)
-  - package-ecosystem: "pip"
+  #
+  # Must be `uv`, not `pip`: they are separate ecosystems, and `pip` does not
+  # cover a uv.lock tree. With only a `pip` block here, the uv job ran with NO
+  # commit-message config and Dependabot inferred `chore(deps):` from git
+  # history instead — which is exactly what PR #72 was titled.
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -64,8 +77,12 @@ updates:
       - "dantech2000"
     assignees:
       - "dantech2000"
+    # `docs`, not `fix`: MkDocs deps build the docs site, not the CLI binary,
+    # so they must not cut a release. Also not `deps(docs)` — a prefix that
+    # already contains a scope collides with `include: scope` and yields the
+    # unparseable `deps(docs)(deps):`.
     commit-message:
-      prefix: "deps(docs)"
+      prefix: "docs"
       include: "scope"
     labels:
       - "dependencies"


### PR DESCRIPTION
Dependency merges have never produced a release. Root cause turned out to be **two** config bugs, neither of which was the squash-commit title I initially suspected.

## Bug 1 — Go bumps were never releasable

```yaml
prefix: "deps"
include: "scope"     # appends a literal "(deps)" AFTER the prefix
```

produces:

```
deps(deps): bump github.com/aws/... from 1.2.3 to 1.2.4
```

`deps` isn't a conventional-commit type release-please recognizes under `release-type: simple`. The README's "a releasable unit is `feat`, `fix`, and `deps`" only holds for the **java** strategy, which defines a `deps` changelog section — `simple` doesn't. So every Go bump ever merged cut no release.

`prefix-development: "deps(dev)"` was doubly dead: it would emit `deps(dev)(deps-dev):`, and `gomod` doesn't support `prefix-development` at all.

## Bug 2 — the docs block wasn't governing the docs deps

`pip` and `uv` are **separate ecosystems**, and `pip` doesn't cover a `uv.lock` tree. With only a `pip` block, the uv job ran with *no* commit-message config, so Dependabot inferred a prefix from git history — it saw `chore*` commits and no `build*`, and produced `chore(deps): `. Byte-for-byte the title on #72.

Its configured `deps(docs)` prefix was self-colliding anyway: a prefix that already contains a scope plus `include: scope` yields the unparseable `deps(docs)(deps):`.

## Why release-please skipped

The gate isn't a `feat`/`fix` allowlist — it renders the changelog and bails if empty:

```ts
if (this.changelogEmpty(releaseNotesBody)) {
  this.logger.info(`No user facing commits found since ${...} - skipping`);
```

A commit is dropped if its type is `hidden: true` **or absent from `changelog-sections` entirely** (the array *replaces* the defaults, it doesn't merge). `chore(deps)` → hidden; `ci:` → absent. Empty body → skip.

## After this change

| ecosystem | commit | result |
|---|---|---|
| `gomod` | `fix(deps): bump ...` | **patch release** |
| `github-actions` | `ci(deps): bump ...` | no release |
| `uv` | `docs(deps): bump ...` | no release |

Verified by cross-checking the new prefixes against `release-please-config.json` — visible types are `feat`, `fix`, `perf`, `refactor`, so only `fix(deps)` passes the gate.

The split is deliberate: **Go modules compile into the shipped binary**, so a bump is genuinely user-facing — see the `x/text` and `crypto/tls` CVEs in c9b53fb, which reached `main` but never reached a released binary. Action and MkDocs bumps never touch the binary; making those `fix` would cut spurious releases on every weekly batch.

This won't spam releases — release-please amends a *single* open release PR until merged, so a week of dep merges accumulates into one patch.

## Scope

Forward-looking only. It does **not** retroactively release the CVE fix already on `main`; `v0.9.0` binaries remain built against the vulnerable `x/text` and `go1.26.4` until something cuts 0.9.1.