### PR TITLE
fix(ci): merge Dependabot PRs directly instead of via --auto

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -80,8 +80,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          echo "Test + Lint passed. Auto-merging Dependabot PR..."
-          gh pr merge ${{ github.event.pull_request.number }} --auto --squash --delete-branch
+          echo "Test + Lint passed. Merging Dependabot PR..."
+          # A direct merge, NOT `--auto`. GitHub's auto-merge is disabled on this
+          # repo (allow_auto_merge=false), so `--auto` failed with "Auto merge is
+          # not allowed for this repository (enablePullRequestAutoMerge)" whenever
+          # the PR was not already mergeable — which is why dep PRs piled up.
+          # Enabling the repo setting would be the other fix, but it is worse: with
+          # no branch protection there are no REQUIRED checks, so repo-wide
+          # auto-merge would merge any PR the moment it is mergeable, checks or not.
+          # We do not need it — the two wait-for-check gates above already prove
+          # Test and Lint passed before we get here, so merging now is equivalent
+          # and fails loudly on conflict instead of queueing silently.
+          gh pr merge ${{ github.event.pull_request.number }} --squash --delete-branch
 
       - name: Comment on non-eligible PR
         if: steps.check.outputs.eligible == 'false'


### PR DESCRIPTION
Follow-up to #99. That fixed *attribution*; this fixes the merge actually succeeding.

## The error

```
GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)
```

```json
$ gh api repos/dantech2000/refresh --jq '{allow_auto_merge}'
{"allow_auto_merge": false}
```

GitHub's auto-merge feature is **disabled on this repo**, so `gh pr merge --auto` only ever worked by accident — when a PR happened to be fully green and mergeable at that instant, `gh` merged it directly; otherwise the call errored. That's precisely the observed mix of `success` and `failure` runs, and why #82–#95 piled up with `autoMerge=no`.

## Why not just enable the repo setting

Because there's **no branch protection**, so there are no *required* status checks. Repo-wide auto-merge would merge any PR the moment it became mergeable, whether or not CI had run — a footgun well beyond Dependabot.

We don't need it. The two `wait-for-check` gates already block until `Run go test` and `Run golangci-lint` report success, and the merge step's `if` requires both conclusions to be `success`. By the time execution reaches the merge, checks have demonstrably passed. A direct merge is equivalent in safety, and it fails loudly on conflict instead of queueing silently forever.

## Evidence the combined fix works

| commit | how merged | workflows triggered |
|---|---|---|
| `ab21bd1` (#99) | manually, as a user | `Test`, `Lint`, `Release Please` ✅ |
| `37f1d0f` (#100) | auto-merged, old token | none ❌ |

#99's `GH_PAT` gives correct attribution; this PR makes the merge call succeed in the first place. Together the full path works: **bump merged as a real user → Test/Lint/Release Please fire on `main` → `fix(deps)` cuts a patch release.**

## Verification

```
command: gh pr merge ${{ ... }} --squash --delete-branch
has --auto flag: False
token: ${{ secrets.GH_PAT }}
```

The real proof is the next Dependabot PR: it should merge cleanly, and the resulting `main` commit should show `Test`, `Lint`, and `Release Please` runs.