### PR TITLE
fix(ci): merge Dependabot PRs as a user so CI and releases trigger

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -65,13 +65,20 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           timeoutSeconds: 900
 
+      # GH_PAT, not GITHUB_TOKEN, and ONLY on this step. GitHub does not trigger
+      # workflows from pushes made with GITHUB_TOKEN (its recursion guard), so
+      # merging with it lands dep bumps on main with NO Test/Lint run and NO
+      # Release Please run — meaning `fix(deps)` commits never cut a release.
+      # Merging as a real user restores both. release-please.yml uses GH_PAT for
+      # the same reason. Every other step here stays on the scoped, auto-rotating
+      # GITHUB_TOKEN — they only read metadata and checks.
       - name: Auto-merge Dependabot PR
         if: |
           steps.check.outputs.eligible == 'true' &&
           steps.wait-test.outputs.conclusion == 'success' &&
           steps.wait-lint.outputs.conclusion == 'success'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           echo "Test + Lint passed. Auto-merging Dependabot PR..."
           gh pr merge ${{ github.event.pull_request.number }} --auto --squash --delete-branch


### PR DESCRIPTION
Auto-merge was fixed in #73 and genuinely works — `fetch-metadata` now returns `update-type` correctly. But it merges with `secrets.GITHUB_TOKEN`, and **GitHub does not trigger workflows from pushes made with `GITHUB_TOKEN`** (its recursion guard).

## Impact — two silent failures

```
$ gh pr view 81 --json mergedBy       -> app/github-actions
$ gh run list --commit fb059dc        -> (empty)
$ gh run list --commit 698e701        -> (empty)
$ gh run list --commit b368ce3        -> (empty)
```

1. **`main` goes untested after every dep bump.** #80, #81, #86, #88, #90, #95 all merged with zero Test/Lint/govulncheck runs against the resulting commits. A bad bump would land silently.
2. **`fix(deps)` commits never cut a release.** This defeats #75/#77 entirely — the prefix is correct, but Release Please is never invoked to act on it. The gap that left the `x/text` and `crypto/tls` CVEs unreleased is still open.

## Fix

Switch **only** the merge step to `GH_PAT`, so the merge is attributed to a real user and downstream workflows fire. `release-please.yml:23` already uses `GH_PAT` for precisely this reason.

The other four steps stay on the scoped, auto-rotating `GITHUB_TOKEN` — they only read Dependabot metadata and check results, so there's no reason to widen their credentials. This keeps the long-lived PAT's blast radius to a single step.

## Trade-off

A PAT is long-lived and broadly scoped versus `GITHUB_TOKEN`'s auto-rotation. The alternative is dropping auto-merge and reviewing dep PRs by hand. Given auto-merge is already gated on Test **and** Lint passing, and restricted to patch/minor via `fetch-metadata`, the PAT is scoped to the narrowest possible step here.

## Verification

Since CI never ran on those merged bumps, I validated current `main` locally:

```
task dev:full     ✅ passed (fmt + vet + lint + test + build)
govulncheck ./... No vulnerabilities found.
```

`main` is healthy — the missing runs hadn't masked a real break.

The real proof is the next Dependabot auto-merge: Test, Lint, and Release Please should all run on the resulting `main` commit, and a `0.9.2` release PR should appear on its own.