### PR TITLE
feat(noderoll): watch-backed live roll view via informers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,12 @@ real time (nodes draining/joining/terminating) from live Kubernetes Node state â
 the per-node truth EKS's coarse `DescribeUpdate` can't give. `KubeObserver`
 scopes by the `eks.amazonaws.com/nodegroup` label and classifies by Ready /
 cordon-or-drain-taint, with old-vs-new from either the `nodegroup-image` AMI
-label or a roll-start `CaptureBaseline`. `Tracker` diffs snapshots into a
+label or a roll-start `CaptureBaseline`. It is watch-backed when possible
+(`StartInformers`: one informer stream per resource, snapshots read the local
+cache) and falls back to per-poll List calls when informers can't start â€” the
+watch is an upgrade, never a requirement. Note this applies only to the
+repeatedly-polled live view; one-shot reads (pre-flight health checks,
+`--check-pdbs`, post-roll verify) correctly stay as single List calls. `Tracker` diffs snapshots into a
 lifecycle event feed. Testable with **zero AWS / zero cluster** via
 `client-go/kubernetes/fake` (see `observer_test.go`) and a `ScriptedObserver`
 (`DemoTimeline`). `refresh nodegroup update --simulate` (hidden flag) drives the

--- a/docs/commands/cluster.md
+++ b/docs/commands/cluster.md
@@ -223,6 +223,11 @@ with the hop target) → nodegroup rolls.
     A dry-run (or any run) whose plan contains a **blocker** prints the plan and
     exits non-zero without mutating — handy as a readiness gate in CI.
 
