### PR TITLE
fix(ci): repair invalid dependabot.yml allow block

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,14 +24,14 @@ updates:
     labels:
       - "dependencies"
       - "go"
-    # Auto-merge patch and minor updates for Go modules
+    # `allow` accepts only dependency-name / dependency-type — it cannot filter
+    # by update type, and the `update-type` keys that used to live here made the
+    # WHOLE file unparseable, so none of it applied. Patch/minor gating is
+    # enforced where it actually belongs: auto-merge.yml reads update-type from
+    # dependabot/fetch-metadata and only merges patch and minor.
     allow:
       - dependency-type: "direct"
-        update-type: "version-update:semver-patch"
-      - dependency-type: "direct"  
-        update-type: "version-update:semver-minor"
       - dependency-type: "indirect"
-        update-type: "version-update:semver-patch"
     ignore:
       # Ignore major version updates for critical dependencies
       - dependency-name: "github.com/aws/aws-sdk-go-v2/*"


### PR DESCRIPTION
GitHub's Dependabot config validator has been **rejecting the entire file**, and it surfaced only because #75 happened to touch `.github/dependabot.yml` — that check runs on nothing else.

```
The property '#/updates/0/allow/0' contains additional properties
["update-type"] outside of the schema when none are allowed
```
(same for `/allow/1` and `/allow/2`)

## The bug

`allow` accepts only `dependency-name` and `dependency-type`. It **cannot** filter by update type — that's `ignore` + `update-types` (plural). The three `update-type` keys were invalid, and since this is a parse error it invalidated the **whole file**, not just that block.

This is pre-existing; it predates tonight's work and was never introduced by #75.

## Why it matters more than it looks

Two consequences:

1. The original intent — "auto-merge patch and minor updates for Go modules" — was never actually expressed. `allow` can't do that.
2. **The prefix fix in #75 could not have taken effect.** An unparseable config is ignored wholesale, which is a second, independent explanation for Dependabot falling back to the inferred `chore(deps)` prefix on #72 — alongside the missing `uv` block.

So #75 was necessary but not sufficient. This is the other half.

## The fix

```yaml
allow:
  - dependency-type: "direct"
  - dependency-type: "indirect"
```

Patch/minor gating isn't lost — `auto-merge.yml` already reads `update-type` from `dependabot/fetch-metadata` and merges only `semver-patch` and `semver-minor`. That's the real gate, and it's the correct place for it. Major bumps still get the "requires manual review" comment.

## Verification

Validated `allow`/`ignore` entries against the documented schema:

```
allow/ignore schema OK
  gomod            fix(deps):
  github-actions   ci(deps):
  uv               docs(deps):
```

The authoritative confirmation is the `.github/dependabot.yml` check on this PR — it must go green, since it's the same validator that's currently failing.