+!!! note "Kubernetes access for the live roll view"
+    The nodegroup phase renders the same live per-node roll panel as
+    [`nodegroup update`](nodegroup.md#update); see that page for the Kubernetes
+    RBAC it uses (`list` on nodes/pods/events, plus `watch` for streaming).
+
 ### Examples
 
 ```bash

--- a/docs/commands/nodegroup.md
+++ b/docs/commands/nodegroup.md
@@ -192,6 +192,16 @@ refresh nodegroup update --all-clusters -r us-east-1 --yes   # execute in one re
     Without a TTY **and** without `--yes`, a run that would otherwise prompt
     fails fast. For cron, pair `--yes` with `--require-healthy` and `-o json`.
 
+!!! note "Kubernetes access for the live roll view"
+    During a roll, `refresh` renders a live per-node panel (draining / joining /
+    Ready, pod-eviction progress, Warning events) read from the Kubernetes API
+    via `--kubeconfig`. It needs the `list` verb on nodes, pods, and events;
+    granting `watch` as well upgrades it to streaming, so node transitions
+    appear as they happen instead of on the next poll. Access is optional and
+    degrades gracefully: without `watch` the panel polls, and without any
+    Kubernetes access the roll still runs — you just get the coarse EKS update
+    status instead of per-node detail.
+
 ### Exit-code contract
 
 `nodegroup update` returns a meaningful exit code so unattended runs can branch:

--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,8 @@ github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcY
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=
 go.yaml.in/yaml/v2 v2.4.4/go.mod h1:gMZqIpDtDqOfM0uNfy0SkpRhvUryYH0Z6wdMYcacYXQ=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=

--- a/internal/noderoll/informer.go
+++ b/internal/noderoll/informer.go
@@ -1,0 +1,92 @@
+package noderoll
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// informerSyncTimeout bounds the initial cache sync in StartInformers. A var
+// (not const) so tests can shrink it.
+var informerSyncTimeout = 10 * time.Second
+
+// informerSet holds cache-backed listers fed by long-lived watch streams — the
+// push-based alternative to issuing List calls on every Snapshot.
+type informerSet struct {
+	nodes  corelisters.NodeLister
+	pods   corelisters.PodLister
+	events corelisters.EventLister
+	stop   context.CancelFunc
+}
+
+// StartInformers switches the observer from per-Snapshot List calls to shared
+// informers: one watch stream per resource (nodes, pods, Warning events), with
+// every Snapshot read served from the informer's local cache. Changes arrive
+// as they happen instead of on the next poll, and the repeated cluster-wide
+// pod List — the expensive call on large clusters — collapses into a single
+// stream. On error (e.g. credentials whose RBAC grants list but not watch) the
+// observer is unchanged and keeps its polling behavior; callers treat watch as
+// an upgrade, never a requirement. Callers must StopInformers when done.
+func (o *KubeObserver) StartInformers(ctx context.Context) error {
+	if o.inf != nil {
+		return nil
+	}
+	stopCtx, cancel := context.WithCancel(ctx)
+
+	nodeFactory := informers.NewSharedInformerFactoryWithOptions(o.client, 0,
+		informers.WithTweakListOptions(func(lo *metav1.ListOptions) {
+			lo.LabelSelector = LabelNodegroup + "=" + o.nodegroup
+		}))
+	// Pods and events need their own factories: a factory's tweak applies to
+	// every informer it creates, and the nodegroup label above only exists on
+	// Nodes.
+	podFactory := informers.NewSharedInformerFactoryWithOptions(o.client, 0)
+	eventFactory := informers.NewSharedInformerFactoryWithOptions(o.client, 0,
+		informers.WithTweakListOptions(func(lo *metav1.ListOptions) {
+			lo.FieldSelector = "type=" + corev1.EventTypeWarning
+		}))
+
+	nodes := nodeFactory.Core().V1().Nodes()
+	pods := podFactory.Core().V1().Pods()
+	events := eventFactory.Core().V1().Events()
+	synced := []cache.InformerSynced{
+		nodes.Informer().HasSynced,
+		pods.Informer().HasSynced,
+		events.Informer().HasSynced,
+	}
+
+	nodeFactory.Start(stopCtx.Done())
+	podFactory.Start(stopCtx.Done())
+	eventFactory.Start(stopCtx.Done())
+
+	syncCtx, syncCancel := context.WithTimeout(stopCtx, informerSyncTimeout)
+	defer syncCancel()
+	if !cache.WaitForCacheSync(syncCtx.Done(), synced...) {
+		cancel()
+		return errors.New("informer caches did not sync")
+	}
+
+	o.inf = &informerSet{
+		nodes:  nodes.Lister(),
+		pods:   pods.Lister(),
+		events: events.Lister(),
+		stop:   cancel,
+	}
+	return nil
+}
+
+// StopInformers tears down the watch streams started by StartInformers and
+// returns the observer to polling. Safe to call when informers were never
+// started (or already stopped).
+func (o *KubeObserver) StopInformers() {
+	if o.inf != nil {
+		o.inf.stop()
+		o.inf = nil
+	}
+}

--- a/internal/noderoll/informer_test.go
+++ b/internal/noderoll/informer_test.go
@@ -1,0 +1,152 @@
+package noderoll
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// waitForSnapshot polls obs until pred(snapshot) holds — fake-clientset watch
+// events propagate to informer caches asynchronously, so tests must wait for
+// the cache rather than assert immediately after a mutation.
+func waitForSnapshot(t *testing.T, obs Observer, pred func(Snapshot) bool) Snapshot {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last Snapshot
+	for time.Now().Before(deadline) {
+		s, err := obs.Snapshot(context.Background())
+		if err != nil {
+			t.Fatalf("snapshot: %v", err)
+		}
+		if pred(s) {
+			return s
+		}
+		last = s
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("snapshot never matched predicate; last = %+v", last)
+	return Snapshot{}
+}
+
+// TestKubeObserver_InformerRollTransitions mirrors the polling roll-transition
+// test but serves every snapshot from informer caches: the same per-node
+// truths must surface, arriving via watch events instead of List calls.
+func TestKubeObserver_InformerRollTransitions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	other := mkNode("ip-other", newAMI, true, false)
+	other.Labels[LabelNodegroup] = "general"
+	client := fake.NewClientset(
+		mkNode("ip-1", oldAMI, true, false),
+		mkNode("ip-2", oldAMI, true, false),
+		mkNode("ip-3", oldAMI, true, false),
+		other,
+	)
+	obs := NewKubeObserver(client, ng, newAMI)
+	if err := obs.StartInformers(ctx); err != nil {
+		t.Fatalf("StartInformers: %v", err)
+	}
+	defer obs.StopInformers()
+
+	// t0: steady state — 3 old-AMI nodes; ip-other excluded by the label-scoped
+	// node informer.
+	s := waitForSnapshot(t, obs, func(s Snapshot) bool { return s.Total == 3 })
+	if s.ReadyTarget != 0 {
+		t.Fatalf("ReadyTarget = %d, want 0 (all still on old AMI)", s.ReadyTarget)
+	}
+
+	// t1: surge a new node (joining) and cordon an old one (draining); the
+	// changes must reach snapshots without any further List calls.
+	if _, err := client.CoreV1().Nodes().Create(ctx, mkNode("ip-4", newAMI, false, false), metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	cordon(ctx, t, client, "ip-1")
+
+	s = waitForSnapshot(t, obs, func(s Snapshot) bool {
+		return s.Total == 4 && s.Draining == 1 && s.Joining == 1
+	})
+	if got := phaseOf(s, "ip-1"); got != PhaseDraining {
+		t.Fatalf("ip-1 phase = %s, want Draining", got)
+	}
+	if got := phaseOf(s, "ip-4"); got != PhaseJoining {
+		t.Fatalf("ip-4 phase = %s, want Joining", got)
+	}
+
+	// t2: new node Ready; drained node terminated.
+	setReady(ctx, t, client, "ip-4")
+	if err := client.CoreV1().Nodes().Delete(ctx, "ip-1", metav1.DeleteOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	s = waitForSnapshot(t, obs, func(s Snapshot) bool {
+		return s.Total == 3 && s.ReadyTarget == 1 && s.Draining == 0 && s.Joining == 0
+	})
+	if v := nodeOf(s, "ip-4"); !v.OnTarget || v.Phase != PhaseReady {
+		t.Fatalf("ip-4 = %+v, want OnTarget Ready", v)
+	}
+}
+
+// TestKubeObserver_InformerWarningsAndEviction verifies the cache-backed paths
+// for the secondary reads: Warning events scoped to the nodegroup's nodes and
+// pod-eviction progress on a draining node.
+func TestKubeObserver_InformerWarningsAndEviction(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	now := metav1.NewTime(time.Now())
+	client := fake.NewClientset(
+		mkNode("ip-1", oldAMI, true, true), // cordoned → Draining
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "web-a", Namespace: "default"},
+			Spec:       corev1.PodSpec{NodeName: "ip-1"},
+		},
+		&corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Name: "e1", Namespace: "default"},
+			Type:           "Warning",
+			Reason:         "FailedDraining",
+			Message:        "Cannot evict pod as it would violate the pod's disruption budget",
+			InvolvedObject: corev1.ObjectReference{Kind: "Node", Name: "ip-1"},
+			LastTimestamp:  now,
+		},
+	)
+	obs := NewKubeObserver(client, ng, newAMI)
+	if err := obs.StartInformers(ctx); err != nil {
+		t.Fatalf("StartInformers: %v", err)
+	}
+	defer obs.StopInformers()
+
+	s := waitForSnapshot(t, obs, func(s Snapshot) bool {
+		return s.Draining == 1 && len(s.Warnings) == 1
+	})
+	if s.Warnings[0].Node != "ip-1" || s.Warnings[0].Reason != "FailedDraining" {
+		t.Errorf("warning = %+v, want ip-1/FailedDraining", s.Warnings[0])
+	}
+	if v := nodeOf(s, "ip-1"); v.Pods != 1 || v.PodsTotal != 1 {
+		t.Errorf("ip-1 eviction = %d/%d, want 1/1", v.Pods, v.PodsTotal)
+	}
+}
+
+// TestStopInformers_Idempotent guards the teardown paths: stop without start,
+// double stop, and reads after stop (which must fall back to List calls).
+func TestStopInformers_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewClientset(mkNode("ip-1", oldAMI, true, false))
+	obs := NewKubeObserver(client, ng, newAMI)
+
+	obs.StopInformers() // never started
+	if err := obs.StartInformers(ctx); err != nil {
+		t.Fatalf("StartInformers: %v", err)
+	}
+	obs.StopInformers()
+	obs.StopInformers() // double stop
+
+	s, err := obs.Snapshot(ctx)
+	if err != nil || s.Total != 1 {
+		t.Fatalf("post-stop snapshot = %+v, %v; want 1 node via List fallback", s, err)
+	}
+}

--- a/internal/noderoll/observer.go
+++ b/internal/noderoll/observer.go
@@ -17,6 +17,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -96,6 +97,9 @@ type KubeObserver struct {
 	// drainStart remembers the evictable-pod count when a node first appears
 	// Draining, so the panel can show evicted/total as pods leave.
 	drainStart map[string]int
+	// inf, when set (StartInformers), serves reads from informer caches fed by
+	// watch streams instead of issuing List calls per snapshot.
+	inf *informerSet
 }
 
 // NewKubeObserver returns an Observer for nodegroup, treating targetAMI as the
@@ -108,32 +112,49 @@ func NewKubeObserver(client kubernetes.Interface, nodegroup, targetAMI string) *
 // nodes appearing afterward count as the new (on-target) nodes — for live rolls
 // where the target AMI ID isn't known in advance.
 func (o *KubeObserver) CaptureBaseline(ctx context.Context) error {
+	nodes, err := o.listNodes(ctx)
+	if err != nil {
+		return err
+	}
+	o.baseline = make(map[string]bool, len(nodes))
+	for _, n := range nodes {
+		o.baseline[n.Name] = true
+	}
+	return nil
+}
+
+// listNodes returns the nodegroup's nodes: from the informer cache when
+// watching, else via a label-scoped List call.
+func (o *KubeObserver) listNodes(ctx context.Context) ([]*corev1.Node, error) {
+	if o.inf != nil {
+		// The node informer's cache is already scoped to the nodegroup by its
+		// factory's label-selector tweak.
+		return o.inf.nodes.List(labels.Everything())
+	}
 	list, err := o.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{
 		LabelSelector: LabelNodegroup + "=" + o.nodegroup,
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
-	o.baseline = make(map[string]bool, len(list.Items))
+	nodes := make([]*corev1.Node, len(list.Items))
 	for i := range list.Items {
-		o.baseline[list.Items[i].Name] = true
+		nodes[i] = &list.Items[i]
 	}
-	return nil
+	return nodes, nil
 }
 
 // Snapshot lists the nodegroup's nodes and classifies each. Nodes from other
 // nodegroups are excluded by the label selector.
 func (o *KubeObserver) Snapshot(ctx context.Context) (Snapshot, error) {
-	list, err := o.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{
-		LabelSelector: LabelNodegroup + "=" + o.nodegroup,
-	})
+	nodes, err := o.listNodes(ctx)
 	if err != nil {
 		return Snapshot{}, err
 	}
 
 	var snap Snapshot
-	for i := range list.Items {
-		v := classify(&list.Items[i], o.targetAMI, o.baseline)
+	for _, n := range nodes {
+		v := classify(n, o.targetAMI, o.baseline)
 		snap.Nodes = append(snap.Nodes, v)
 		snap.Total++
 		switch v.Phase {
@@ -153,9 +174,9 @@ func (o *KubeObserver) Snapshot(ctx context.Context) (Snapshot, error) {
 	}
 
 	// Best-effort Warning events scoped to this nodegroup's nodes.
-	nodeSet := make(map[string]bool, len(list.Items))
-	for i := range list.Items {
-		nodeSet[list.Items[i].Name] = true
+	nodeSet := make(map[string]bool, len(nodes))
+	for _, n := range nodes {
+		nodeSet[n.Name] = true
 	}
 	o.fillWarnings(ctx, &snap, nodeSet)
 
@@ -172,27 +193,48 @@ const warningWindow = 10 * time.Minute
 // nodes. Best-effort: a list failure leaves Warnings empty (the panel omits the
 // section) rather than failing the snapshot.
 func (o *KubeObserver) fillWarnings(ctx context.Context, snap *Snapshot, nodeSet map[string]bool) {
+	events, err := o.listWarningEvents(ctx)
+	if err != nil {
+		return
+	}
+	snap.Warnings = scopeWarnings(events, nodeSet, time.Now(), warningWindow)
+}
+
+// listWarningEvents returns cluster Warning events: from the informer cache
+// when watching (its factory tweak pre-filters to type=Warning), else via a
+// bounded List call.
+func (o *KubeObserver) listWarningEvents(ctx context.Context) ([]corev1.Event, error) {
+	if o.inf != nil {
+		ptrs, err := o.inf.events.List(labels.Everything())
+		if err != nil {
+			return nil, err
+		}
+		events := make([]corev1.Event, len(ptrs))
+		for i := range ptrs {
+			events[i] = *ptrs[i]
+		}
+		return events, nil
+	}
 	evList, err := o.client.CoreV1().Events(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
 		FieldSelector: "type=Warning",
 		Limit:         200,
 	})
 	if err != nil {
-		return
+		return nil, err
 	}
-	snap.Warnings = scopeWarnings(evList.Items, nodeSet, time.Now(), warningWindow)
+	return evList.Items, nil
 }
 
 // fillPodEviction counts the evictable pods on each draining node and records
 // the count at drain start, so the panel can show evicted/total. Best-effort:
 // a list failure leaves the pod fields zero (the panel just omits the bar).
 func (o *KubeObserver) fillPodEviction(ctx context.Context, snap *Snapshot) {
-	pods, err := o.client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	pods, err := o.listPods(ctx)
 	if err != nil {
 		return
 	}
 	counts := make(map[string]int)
-	for i := range pods.Items {
-		p := &pods.Items[i]
+	for _, p := range pods {
 		if isEvictablePod(p) {
 			counts[p.Spec.NodeName]++
 		}
@@ -212,6 +254,24 @@ func (o *KubeObserver) fillPodEviction(ctx context.Context, snap *Snapshot) {
 		n.Pods = cur
 		n.PodsTotal = o.drainStart[n.Name]
 	}
+}
+
+// listPods returns all pods in the cluster (drain accounting needs pods on
+// every draining node, whatever their namespace): from the informer cache when
+// watching, else via a List call.
+func (o *KubeObserver) listPods(ctx context.Context) ([]*corev1.Pod, error) {
+	if o.inf != nil {
+		return o.inf.pods.List(labels.Everything())
+	}
+	list, err := o.client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	pods := make([]*corev1.Pod, len(list.Items))
+	for i := range list.Items {
+		pods[i] = &list.Items[i]
+	}
+	return pods, nil
 }
 
 // scopeWarnings filters cluster Warning events down to those concerning the

--- a/internal/rollview/rollview.go
+++ b/internal/rollview/rollview.go
@@ -21,10 +21,16 @@ import (
 	"github.com/dantech2000/refresh/internal/ui"
 )
 
-// liveRollPoll is how often the live roll panel re-reads cluster state. Kept
-// snappy (vs the EKS --poll-interval) so the view feels live, while staying
-// cheap: a node + pod list every few seconds.
+// liveRollPoll is how often the live roll panel re-reads cluster state when
+// the observer polls with List calls. Kept snappy (vs the EKS --poll-interval)
+// so the view feels live, while staying cheap: a node + pod list every few
+// seconds.
 const liveRollPoll = 3 * time.Second
+
+// liveRollWatchRepaint is the repaint cadence when the observer is
+// watch-backed (informers): snapshots read a local cache, so repainting faster
+// costs no API calls.
+const liveRollWatchRepaint = 1 * time.Second
 
 // rollMeta is the static context for a live roll panel.
 type rollMeta struct {
@@ -243,6 +249,11 @@ func LiveRollForUpdate(ctx context.Context, kube kubernetes.Interface, nodegroup
 		return
 	}
 	obs := noderoll.NewKubeObserver(kube, nodegroup, "")
+	// Prefer watch streams (informers) over per-poll List calls: node/pod/event
+	// changes surface as they happen, and API load drops to one stream per
+	// resource. On failure (e.g. RBAC without watch) the observer just polls.
+	watching := obs.StartInformers(ctx) == nil
+	defer obs.StopInformers()
 	if err := obs.CaptureBaseline(ctx); err != nil {
 		return // can't read the cluster — degrade to the standard monitor
 	}
@@ -252,9 +263,13 @@ func LiveRollForUpdate(ctx context.Context, kube kubernetes.Interface, nodegroup
 	}
 	desired := snap0.Total
 
+	defaultPoll := liveRollPoll
+	if watching {
+		defaultPoll = liveRollWatchRepaint
+	}
 	poll := pollInterval
 	if poll <= 0 || poll > liveRollPoll {
-		poll = liveRollPoll
+		poll = defaultPoll
 	}
 	rollCtx := ctx
 	if timeout > 0 {


### PR DESCRIPTION
## Summary

Replaces per-poll `List` calls in the live node-roll panel with client-go **shared informers**: one watch stream each for nodes (label-scoped to the nodegroup), pods, and Warning events, with every snapshot served from the informer's local cache.

- Node transitions surface as they happen instead of on the next 3s poll; the panel repaints at **1s** when watch-backed.
- The repeated cluster-wide pod `List` (the expensive call on large clusters) collapses into a single stream.
- **Watch is an upgrade, never a requirement**: if informers can't start (e.g. RBAC grants `list` but not `watch`), the observer keeps today's polling behavior unchanged.
- Covers both `nodegroup update` and `cluster upgrade` — they share `LiveRollForUpdate`.

## Deliberately out of scope

One-shot reads (pre-flight health checks, `nodegroup scale --check-pdbs`, post-roll verify) stay as single `List` calls — an informer's initial cache sync costs more than one `List` there. AWS-side polling (`DescribeUpdate`, SSM) has no push API and is unchanged. Rationale recorded in CLAUDE.md.

## Changes

- `internal/noderoll/informer.go` (new): `StartInformers`/`StopInformers` on `KubeObserver`; per-resource factories (label-scoped nodes, pods, `type=Warning` events); sync-timeout fallback.
- `internal/noderoll/observer.go`: reads branch to informer cache when active, unchanged `List` path otherwise.
- `internal/rollview/rollview.go`: `LiveRollForUpdate` prefers watch; 1s repaint when watch-backed, 3s fallback.
- Docs: RBAC note for the live roll view in `docs/commands/nodegroup.md`, cross-reference in `docs/commands/cluster.md`.
- Tests: informer-driven roll transitions, warning/eviction cache paths, stop idempotency (fake clientset, no AWS / no cluster).

## Testing

- `task dev:full` green (fmt, vet, lint, test, build)
- `go test ./... -race` green
- `task docs:gen` — no reference drift; `mkdocs build --strict` passes